### PR TITLE
Es/retry error

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -389,6 +389,15 @@
     "description": "Title of settings screen",
     "message": "Settings"
   },
+  "sharedComponents.ErrorModal.goBack": {
+    "message": "Go Back"
+  },
+  "sharedComponents.ErrorModal.somethingWrong": {
+    "message": "Something Went Wrong"
+  },
+  "sharedComponents.ErrorModal.tryAgain": {
+    "message": "Please go back and try again"
+  },
   "sharedComponents.WifiBar.noWifi": {
     "message": "No Internet"
   },

--- a/src/frontend/screens/FatalError.tsx
+++ b/src/frontend/screens/FatalError.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
-import RNRestart from 'react-native-restart'; // Import package from node modules
-import CoMapeoLogo from '../images/CoMapeoLogo.svg';
-import ErrorIcon from '../images/Error.svg';
+import RNRestart from 'react-native-restart';
 import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {WHITE} from '../lib/styles';
 import {defineMessages, useIntl} from 'react-intl';
+import {LogoWithErrorIcon} from '../sharedComponents/LogoWithErrorIcon';
 
 const m = defineMessages({
   somethingWrong: {
@@ -25,14 +24,7 @@ export const FatalError = () => {
   return (
     <View style={styles.container}>
       <View style={{alignItems: 'center'}}>
-        <View style={{position: 'relative'}}>
-          <CoMapeoLogo width={160} height={160} />
-          <ErrorIcon
-            width={50}
-            height={50}
-            style={{position: 'absolute', bottom: 0, right: 0}}
-          />
-        </View>
+        <LogoWithErrorIcon />
         <Text style={styles.text}>{formatMessage(m.somethingWrong)}</Text>
       </View>
       <Button

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -105,15 +105,7 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
         snapPoints={!fullHeight ? undefined : ['100%']}
         enableDynamicSizing={!fullHeight}
         handleComponent={() => null}>
-        <BottomSheetView
-          style={{
-            padding: 20,
-            paddingTop: 30,
-            // need to add paddingbottom due to bug: https://github.com/gorhom/react-native-bottom-sheet/issues/791
-            paddingBottom: 20,
-          }}>
-          {children}
-        </BottomSheetView>
+        <BottomSheetView>{children}</BottomSheetView>
       </RNBottomSheetModal>
     );
   },

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 
-import {LIGHT_GREY} from '../../lib/styles';
+import {DARK_GREY, LIGHT_GREY} from '../../lib/styles';
 
 export const MODAL_NAVIGATION_OPTIONS: NativeStackNavigationOptions = {
   presentation: 'transparentModal',
@@ -22,15 +22,15 @@ export const useBottomSheetModal = ({openOnMount}: {openOnMount: boolean}) => {
 
   const closeSheet = React.useCallback(() => {
     if (sheetRef.current) {
-      sheetRef.current.close();
       setIsOpen(false);
+      sheetRef.current.close();
     }
   }, []);
 
   const openSheet = React.useCallback(() => {
     if (sheetRef.current) {
-      sheetRef.current.present();
       setIsOpen(true);
+      sheetRef.current.present();
     }
   }, []);
 
@@ -70,12 +70,12 @@ interface Props extends React.PropsWithChildren<{}> {
   onDismiss?: () => void;
   // Triggered by: Android hardware back press and gesture back swipe
   onBack?: () => void;
-  snapPoints?: (string | number)[];
   disableBackrop?: boolean;
+  fullHeight?: boolean;
 }
 
 export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
-  ({children, isOpen, onBack, disableBackrop}, ref) => {
+  ({children, isOpen, onBack, disableBackrop, fullHeight}, ref) => {
     useBackHandler(isOpen, onBack);
 
     const renderBackdrop = React.useCallback(
@@ -94,10 +94,16 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
     return (
       <RNBottomSheetModal
         ref={ref}
+        backgroundStyle={[
+          fullHeight
+            ? {borderRadius: 0}
+            : {borderColor: DARK_GREY, borderWidth: 1},
+        ]}
         backdropComponent={disableBackrop ? null : renderBackdrop}
         enableContentPanningGesture={false}
         enableHandlePanningGesture={false}
-        enableDynamicSizing
+        snapPoints={!fullHeight ? undefined : ['100%']}
+        enableDynamicSizing={!fullHeight}
         handleComponent={() => null}>
         <BottomSheetView
           style={{
@@ -105,10 +111,6 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
             paddingTop: 30,
             // need to add paddingbottom due to bug: https://github.com/gorhom/react-native-bottom-sheet/issues/791
             paddingBottom: 20,
-            borderColor: LIGHT_GREY,
-            borderWidth: 1,
-            borderTopLeftRadius: 16,
-            borderTopRightRadius: 16,
           }}>
           {children}
         </BottomSheetView>

--- a/src/frontend/sharedComponents/ErrorModal.tsx
+++ b/src/frontend/sharedComponents/ErrorModal.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import {BottomSheetModal, useBottomSheetModal} from './BottomSheetModal';
+import {Button} from './Button';
+import {View} from 'react-native';
+
+type ErrorModalProps = Omit<
+  ReturnType<typeof useBottomSheetModal>,
+  'openSheet'
+> & {clearError: () => void; retryFn?: () => void};
+
+export const ErrorModal = ({
+  clearError,
+  closeSheet,
+  sheetRef,
+  retryFn,
+  isOpen,
+}: ErrorModalProps) => {
+  function handleGoBack() {
+    clearError();
+    closeSheet();
+  }
+
+  function handleTryAgain() {
+    clearError();
+    if (!retryFn) throw new Error('cannot retryFn if no function was provided');
+    retryFn();
+    closeSheet();
+  }
+
+  return (
+    <BottomSheetModal ref={sheetRef} fullHeight isOpen={isOpen}>
+      <View>
+        <Button onPress={handleGoBack}> Go Back</Button>
+        {retryFn && <Button onPress={handleTryAgain}>Try Again</Button>}
+      </View>
+    </BottomSheetModal>
+  );
+};

--- a/src/frontend/sharedComponents/ErrorModal.tsx
+++ b/src/frontend/sharedComponents/ErrorModal.tsx
@@ -1,38 +1,82 @@
 import * as React from 'react';
 import {BottomSheetModal, useBottomSheetModal} from './BottomSheetModal';
 import {Button} from './Button';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
+import {LogoWithErrorIcon} from './LogoWithErrorIcon';
+import {Text} from './Text';
+import {defineMessages, useIntl} from 'react-intl';
+
+const m = defineMessages({
+  somethingWrong: {
+    id: 'sharedComponents.ErrorModal.somethingWrong',
+    defaultMessage: 'Something Went Wrong',
+  },
+  goBack: {
+    id: 'sharedComponents.ErrorModal.goBack',
+    defaultMessage: 'Go Back',
+  },
+  tryAgain: {
+    id: 'sharedComponents.ErrorModal.tryAgain',
+    defaultMessage: 'Please go back and try again',
+  },
+});
 
 type ErrorModalProps = Omit<
   ReturnType<typeof useBottomSheetModal>,
   'openSheet'
-> & {clearError: () => void; retryFn?: () => void};
+> & {clearError?: () => void};
 
+/**
+ *
+ * should be used with 'useBottomSheetModal()' Hook
+ */
 export const ErrorModal = ({
   clearError,
   closeSheet,
   sheetRef,
-  retryFn,
   isOpen,
 }: ErrorModalProps) => {
-  function handleGoBack() {
-    clearError();
-    closeSheet();
-  }
+  const {formatMessage} = useIntl();
 
-  function handleTryAgain() {
-    clearError();
-    if (!retryFn) throw new Error('cannot retryFn if no function was provided');
-    retryFn();
+  function handleGoBack() {
+    if (clearError) clearError();
     closeSheet();
   }
 
   return (
     <BottomSheetModal ref={sheetRef} fullHeight isOpen={isOpen}>
-      <View>
-        <Button onPress={handleGoBack}> Go Back</Button>
-        {retryFn && <Button onPress={handleTryAgain}>Try Again</Button>}
+      <View style={styles.container}>
+        <View style={{alignItems: 'center'}}>
+          <LogoWithErrorIcon />
+          <Text style={styles.headerText}>
+            {formatMessage(m.somethingWrong)}
+          </Text>
+          <Text style={{textAlign: 'center', marginTop: 20}}>
+            {formatMessage(m.tryAgain)}
+          </Text>
+        </View>
+        <View style={{width: '100%'}}>
+          <Button fullWidth onPress={handleGoBack}>
+            {formatMessage(m.goBack)}
+          </Button>
+        </View>
       </View>
     </BottomSheetModal>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    height: '100%',
+    padding: 20,
+    paddingTop: 80,
+  },
+  headerText: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginTop: 30,
+  },
+});

--- a/src/frontend/sharedComponents/LogoWithErrorIcon.tsx
+++ b/src/frontend/sharedComponents/LogoWithErrorIcon.tsx
@@ -1,0 +1,17 @@
+import {View} from 'react-native';
+import CoMapeoLogo from '../images/CoMapeoLogo.svg';
+import ErrorIcon from '../images/Error.svg';
+import {ViewStyleProp} from '../sharedTypes';
+
+export const LogoWithErrorIcon = ({style}: {style?: ViewStyleProp}) => {
+  return (
+    <View style={[{alignItems: 'center', position: 'relative'}, style]}>
+      <CoMapeoLogo width={160} height={160} />
+      <ErrorIcon
+        width={50}
+        height={50}
+        style={{position: 'absolute', bottom: 0, right: 0}}
+      />
+    </View>
+  );
+};


### PR DESCRIPTION
Created an error modal that notifies user of error and asks them to try it again.

https://github.com/digidem/CoMapeo-mobile/assets/67773827/b8187ff2-f7ad-41a5-9f10-7f79cee248d0

## Technical notes
- Ideally this modal would be declarative, and show up when there is an error, but gorham bottom sheet is designed to be imperatively opened and closed.
- This should be paired with a loading state. Ideally the user activates the api call, the button is turned into a loader, and then when promise is resolved/rejected, the appropriate ui is shown.
- If possible, reset the error state, so that the user can try again and the react can pick up the new error state by this new attempt. tanstack/query has a [Reset Mutation State](https://tanstack.com/query/v4/docs/react/guides/mutations#resetting-mutation-state)
- When being used with tanstack/query, call `openSheet` in `onError` Callback:
``` ts
const someMutation = useMutation(....)

function handleMutation(){
    someMutation.mutate({}, {onError:()=>{openSheet()})
}

return(
    <>
        <Button onPress={handleMutation}>
            Mutate
        </Button>
        <ErrorModal {...props/>
    </>


```

closes #147 