### PR TITLE
ensure light theme is used for native styles

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,8 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <!-- TODO: Change this to Theme.AppCompat.DayNight.NoActionBar when we support both light and
+    dark themes -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
         <!-- <item name="android:windowBackground">@drawable/splashscreen</item> -->


### PR DESCRIPTION
Fixes an issue where having a dark theme set for the OS causes native styes to be incompatible with the app styles (e.g. scrollbar color for scrollviews).

Once our app styles account for light vs dark themes, we can revert this change.

---

Preview (see right-hand side of images):

- Before:

    <img width="480" alt="image" src="https://github.com/digidem/CoMapeo-mobile/assets/18542095/808995ff-d1b1-41a4-9add-575b2028be6e">


- After:

    <img width="480" alt="image" src="https://github.com/digidem/CoMapeo-mobile/assets/18542095/3e3b4017-c96d-4480-9749-a625169bdb2c">
