### PR TITLE
Es/chore update tanstack query to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@react-navigation/native": "^6.1.7",
         "@react-navigation/native-stack": "^6.9.13",
         "@rnmapbox/maps": "^10.0.12",
-        "@tanstack/react-query": "^4.35.3",
+        "@tanstack/react-query": "^5.12.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "cheap-ruler": "^3.0.2",
@@ -7034,38 +7034,27 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.35.3.tgz",
-      "integrity": "sha512-PS+WEjd9wzKTyNjjQymvcOe1yg8f3wYc6mD+vb6CKyZAKvu4sIJwryfqfBULITKCla7P9C4l5e9RXePHvZOZeQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.12.1.tgz",
+      "integrity": "sha512-WbZztNmKq0t6QjdNmHzezbi/uifYo9j6e2GLJkodsYaYUlzMbAp91RDyeHkIZrm7EfO4wa6Sm5sxJZm5SPlh6w==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.3.tgz",
-      "integrity": "sha512-UgTPioip/rGG3EQilXfA2j4BJkhEQsR+KAbF+KIuvQ7j4MkgnTCJF01SfRpIRNtQTlEfz/+IL7+jP8WA8bFbsw==",
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.12.2.tgz",
+      "integrity": "sha512-BeWZu8zVFH20oRc+S/K9ADPgWjEzP/XQCGBNz5IbApUwPQAdwkQYbXODVL5AyAlWiSxhx+P2xlARPBApj2Yrog==",
       "dependencies": {
-        "@tanstack/query-core": "4.35.3",
-        "use-sync-external-store": "^1.2.0"
+        "@tanstack/query-core": "5.12.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
+        "react": "^18.0.0"
       }
     },
     "node_modules/@trysound/sax": {
@@ -30416,17 +30405,16 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.35.3.tgz",
-      "integrity": "sha512-PS+WEjd9wzKTyNjjQymvcOe1yg8f3wYc6mD+vb6CKyZAKvu4sIJwryfqfBULITKCla7P9C4l5e9RXePHvZOZeQ=="
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.12.1.tgz",
+      "integrity": "sha512-WbZztNmKq0t6QjdNmHzezbi/uifYo9j6e2GLJkodsYaYUlzMbAp91RDyeHkIZrm7EfO4wa6Sm5sxJZm5SPlh6w=="
     },
     "@tanstack/react-query": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.3.tgz",
-      "integrity": "sha512-UgTPioip/rGG3EQilXfA2j4BJkhEQsR+KAbF+KIuvQ7j4MkgnTCJF01SfRpIRNtQTlEfz/+IL7+jP8WA8bFbsw==",
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.12.2.tgz",
+      "integrity": "sha512-BeWZu8zVFH20oRc+S/K9ADPgWjEzP/XQCGBNz5IbApUwPQAdwkQYbXODVL5AyAlWiSxhx+P2xlARPBApj2Yrog==",
       "requires": {
-        "@tanstack/query-core": "4.35.3",
-        "use-sync-external-store": "^1.2.0"
+        "@tanstack/query-core": "5.12.1"
       }
     },
     "@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.13",
     "@rnmapbox/maps": "^10.0.12",
-    "@tanstack/react-query": "^4.35.3",
+    "@tanstack/react-query": "^5.12.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
     "cheap-ruler": "^3.0.2",

--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -47,6 +47,6 @@ export function useObservationAttachmentUrl(
     enabled: !!project,
     // setting staleTime and CacheTime to infinity means it will only call the api once (aka photos do not get editted so we do not need to keep getting from the server)
     staleTime: Infinity,
-    cacheTime: Infinity,
+    gcTime: Infinity,
   });
 }

--- a/src/frontend/hooks/server/observations.ts
+++ b/src/frontend/hooks/server/observations.ts
@@ -43,7 +43,7 @@ export function useCreateObservation() {
       return project.observation.create(value);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(['observations']);
+      queryClient.invalidateQueries({queryKey: ['observations']});
     },
   });
 }
@@ -64,7 +64,7 @@ export function useEditObservation() {
       return project.observation.update(id, value);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(['observations']);
+      queryClient.invalidateQueries({queryKey: ['observations']});
     },
   });
 }
@@ -79,7 +79,7 @@ export function useDeleteObservation() {
       return project.observation.delete(id);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(['observations']);
+      queryClient.invalidateQueries({queryKey: ['observations']});
     },
   });
 }


### PR DESCRIPTION
Updated Tanstack query to v5

## Minor breaking changes:
- [InvalidateQuery params converted to object](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#supports-a-single-signature-one-object)
- [cacheTime converted to gcTime](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#rename-cachetime-to-gctime)