### PR TITLE
fix: fix useCallback deps in useLocation hook

### DIFF
--- a/src/frontend/hooks/useLocation.ts
+++ b/src/frontend/hooks/useLocation.ts
@@ -26,7 +26,9 @@ interface LocationState {
 
 export function useLocation({
   minDistanceInterval: distanceInterval = 1,
-  ...debounceOptions
+  minTimeInterval,
+  maxTimeInterval,
+  maxDistanceInterval,
 }: LocationOptions): LocationState {
   const [location, setLocation] = React.useState<LocationState>({
     location: undefined,
@@ -45,7 +47,11 @@ export function useLocation({
           accuracy: Accuracy.BestForNavigation,
           distanceInterval,
         },
-        debounceLocation(debounceOptions)(location => {
+        debounceLocation({
+          minTimeInterval,
+          maxTimeInterval,
+          maxDistanceInterval,
+        })(location => {
           if (ignore) return;
           setLocation({location, error: undefined});
         }),
@@ -63,7 +69,13 @@ export function useLocation({
         ignore = true;
         locationSubscriptionProm.then(sub => sub.remove());
       };
-    }, [permissions, debounceOptions]),
+    }, [
+      permissions,
+      distanceInterval,
+      minTimeInterval,
+      maxTimeInterval,
+      maxDistanceInterval,
+    ]),
   );
 
   return location;

--- a/src/frontend/hooks/useLocation.ts
+++ b/src/frontend/hooks/useLocation.ts
@@ -24,10 +24,6 @@ interface LocationState {
   error: Error | undefined;
 }
 
-// Timeout between location updates --> means location was probably turned off
-// so we need to check it.
-const LOCATION_TIMEOUT = 10000;
-
 export function useLocation({
   minDistanceInterval: distanceInterval = 1,
   ...debounceOptions


### PR DESCRIPTION
the useCallback in the useLocation hook was missing a dependency (`distanceInterval`) which would have resulted in that option not being able to be changed in subsequent renders (granted, not something we are likely to ever do).

Also, of more consquence, we were using `debounceOptions` as a dependency for the `useCallback`, which since it was created from a spread, this would be a new variable for every render. This would have resulted in the watch position subscription being unsubscribed and re-attached on each render. The solution is to use the primitive values  as the dependencies.