### PR TITLE
feat: useLocationProviderStatus hook

### DIFF
--- a/src/frontend/hooks/useLocation.ts
+++ b/src/frontend/hooks/useLocation.ts
@@ -2,7 +2,6 @@ import {useFocusEffect} from '@react-navigation/native';
 import CheapRuler from 'cheap-ruler';
 import {
   watchPositionAsync,
-  hasServicesEnabledAsync,
   useForegroundPermissions,
   type LocationObject,
   Accuracy,
@@ -56,6 +55,7 @@ export function useLocation({
         }),
       );
 
+      // Should not happen because we are checking permissions above, but just in case
       locationSubscriptionProm.catch(error => {
         if (ignore) return;
         setLocation(({location}) => {
@@ -79,26 +79,9 @@ function debounceLocation({
   minTimeInterval = 200,
 }: Omit<LocationOptions, 'minDistanceInterval'>) {
   let lastLocation: LocationObject | undefined;
-  let interval: ReturnType<typeof setInterval>;
 
   return function (callback: (location: LocationObject | undefined) => any) {
     return function (location: LocationObject) {
-      // The user can turn off location services via the quick settings dropdown
-      // (swiping down from the top of their phone screen) without moving away
-      // from the app. In this case the location will just stop updating and we
-      // won't know why. If we haven't had a location update for a while, we check
-      // on the provider status to see if location services are enabled, so that
-      // we can update the state with the current status
-      if (interval) clearInterval(interval);
-      interval = setInterval(async () => {
-        if (!(await hasServicesEnabledAsync())) {
-          lastLocation = undefined;
-          callback(undefined);
-          clearInterval(interval);
-          return;
-        }
-      }, LOCATION_TIMEOUT);
-
       if (!lastLocation) {
         lastLocation = location;
         callback(location);

--- a/src/frontend/hooks/useLocationProviderStatus.ts
+++ b/src/frontend/hooks/useLocationProviderStatus.ts
@@ -2,14 +2,13 @@ import React from 'react';
 import {
   type LocationProviderStatus,
   getProviderStatusAsync,
-  watchPositionAsync,
   useForegroundPermissions,
 } from 'expo-location';
 
 // How frequently to poll the location provider status
 const POLL_PROVIDER_STATUS_INTERVAL = 10_000; // 10 seconds
 
-export function useLocationProviderStatusPolling() {
+export function useLocationProviderStatus() {
   const [providerStatus, setProviderStatus] = React.useState<
     LocationProviderStatus | undefined
   >(undefined);
@@ -18,7 +17,7 @@ export function useLocationProviderStatusPolling() {
   React.useEffect(() => {
     if (!permissions || !permissions.granted) return;
     let ignore = false;
-    function checkProviderStatus() {
+    async function checkProviderStatus() {
       getProviderStatusAsync()
         .then(status => {
           if (ignore) return;
@@ -35,44 +34,6 @@ export function useLocationProviderStatusPolling() {
     return () => {
       clearInterval(intervalId);
       ignore = true;
-    };
-  }, [permissions]);
-
-  return providerStatus;
-}
-
-// How long without a position update before we check the location provider status
-const PROVIDER_STATUS_TIMEOUT = 10_000; // 10 seconds
-
-export function useLocationProviderStatusWatch() {
-  const [providerStatus, setProviderStatus] = React.useState<
-    LocationProviderStatus | undefined
-  >(undefined);
-  const [permissions] = useForegroundPermissions();
-
-  React.useEffect(() => {
-    if (!permissions || !permissions.granted) return;
-    let ignore = false;
-    function checkProviderStatus() {
-      getProviderStatusAsync()
-        .then(status => {
-          if (ignore) return;
-          setProviderStatus(status);
-        })
-        // Shouldn't happen because we check permissions.granted above, but just in case
-        .catch(noop);
-    }
-    checkProviderStatus();
-    let timeoutId = setTimeout(checkProviderStatus, PROVIDER_STATUS_TIMEOUT);
-    const locationSubscriptionProm = watchPositionAsync({}, () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(checkProviderStatus, PROVIDER_STATUS_TIMEOUT);
-    });
-    // Shouldn't happen because we check permissions.granted above, but just in case
-    locationSubscriptionProm.catch(noop);
-    return () => {
-      ignore = true;
-      clearTimeout(timeoutId);
     };
   }, [permissions]);
 

--- a/src/frontend/hooks/useLocationProviderStatus.ts
+++ b/src/frontend/hooks/useLocationProviderStatus.ts
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  type LocationProviderStatus,
+  getProviderStatusAsync,
+  watchPositionAsync,
+  useForegroundPermissions,
+} from 'expo-location';
+
+// How frequently to poll the location provider status
+const POLL_PROVIDER_STATUS_INTERVAL = 10_000; // 10 seconds
+
+export function useLocationProviderStatusPolling() {
+  const [providerStatus, setProviderStatus] = React.useState<
+    LocationProviderStatus | undefined
+  >(undefined);
+  const [permissions] = useForegroundPermissions();
+
+  React.useEffect(() => {
+    if (!permissions || !permissions.granted) return;
+    let ignore = false;
+    function checkProviderStatus() {
+      getProviderStatusAsync()
+        .then(status => {
+          if (ignore) return;
+          setProviderStatus(status);
+        })
+        // Shouldn't happen because we check permissions.granted above, but just in case
+        .catch(noop);
+    }
+    checkProviderStatus();
+    const intervalId = setInterval(
+      checkProviderStatus,
+      POLL_PROVIDER_STATUS_INTERVAL,
+    );
+    return () => {
+      clearInterval(intervalId);
+      ignore = true;
+    };
+  }, [permissions]);
+
+  return providerStatus;
+}
+
+// How long without a position update before we check the location provider status
+const PROVIDER_STATUS_TIMEOUT = 10_000; // 10 seconds
+
+export function useLocationProviderStatusWatch() {
+  const [providerStatus, setProviderStatus] = React.useState<
+    LocationProviderStatus | undefined
+  >(undefined);
+  const [permissions] = useForegroundPermissions();
+
+  React.useEffect(() => {
+    if (!permissions || !permissions.granted) return;
+    let ignore = false;
+    function checkProviderStatus() {
+      getProviderStatusAsync()
+        .then(status => {
+          if (ignore) return;
+          setProviderStatus(status);
+        })
+        // Shouldn't happen because we check permissions.granted above, but just in case
+        .catch(noop);
+    }
+    checkProviderStatus();
+    let timeoutId = setTimeout(checkProviderStatus, PROVIDER_STATUS_TIMEOUT);
+    const locationSubscriptionProm = watchPositionAsync({}, () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(checkProviderStatus, PROVIDER_STATUS_TIMEOUT);
+    });
+    // Shouldn't happen because we check permissions.granted above, but just in case
+    locationSubscriptionProm.catch(noop);
+    return () => {
+      ignore = true;
+      clearTimeout(timeoutId);
+    };
+  }, [permissions]);
+
+  return providerStatus;
+}
+
+function noop() {}


### PR DESCRIPTION
Fixes #126

This PR contains two potential approaches to monitoring location provider status:

1. polling the status at a fixed interval
2. listening for location updates and checking the status if an update has not been received after a fixed interval

This separates the provider status from the location (in the useLocation() hook), because the provider status is displayed in a different component within the UI to the location.

The two approaches both achieve the same thing, but may have different performance implications. My instinct is that polling will be the most performant, since it looks like checking status has a low overhead. If we are going to use this state in more than one component we might want to put this into react context, so that we only create one interval for polling, vs. creating a separate polling interval for each use of the hook.

As an alternative to creating a context, we could create our own event emitter that polls the status and emits an event when it changes, then the hook can just listen to this event.
