### PR TITLE
Provide Android external storage path to backend on initialization

### DIFF
--- a/android/app/src/main/java/com/mapeonext/FileSystemModule.java
+++ b/android/app/src/main/java/com/mapeonext/FileSystemModule.java
@@ -1,0 +1,38 @@
+package com.mapeonext;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.io.File;
+
+// Very tightly scoped native module for surfacing relevant directory paths
+public class FileSystemModule extends ReactContextBaseJavaModule {
+    FileSystemModule(ReactApplicationContext context) {
+        super(context);
+    }
+
+    @Override
+    public String getName() {
+        return "FileSystemModule";
+    }
+
+    // Extracted from https://github.com/itinance/react-native-fs/blob/64aa755cc1d37f59fa205bf2d52dd71a7d691504/android/src/main/java/com/rnfs/RNFSManager.java#L990
+    @Override
+    public Map<String, Object> getConstants() {
+        final Map<String, Object> constants = new HashMap<>();
+
+        File externalDirectory = this.getReactApplicationContext().getExternalFilesDir(null);
+        if (externalDirectory != null) {
+            constants.put("EXTERNAL_FILES_DIR", externalDirectory.getAbsolutePath());
+        } else {
+            constants.put("EXTERNAL_FILES_DIR", null);
+        }
+
+        return constants;
+    }
+}

--- a/android/app/src/main/java/com/mapeonext/FileSystemPackage.java
+++ b/android/app/src/main/java/com/mapeonext/FileSystemPackage.java
@@ -1,0 +1,27 @@
+package com.mapeonext;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class FileSystemPackage implements ReactPackage {
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new FileSystemModule(reactContext));
+
+        return modules;
+    }
+
+}

--- a/android/app/src/main/java/com/mapeonext/MainApplication.java
+++ b/android/app/src/main/java/com/mapeonext/MainApplication.java
@@ -13,6 +13,8 @@ import com.facebook.react.defaults.DefaultReactNativeHost;
 import com.facebook.soloader.SoLoader;
 import java.util.List;
 
+import com.mapeonext.FileSystemPackage;
+
 public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost =
@@ -28,6 +30,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // packages.add(new MyReactNativePackage());
+          packages.add(new FileSystemPackage());
           return packages;
         }
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -15,6 +15,7 @@ try {
     options: {
       version: { type: 'string' },
       rootKey: { type: 'string' },
+      sharedStoragePath: { type: 'string' },
     },
   })
 
@@ -22,11 +23,18 @@ try {
     throw new Error('backend did not receive root key from front end')
   }
 
+  if (typeof values.sharedStoragePath !== 'string') {
+    throw new Error(
+      'backend did not receive shared storage path from front end',
+    )
+  }
+
   // Do not await this as we want this to run indefinitely
   init({
     version: values.version,
     rootKey: Buffer.from(values.rootKey, 'hex'),
     migrationsFolderPath: MIGRATIONS_FOLDER_PATH,
+    sharedStoragePath: values.sharedStoragePath,
   }).catch((err) => {
     console.error('Server startup error:', err)
   })

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -10,9 +10,18 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@electron/asar": "^3.2.8",
+        "@fastify/error": "^3.4.1",
+        "@fastify/static": "^6.12.0",
+        "@fastify/type-provider-typebox": "^4.0.0",
         "@mapeo/core": "9.0.0-alpha.4",
         "@mapeo/ipc": "^0.1.3",
-        "debug": "^4.3.4"
+        "@sinclair/typebox": "^0.32.9",
+        "debug": "^4.3.4",
+        "fastify": "^4.25.2",
+        "mime": "^4.0.1",
+        "p-timeout": "^6.1.2",
+        "start-stop-state-machine": "^1.2.0"
       },
       "devDependencies": {
         "@digidem/types": "~2.1.0",
@@ -57,6 +66,61 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.5.tgz",
       "integrity": "sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==",
       "dev": true
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.8.tgz",
+      "integrity": "sha512-cmskk5M06ewHMZAplSiF4AlME3IrnnZhKnWbtwKVLRkdJkKyUVjMLhDIiPIx/+6zQWVlKX/LtmK9xDme7540Sg==",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.19.5",
@@ -187,6 +251,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
+      "integrity": "sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
@@ -203,9 +275,9 @@
       "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A=="
     },
     "node_modules/@fastify/error": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.0.tgz",
-      "integrity": "sha512-e/mafFwbK3MNqxUcFBLgHhgxsF8UT1m8aj0dAlqEa2nJEgPsRtpHTZ3ObgrgkZ2M1eJHPTwgyUl/tXkvabsZdQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ=="
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "4.3.0",
@@ -215,12 +287,48 @@
         "fast-json-stringify": "^5.7.0"
       }
     },
+    "node_modules/@fastify/send": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-2.1.0.tgz",
+      "integrity": "sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.1",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "2.0.0",
+        "mime": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/send/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-6.12.0.tgz",
+      "integrity": "sha512-KK1B84E6QD/FcQWxDI2aiUCwHxMJBI1KeCUzm1BwYpPY1b742+jeKruGHP2uOluuM6OkBPI8CIANrXcCRtC2oQ==",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^1.0.0",
+        "@fastify/send": "^2.0.0",
+        "content-disposition": "^0.5.3",
+        "fastify-plugin": "^4.0.0",
+        "glob": "^8.0.1",
+        "p-limit": "^3.1.0"
+      }
+    },
     "node_modules/@fastify/type-provider-typebox": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-3.5.0.tgz",
-      "integrity": "sha512-f48uGzvLflE/y4pvXOS8qjAC+mZmlqev9CPHnB8NDsBSL4EbeydO61IgPuzOkeNlAYeRP9Y56UOKj1XWFibgMw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-4.0.0.tgz",
+      "integrity": "sha512-kTlN0saC/+xhcQPyBjb3YONQAMjiD/EHlCRjQjsr5E3NFjS5K8ZX5LGzXYDRjSa+sV4y8gTL5Q7FlObePv4iTA==",
       "peerDependencies": {
-        "@sinclair/typebox": ">=0.26 <=0.31"
+        "@sinclair/typebox": ">=0.26 <=0.32"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -349,6 +457,14 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@mapeo/core": {
       "version": "9.0.0-alpha.4",
       "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-9.0.0-alpha.4.tgz",
@@ -406,6 +522,19 @@
         "tiny-typed-emitter": "^2.1.0"
       }
     },
+    "node_modules/@mapeo/core/node_modules/@fastify/type-provider-typebox": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-3.6.0.tgz",
+      "integrity": "sha512-HTeOLvirfGg0u1KGao3iXn5rZpYNqlrOmyDnXSXAbWVPa+mDQTTBNs/x5uZzOB6vFAqr0Xcf7x1lxOamNSYKjw==",
+      "peerDependencies": {
+        "@sinclair/typebox": ">=0.26 <=0.32"
+      }
+    },
+    "node_modules/@mapeo/core/node_modules/@sinclair/typebox": {
+      "version": "0.29.6",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
+      "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
+    },
     "node_modules/@mapeo/core/node_modules/@types/node": {
       "version": "18.18.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.10.tgz",
@@ -437,17 +566,6 @@
         "streamx": "^2.12.4",
         "xache": "^1.1.0",
         "z32": "^1.0.0"
-      }
-    },
-    "node_modules/@mapeo/core/node_modules/p-timeout": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@mapeo/core/node_modules/type-fest": {
@@ -836,9 +954,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.29.6",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
-      "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
+      "version": "0.32.9",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.9.tgz",
+      "integrity": "sha512-6oeJJPTIb0y3cs713HmXmXSx3WRWgid74KICYL9blOhNFuAcAB18dDWfATgcgzynfpF5xDzHGxEVbDYYr6nvgg=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "16.1.1",
@@ -1325,6 +1443,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1369,6 +1495,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
       "integrity": "sha512-T8/9bffg5RThuejasJWrwqxs3Q0fsJvyl7/33IB6svroD8JC93E7X60AuuOnDE8RlP6Jlb5FxmlrVDpl9KiU2Q=="
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -1498,6 +1635,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -1711,6 +1856,11 @@
         "@esbuild/win32-ia32": "0.19.5",
         "@esbuild/win32-x64": "0.19.5"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2037,32 +2187,37 @@
       "integrity": "sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg=="
     },
     "node_modules/fastify": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.24.0.tgz",
-      "integrity": "sha512-6Uu2cCAV1UgexPnWKchgRt77lng9ivNmyFhPMcgUbJ4VaVBE1l6aYluiYZiVsgOBFpHrmdj7FD6n1aHswln4yQ==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.25.2.tgz",
+      "integrity": "sha512-SywRouGleDHvRh054onj+lEZnbC1sBCLkR0UY3oyJwjD4BdZJUrxBqfkfCaqn74pVCwBaRHGuL3nEWeHbHzAfw==",
       "dependencies": {
         "@fastify/ajv-compiler": "^3.5.0",
-        "@fastify/error": "^3.2.0",
+        "@fastify/error": "^3.4.0",
         "@fastify/fast-json-stringify-compiler": "^4.3.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^8.2.1",
-        "fast-content-type-parse": "^1.0.0",
-        "fast-json-stringify": "^5.7.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
         "find-my-way": "^7.7.0",
-        "light-my-request": "^5.9.1",
-        "pino": "^8.12.0",
-        "process-warning": "^2.2.0",
+        "light-my-request": "^5.11.0",
+        "pino": "^8.17.0",
+        "process-warning": "^3.0.0",
         "proxy-addr": "^2.0.7",
         "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.5.0",
-        "semver": "^7.5.0",
-        "toad-cache": "^3.2.0"
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
       }
     },
     "node_modules/fastify-plugin": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
       "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ=="
+    },
+    "node_modules/fastify/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2318,7 +2473,6 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
       "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2409,6 +2563,21 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/hyperbee": {
@@ -3002,6 +3171,20 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.1.tgz",
+      "integrity": "sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -3017,7 +3200,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3270,7 +3452,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3297,11 +3478,14 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parent-module": {
@@ -3411,16 +3595,16 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.0.tgz",
-      "integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.17.2.tgz",
+      "integrity": "sha512-LA6qKgeDMLr2ux2y/YiUt47EfgQ+S9LznBWOJdN3q1dx2sv0ziDLUBeVpyVv17TEcGCBuWf0zNtg3M5m1NhhWQ==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "v1.1.0",
         "pino-std-serializers": "^6.0.0",
-        "process-warning": "^2.0.0",
+        "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
@@ -3464,9 +3648,9 @@
       }
     },
     "node_modules/pino-abstract-transport/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -3482,6 +3666,11 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
+    "node_modules/pino/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
@@ -3928,6 +4117,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
       "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA=="
     },
+    "node_modules/rpc-reflector/node_modules/p-timeout": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4044,6 +4241,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sha256-universal": {
       "version": "1.2.1",
@@ -4266,9 +4468,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.7.0.tgz",
-      "integrity": "sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
+      "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -4295,6 +4497,14 @@
       "integrity": "sha512-U9OtWHh+YKPqXHPZc5Ziz5+P/bdKFq14Lz8GnsPXyxNN6RC18nvJ0QAey5FfDpW9DDSaakByrQ4VcnPYm4a+YA==",
       "dependencies": {
         "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stream-shift": {
@@ -4551,6 +4761,14 @@
       "integrity": "sha512-3oDzcogWGHZdkwrHyvJVpPjA7oNzY6ENOV3PsWJY9XYPZ6INo94Yd47s5may1U+nleBPwDhrRiTPMIvKaa3MQg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -4854,7 +5072,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -4894,6 +5111,48 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.5.tgz",
           "integrity": "sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==",
           "dev": true
+        }
+      }
+    },
+    "@electron/asar": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.8.tgz",
+      "integrity": "sha512-cmskk5M06ewHMZAplSiF4AlME3IrnnZhKnWbtwKVLRkdJkKyUVjMLhDIiPIx/+6zQWVlKX/LtmK9xDme7540Sg==",
+      "requires": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         }
       }
     },
@@ -4988,6 +5247,11 @@
       "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
       "dev": true
     },
+    "@fastify/accept-negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
+      "integrity": "sha512-OIHZrb2ImZ7XG85HXOONLcJWGosv7sIvM2ifAPQVhg9Lv7qdmMBNVaai4QTdyuaqbKM5eO6sLSQOYI7wEQeCJQ=="
+    },
     "@fastify/ajv-compiler": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
@@ -5004,9 +5268,9 @@
       "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A=="
     },
     "@fastify/error": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.0.tgz",
-      "integrity": "sha512-e/mafFwbK3MNqxUcFBLgHhgxsF8UT1m8aj0dAlqEa2nJEgPsRtpHTZ3ObgrgkZ2M1eJHPTwgyUl/tXkvabsZdQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ=="
     },
     "@fastify/fast-json-stringify-compiler": {
       "version": "4.3.0",
@@ -5016,10 +5280,42 @@
         "fast-json-stringify": "^5.7.0"
       }
     },
+    "@fastify/send": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-2.1.0.tgz",
+      "integrity": "sha512-yNYiY6sDkexoJR0D8IDy3aRP3+L4wdqCpvx5WP+VtEU58sn7USmKynBzDQex5X42Zzvw2gNzzYgP90UfWShLFA==",
+      "requires": {
+        "@lukeed/ms": "^2.0.1",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "2.0.0",
+        "mime": "^3.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+        }
+      }
+    },
+    "@fastify/static": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-6.12.0.tgz",
+      "integrity": "sha512-KK1B84E6QD/FcQWxDI2aiUCwHxMJBI1KeCUzm1BwYpPY1b742+jeKruGHP2uOluuM6OkBPI8CIANrXcCRtC2oQ==",
+      "requires": {
+        "@fastify/accept-negotiator": "^1.0.0",
+        "@fastify/send": "^2.0.0",
+        "content-disposition": "^0.5.3",
+        "fastify-plugin": "^4.0.0",
+        "glob": "^8.0.1",
+        "p-limit": "^3.1.0"
+      }
+    },
     "@fastify/type-provider-typebox": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-3.5.0.tgz",
-      "integrity": "sha512-f48uGzvLflE/y4pvXOS8qjAC+mZmlqev9CPHnB8NDsBSL4EbeydO61IgPuzOkeNlAYeRP9Y56UOKj1XWFibgMw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-4.0.0.tgz",
+      "integrity": "sha512-kTlN0saC/+xhcQPyBjb3YONQAMjiD/EHlCRjQjsr5E3NFjS5K8ZX5LGzXYDRjSa+sV4y8gTL5Q7FlObePv4iTA==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -5134,6 +5430,11 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="
+    },
     "@mapeo/core": {
       "version": "9.0.0-alpha.4",
       "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-9.0.0-alpha.4.tgz",
@@ -5190,6 +5491,17 @@
             "tiny-typed-emitter": "^2.1.0"
           }
         },
+        "@fastify/type-provider-typebox": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-3.6.0.tgz",
+          "integrity": "sha512-HTeOLvirfGg0u1KGao3iXn5rZpYNqlrOmyDnXSXAbWVPa+mDQTTBNs/x5uZzOB6vFAqr0Xcf7x1lxOamNSYKjw==",
+          "requires": {}
+        },
+        "@sinclair/typebox": {
+          "version": "0.29.6",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
+          "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
+        },
         "@types/node": {
           "version": "18.18.10",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.10.tgz",
@@ -5222,11 +5534,6 @@
             "xache": "^1.1.0",
             "z32": "^1.0.0"
           }
-        },
-        "p-timeout": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-          "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
         },
         "type-fest": {
           "version": "4.8.1",
@@ -5499,9 +5806,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.29.6",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
-      "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
+      "version": "0.32.9",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.9.tgz",
+      "integrity": "sha512-6oeJJPTIb0y3cs713HmXmXSx3WRWgid74KICYL9blOhNFuAcAB18dDWfATgcgzynfpF5xDzHGxEVbDYYr6nvgg=="
     },
     "@tsconfig/node16": {
       "version": "16.1.1",
@@ -5885,6 +6192,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -5929,6 +6241,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
       "integrity": "sha512-T8/9bffg5RThuejasJWrwqxs3Q0fsJvyl7/33IB6svroD8JC93E7X60AuuOnDE8RlP6Jlb5FxmlrVDpl9KiU2Q=="
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
     },
     "cookie": {
       "version": "0.5.0",
@@ -6032,6 +6352,11 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "detect-libc": {
       "version": "2.0.2",
@@ -6149,6 +6474,11 @@
         "@esbuild/win32-ia32": "0.19.5",
         "@esbuild/win32-x64": "0.19.5"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -6407,26 +6737,33 @@
       "integrity": "sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg=="
     },
     "fastify": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.24.0.tgz",
-      "integrity": "sha512-6Uu2cCAV1UgexPnWKchgRt77lng9ivNmyFhPMcgUbJ4VaVBE1l6aYluiYZiVsgOBFpHrmdj7FD6n1aHswln4yQ==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.25.2.tgz",
+      "integrity": "sha512-SywRouGleDHvRh054onj+lEZnbC1sBCLkR0UY3oyJwjD4BdZJUrxBqfkfCaqn74pVCwBaRHGuL3nEWeHbHzAfw==",
       "requires": {
         "@fastify/ajv-compiler": "^3.5.0",
-        "@fastify/error": "^3.2.0",
+        "@fastify/error": "^3.4.0",
         "@fastify/fast-json-stringify-compiler": "^4.3.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^8.2.1",
-        "fast-content-type-parse": "^1.0.0",
-        "fast-json-stringify": "^5.7.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
         "find-my-way": "^7.7.0",
-        "light-my-request": "^5.9.1",
-        "pino": "^8.12.0",
-        "process-warning": "^2.2.0",
+        "light-my-request": "^5.11.0",
+        "pino": "^8.17.0",
+        "process-warning": "^3.0.0",
         "proxy-addr": "^2.0.7",
         "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.5.0",
-        "semver": "^7.5.0",
-        "toad-cache": "^3.2.0"
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
+      },
+      "dependencies": {
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+        }
       }
     },
     "fastify-plugin": {
@@ -6634,7 +6971,6 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
       "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6697,6 +7033,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "requires": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      }
     },
     "hyperbee": {
       "version": "2.17.0",
@@ -7166,6 +7514,11 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.1.tgz",
+      "integrity": "sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA=="
+    },
     "mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -7175,7 +7528,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
       }
@@ -7378,7 +7730,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -7393,9 +7744,9 @@
       }
     },
     "p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -7472,21 +7823,28 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pino": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.16.0.tgz",
-      "integrity": "sha512-UUmvQ/7KTZt/vHjhRrnyS7h+J7qPBQnpG80V56xmIC+o9IqYmQOw/UIny9S9zYDfRBR0ClouCr464EkBMIT7Fw==",
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.17.2.tgz",
+      "integrity": "sha512-LA6qKgeDMLr2ux2y/YiUt47EfgQ+S9LznBWOJdN3q1dx2sv0ziDLUBeVpyVv17TEcGCBuWf0zNtg3M5m1NhhWQ==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "v1.1.0",
         "pino-std-serializers": "^6.0.0",
-        "process-warning": "^2.0.0",
+        "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^3.7.0",
         "thread-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+        }
       }
     },
     "pino-abstract-transport": {
@@ -7508,9 +7866,9 @@
           }
         },
         "readable-stream": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
           "requires": {
             "abort-controller": "^3.0.0",
             "buffer": "^6.0.3",
@@ -7867,6 +8225,11 @@
           "version": "18.16.19",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
           "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA=="
+        },
+        "p-timeout": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+          "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="
         }
       }
     },
@@ -7942,6 +8305,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sha256-universal": {
       "version": "1.2.1",
@@ -8120,9 +8488,9 @@
       }
     },
     "sonic-boom": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.7.0.tgz",
-      "integrity": "sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
+      "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
       "requires": {
         "atomic-sleep": "^1.0.0"
       }
@@ -8144,6 +8512,11 @@
       "requires": {
         "tiny-typed-emitter": "^2.1.0"
       }
+    },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "stream-shift": {
       "version": "1.0.1",
@@ -8348,6 +8721,11 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.3.0.tgz",
       "integrity": "sha512-3oDzcogWGHZdkwrHyvJVpPjA7oNzY6ENOV3PsWJY9XYPZ6INo94Yd47s5may1U+nleBPwDhrRiTPMIvKaa3MQg=="
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "tr46": {
       "version": "0.0.3",
@@ -8587,8 +8965,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "z32": {
       "version": "1.0.1",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -13,9 +13,18 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "dependencies": {
+    "@electron/asar": "^3.2.8",
+    "@fastify/error": "^3.4.1",
+    "@fastify/static": "^6.12.0",
+    "@fastify/type-provider-typebox": "^4.0.0",
     "@mapeo/core": "9.0.0-alpha.4",
     "@mapeo/ipc": "^0.1.3",
-    "debug": "^4.3.4"
+    "@sinclair/typebox": "^0.32.9",
+    "debug": "^4.3.4",
+    "fastify": "^4.25.2",
+    "mime": "^4.0.1",
+    "p-timeout": "^6.1.2",
+    "start-stop-state-machine": "^1.2.0"
   },
   "devDependencies": {
     "@digidem/types": "~2.1.0",

--- a/src/backend/scripts/bundle-backend.mjs
+++ b/src/backend/scripts/bundle-backend.mjs
@@ -23,6 +23,11 @@ const plugins = [
   nativePaths(),
   commonjs({
     ignoreDynamicRequires: true,
+    ignore: [
+      // Used by @electron/asar but only in Electron environments
+      // https://github.com/electron/asar/blob/e1c143c9ad9ca4571e8f8d447bddf2cdaa1c9664/lib/wrapped-fs.js#L3
+      'original-fs',
+    ],
   }),
   esmShim(),
   nodeResolve({ preferBuiltins: true }),

--- a/src/backend/src/map-server/index.js
+++ b/src/backend/src/map-server/index.js
@@ -1,0 +1,137 @@
+import { promisify } from 'util'
+import { once } from 'events'
+import pTimeout from 'p-timeout'
+import Fastify from 'fastify'
+import StateMachine from 'start-stop-state-machine'
+
+import { StaticStylesPlugin } from './static-styles-plugin.js'
+
+export class MapServer {
+  #fastify
+  #serverState
+  #fastifyStarted
+  #host
+  #port
+
+  /**
+   * @param {object} mapOpts
+   * @param {string} mapOpts.staticStylesDir
+   * @param {import('fastify').FastifyServerOptions} [fastifyOpts]
+   */
+  constructor({ staticStylesDir }, fastifyOpts) {
+    this.#fastifyStarted = false
+    this.#host = '127.0.0.1'
+    this.#port = 0
+
+    this.#fastify = Fastify(fastifyOpts)
+
+    this.#fastify.register(StaticStylesPlugin, {
+      // Prefix not strictly needed since this is a standalone server instance (i.e. no route naming conflicts)
+      // prefix: '/styles',
+      staticStylesDir,
+    })
+
+    this.#serverState = new StateMachine({
+      start: this.#start.bind(this),
+      stop: this.#stop.bind(this),
+    })
+  }
+
+  /**
+   * @param {object} opts
+   * @param {string} [opts.host]
+   * @param {number} [opts.port]
+   */
+  async #start({ host = '127.0.0.1', port = 0 } = {}) {
+    this.#host = host
+    this.#port = port
+
+    if (!this.#fastifyStarted) {
+      await this.#fastify.listen({ host: this.#host, port: this.#port })
+      this.#fastifyStarted = true
+      return
+    }
+
+    const { server } = this.#fastify
+
+    await new Promise((res, rej) => {
+      server.listen.call(server, { port: this.#port, host: this.#host })
+
+      server.once('listening', onListening)
+      server.once('error', onError)
+
+      function onListening() {
+        server.removeListener('error', onError)
+        res(null)
+      }
+
+      /**
+       * @param {Error} err
+       */
+      function onError(err) {
+        server.removeListener('listening', onListening)
+        rej(err)
+      }
+    })
+  }
+
+  async #stop() {
+    const { server } = this.#fastify
+    await promisify(server.close.bind(server))()
+  }
+
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.host]
+   * @param {number} [opts.port]
+   */
+  async start(opts) {
+    await this.#serverState.start(opts)
+  }
+
+  async started() {
+    return this.#serverState.started()
+  }
+
+  async stop() {
+    await this.#serverState.stop()
+  }
+
+  /**
+   * @returns {Promise<string>}
+   */
+  async getAddress() {
+    return pTimeout(getServerAddress(this.#fastify.server), {
+      milliseconds: 1000,
+    })
+  }
+}
+
+/**
+ * @param {import('node:http').Server} server
+ *
+ * @returns {Promise<string>}
+ */
+async function getServerAddress(server) {
+  const address = server.address()
+
+  if (!address) {
+    await once(server, 'listening')
+    return getServerAddress(server)
+  }
+
+  if (typeof address === 'string') {
+    return address
+  }
+
+  // Full address construction for non unix-socket address
+  // https://github.com/fastify/fastify/blob/7aa802ed224b91ca559edec469a6b903e89a7f88/lib/server.js#L413
+  let addr = ''
+  if (address.address.indexOf(':') === -1) {
+    addr += address.address + ':' + address.port
+  } else {
+    addr += '[' + address.address + ']:' + address.port
+  }
+
+  return 'http://' + addr
+}

--- a/src/backend/src/map-server/static-styles-plugin.js
+++ b/src/backend/src/map-server/static-styles-plugin.js
@@ -1,0 +1,287 @@
+import assert from 'assert'
+import path from 'path'
+import fs from 'fs/promises'
+import createError from '@fastify/error'
+import FastifyStatic from '@fastify/static'
+import { Type as T } from '@sinclair/typebox'
+import asar from '@electron/asar'
+import mime from 'mime'
+
+/**
+ * @typedef {import('fastify').FastifyInstance} FastifyInstance
+ * @typedef {import('fastify').FastifyBaseLogger} FastifyBaseLogger
+ * @typedef {import('fastify').RawServerDefault} RawServerDefault
+ * @typedef {import('fastify').FastifyInstance<
+ *  import('fastify').RawServerDefault,
+ *  import('fastify').RawRequestDefaultExpression<import('fastify').RawServerDefault>,
+ *  import('fastify').RawReplyDefaultExpression<RawServerDefault>,
+ *  import('fastify').FastifyBaseLogger,
+ *  import('@fastify/type-provider-typebox').TypeBoxTypeProvider
+ * >} FastifyTypebox
+ */
+
+const GetStaticStyleTileParamsSchema = T.Object({
+  id: T.String(),
+  tileId: T.String(),
+  z: T.Number(),
+  y: T.Number(),
+  x: T.Number(),
+  ext: T.Optional(T.String()),
+})
+
+const ListStaticStylesReplySchema = T.Array(
+  T.Object({
+    id: T.String(),
+    name: T.Union([T.String(), T.Null()]),
+    url: T.String(),
+  }),
+)
+
+const GetStyleJsonParamsSchema = T.Object({
+  id: T.String(),
+})
+
+const NotFoundError = createError(
+  'FST_RESOURCE_NOT_FOUND',
+  'Resource `%s` not found',
+  404,
+)
+
+/**
+ * @param {import('fastify').FastifyRequest} request
+ * @returns {string}
+ */
+function getBaseApiUrl(request) {
+  const { hostname, protocol } = request
+  return `${protocol}://${hostname}`
+}
+
+/**
+ * @param {string} archive
+ * @param {string} filename
+ */
+function extractAsarFile(archive, filename) {
+  try {
+    return asar.extractFile(archive, filename)
+  } catch (err) {
+    return undefined
+  }
+}
+
+/**
+ * @param {string} baseDirectory
+ * @param {import('@sinclair/typebox').Static<typeof GetStaticStyleTileParamsSchema>} params
+ * @returns {null | { data: Buffer, mimeType: string | null, shouldGzip: boolean}}
+ */
+function getStyleTileInfo(baseDirectory, params) {
+  const { id, tileId, z, x, y } = params
+  let { ext } = params
+
+  const fileBasename = path.join(z.toString(), x.toString(), y.toString())
+  const asarPath = path.join(baseDirectory, id, 'tiles', tileId + '.asar')
+
+  console.error({
+    fileBasename,
+    asarPath,
+  })
+
+  /** @type {Buffer | undefined} */
+  let data
+
+  if (ext) {
+    data = extractAsarFile(asarPath, fileBasename + '.' + ext)
+  } else {
+    // Try common extensions
+    const extensions = ['png', 'jpg', 'jpeg']
+
+    for (const e of extensions) {
+      data = extractAsarFile(asarPath, fileBasename + '.' + e)
+
+      // Match found, use the corresponding extension moving forward
+      if (data) {
+        ext = e
+        break
+      }
+    }
+  }
+
+  // extension check isn't fully necessary since the buffer will only exist if the extension exists
+  // but useful to check for types reasons
+  if (!data || !ext) {
+    return null
+  }
+
+  const mimeType = mime.getType(ext)
+
+  // Set gzip encoding on {mvt,pbf} tiles.
+  const shouldGzip = /mvt|pbf$/.test(ext)
+
+  return { data, mimeType, shouldGzip }
+}
+
+/**
+ * @param {FastifyTypebox} fastify
+ * @param {object} opts
+ * @param {string} opts.staticStylesDir
+ */
+
+/**
+ * @type {import('fastify').FastifyPluginAsync<{ staticStylesDir: string }>}
+ */
+export async function StaticStylesPlugin(f, opts) {
+  // https://fastify.dev/docs/latest/Reference/Type-Providers/#scoped-type-provider
+  /** @type {FastifyTypebox} */
+  const fastify = f.withTypeProvider()
+
+  const { staticStylesDir } = opts
+
+  const normalizedPrefix = fastify.prefix.endsWith('/')
+    ? fastify.prefix
+    : fastify.prefix + '/'
+
+  /**
+   * @param {import('fastify').FastifyRequest<{Params: import('@sinclair/typebox').Static<typeof GetStaticStyleTileParamsSchema>}>} req
+   * @param {import('fastify').FastifyReply} res
+   */
+  async function handleStyleTileGet(req, res) {
+    const result = getStyleTileInfo(staticStylesDir, req.params)
+
+    if (!result) {
+      const { tileId, z, x, y, ext } = req.params
+      throw new NotFoundError(
+        `Tileset id = ${tileId}, ext=${ext}, [${z}, ${x}, ${y}]`,
+      )
+    }
+
+    const { data, mimeType, shouldGzip } = result
+
+    if (mimeType) {
+      res.header('Content-Type', mimeType)
+    }
+
+    if (shouldGzip) {
+      res.header('Content-Encoding', 'gzip')
+    }
+
+    res.send(data)
+  }
+
+  /// Registered routes
+
+  fastify.get(
+    '/',
+    { schema: { response: { 200: ListStaticStylesReplySchema } } },
+    async (req) => {
+      const styleDirFiles = await fs.readdir(staticStylesDir)
+
+      const result = (
+        await Promise.all(
+          styleDirFiles.map(async (filename) => {
+            const stat = await fs.stat(path.join(staticStylesDir, filename))
+            if (!stat.isDirectory()) return null
+
+            let styleJson
+
+            try {
+              const styleJsonContent = await fs.readFile(
+                path.join(staticStylesDir, filename, 'style.json'),
+                'utf-8',
+              )
+
+              styleJson = JSON.parse(styleJsonContent)
+            } catch (err) {
+              return null
+            }
+
+            return {
+              id: filename,
+              name: typeof styleJson.name === 'string' ? styleJson.name : null,
+              // TODO: What should this URL point to?
+              url: new URL(normalizedPrefix + filename, getBaseApiUrl(req))
+                .href,
+            }
+          }),
+        )
+      ).filter(
+        /**
+         * @template {import('@sinclair/typebox').Static<typeof ListStaticStylesReplySchema>[number] | null} V
+         * @param {V} v
+         * @returns {v is NonNullable<V>}
+         */
+        (v) => v !== null,
+      )
+
+      return result
+    },
+  )
+
+  fastify.get(
+    `/:id/style.json`,
+    { schema: { params: GetStyleJsonParamsSchema } },
+    async (req, res) => {
+      const { id } = req.params
+
+      /** @type {import('fs').Stats} */
+      let stat
+
+      /** @type {string | Buffer} */
+      let data
+
+      try {
+        const filePath = path.join(staticStylesDir, id, 'style.json')
+        stat = await fs.stat(filePath)
+        data = await fs.readFile(filePath, 'utf-8')
+      } catch (err) {
+        throw new NotFoundError(`id = ${id}, style.json`)
+      }
+
+      const address = req.server.server.address()
+      assert(address)
+
+      const hostname =
+        typeof address === 'string'
+          ? address
+          : `${address.address}:${address.port}`
+
+      data = Buffer.from(
+        data.replace(
+          /\{host\}/gm,
+          'http://' + hostname + normalizedPrefix + id,
+        ),
+      )
+      res.header('Content-Type', 'application/json; charset=utf-8')
+      res.header('Last-Modified', new Date(stat.mtime).toUTCString())
+      res.header('Cache-Control', 'max-age=' + 5 * 60) // 5 minutes
+      res.header('Content-Length', data.length)
+      res.header(
+        'Access-Control-Allow-Headers',
+        'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
+      )
+      res.header('Access-Control-Allow-Origin', '*')
+
+      res.send(data)
+    },
+  )
+
+  fastify.get(
+    `/:id/tiles/:tileId/:z/:x/:y.:ext`,
+    { schema: { params: GetStaticStyleTileParamsSchema } },
+    handleStyleTileGet,
+  )
+
+  fastify.get(
+    `/:id/tiles/:tileId/:z/:x/:y`,
+    { schema: { params: GetStaticStyleTileParamsSchema } },
+    handleStyleTileGet,
+  )
+
+  fastify.register(FastifyStatic, {
+    root: staticStylesDir,
+    decorateReply: false,
+    setHeaders: (res, path) => {
+      if (path.toLowerCase().endsWith('.pbf')) {
+        res.setHeader('Content-Type', 'application/x-protobuf')
+      }
+    },
+  })
+}

--- a/src/frontend/initializeNodejs.ts
+++ b/src/frontend/initializeNodejs.ts
@@ -3,6 +3,8 @@ import {getItemAsync, setItemAsync} from 'expo-secure-store';
 import nodejs from 'nodejs-mobile-react-native';
 import {uint8ArrayToHex} from 'uint8array-extras';
 
+import {EXTERNAL_FILES_DIR} from './lib/file-system';
+
 const ROOT_KEY = '__RootKey';
 
 export async function initializeNodejs() {
@@ -19,5 +21,11 @@ export async function initializeNodejs() {
     }
   }
 
-  nodejs.startWithArgs(`loader.js --rootKey=${rootKey}`);
+  const flags = [`--rootKey=${rootKey}`];
+
+  if (EXTERNAL_FILES_DIR) {
+    flags.push(`--sharedStoragePath=${EXTERNAL_FILES_DIR}`);
+  }
+
+  nodejs.startWithArgs(`loader.js ${flags.join(' ')}`);
 }

--- a/src/frontend/lib/file-system.ts
+++ b/src/frontend/lib/file-system.ts
@@ -1,0 +1,13 @@
+import {NativeModules} from 'react-native';
+
+interface FileSystem {
+  getConstants(): {
+    EXTERNAL_FILES_DIR: string | null;
+  };
+}
+
+const FileSystem: FileSystem = NativeModules.FileSystemModule;
+
+const {EXTERNAL_FILES_DIR} = FileSystem.getConstants();
+
+export {FileSystem, EXTERNAL_FILES_DIR};


### PR DESCRIPTION
Introduces the following:


- Fastify plugin for serving "static" maps. The code for it is essentially copied over from https://github.com/digidem/mapeo-map-server/pull/101 because it'll be easier to get this integrated in the app if we don't have to worry about integrating the whole map server dep (which introduces an older version of fastify, better-sqlite3, etc). Its functionality is pretty isolated from the map server so feels okay to vendor that implementation here while I gradually work on updating the map server dep in sorts of ways.

- native module for getting necessary filesystem paths. basically vendors a very specific part of https://github.com/itinance/react-native-fs, which felt like overkill to introduce for this PR.

Still haven't gotten any tiles to render on the map so leaving as a draft until i figure that out 🤔 Seems like the style is read correctly (although not entirely sure)