### PR TITLE
implement query hooks for saving attachments and retrieving attachment urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-native-scale-bar": "^1.0.6",
         "react-native-screens": "^3.24.0",
         "react-native-svg": "^13.14.0",
+        "react-native-url-polyfill": "^2.0.0",
         "react-native-vector-icons": "^10.0.0",
         "readable-stream": "^4.4.1",
         "rpc-reflector": "^1.3.10",
@@ -20805,6 +20806,17 @@
         "react-native-svg": ">=12.0.0"
       }
     },
+    "node_modules/react-native-url-polyfill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
+      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-vector-icons": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.0.tgz",
@@ -25127,11 +25139,55 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
       "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "dependencies": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -41552,6 +41608,14 @@
         "path-dirname": "^1.0.2"
       }
     },
+    "react-native-url-polyfill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
+      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
+      "requires": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      }
+    },
     "react-native-vector-icons": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.0.tgz",
@@ -44127,10 +44191,36 @@
         "defaults": "^1.0.3"
       }
     },
+    "webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+    },
     "whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
       "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
+    "whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-native-scale-bar": "^1.0.6",
     "react-native-screens": "^3.24.0",
     "react-native-svg": "^13.14.0",
+    "react-native-url-polyfill": "^2.0.0",
     "react-native-vector-icons": "^10.0.0",
     "readable-stream": "^4.4.1",
     "rpc-reflector": "^1.3.10",

--- a/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
+++ b/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
@@ -16,6 +16,7 @@ const emptyObservation: ClientGeneratedObservation = {
   tags: {
     notes: '',
   },
+  attachments: [],
 };
 
 export type DraftObservationSlice = {
@@ -118,6 +119,7 @@ const draftObservationSlice: StateCreator<DraftObservationSlice> = (
           refs: [],
           tags: {categoryId: preset.docId},
           metadata: {},
+          attachments: [],
         },
         preset: preset,
       });

--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -17,8 +17,6 @@ export function useCreateAttachmentsMutation() {
 
   return useMutation({
     mutationFn: async (photos: SavablePhoto[]) => {
-      if (!project) throw new Error('Project instance does not exist');
-
       return Promise.all(
         photos.map(p => {
           const {originalUri, previewUri, thumbnailUri} = p;
@@ -60,8 +58,6 @@ export function useAttachmentUrlQueries(
           attachment.name,
         ],
         queryFn: async () => {
-          if (!project) throw new Error('Project instance does not exist');
-
           switch (attachment.type) {
             case 'UNRECOGNIZED': {
               throw new Error(

--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -12,28 +12,23 @@ type SavablePhoto = SetRequired<
   'originalUri'
 >;
 
-export function useCreateAttachmentsMutation() {
+export function useCreateBlobMutation(opts: {retry?: number} = {}) {
   const project = useProject();
 
   return useMutation({
-    mutationFn: async (photos: SavablePhoto[]) => {
-      return Promise.all(
-        photos.map(p => {
-          const {originalUri, previewUri, thumbnailUri} = p;
+    retry: opts.retry,
+    mutationFn: async (photo: SavablePhoto) => {
+      const {originalUri, previewUri, thumbnailUri} = photo;
 
-          return project.$blobs.create(
-            {
-              original: new URL(originalUri).pathname,
-              preview: previewUri ? new URL(previewUri).pathname : undefined,
-              thumbnail: thumbnailUri
-                ? new URL(thumbnailUri).pathname
-                : undefined,
-            },
-            // TODO: DraftPhoto type should probably carry MIME type info that feeds this
-            // although backend currently only uses first part of path
-            {mimeType: 'image/jpeg'},
-          );
-        }),
+      return project.$blobs.create(
+        {
+          original: new URL(originalUri).pathname,
+          preview: previewUri ? new URL(previewUri).pathname : undefined,
+          thumbnail: thumbnailUri ? new URL(thumbnailUri).pathname : undefined,
+        },
+        // TODO: DraftPhoto type should probably carry MIME type info that feeds this
+        // although backend currently only uses first part of path
+        {mimeType: 'image/jpeg'},
       );
     },
   });

--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -52,8 +52,6 @@ export function useAttachmentUrlQueries(
   return useQueries({
     queries: attachments.map(attachment => {
       return {
-        staleTime: Infinity,
-        gcTime: Infinity,
         queryKey: [
           'attachmentUrl',
           attachment.driveDiscoveryId,

--- a/src/frontend/hooks/server/observations.ts
+++ b/src/frontend/hooks/server/observations.ts
@@ -43,7 +43,6 @@ export function useCreateObservation() {
       return project.observation.create({
         ...value,
         schemaName: 'observation',
-        attachments: [],
       });
     },
     onSuccess: () => {

--- a/src/frontend/screens/ObservationEdit/SaveButton.tsx
+++ b/src/frontend/screens/ObservationEdit/SaveButton.tsx
@@ -193,7 +193,8 @@ export const SaveButton = ({
     Alert.alert(t(m.weakGpsTitle), t(m.weakGpsDesc), confirmationOptions);
   };
 
-  return createObservationMutation.isPending ||
+  return createBlobMutation.isPending ||
+    createObservationMutation.isPending ||
     editObservationMutation.isPending ? (
     <View style={{marginRight: 10}}>
       <UIActivityIndicator size={30} />

--- a/src/frontend/screens/ObservationEdit/SaveButton.tsx
+++ b/src/frontend/screens/ObservationEdit/SaveButton.tsx
@@ -78,6 +78,22 @@ export const SaveButton = ({
 
     const savablePhotos = photos.filter(isSavablePhoto);
 
+    if (!savablePhotos) {
+      createObservationMutation.mutate(
+        {value},
+        {
+          onError: () => {
+            if (openErrorModal) openErrorModal();
+          },
+          onSuccess: () => {
+            navigation.navigate('Home', {screen: 'Map'});
+          },
+        },
+      );
+
+      return;
+    }
+
     createAttachmentsMutation.mutate(savablePhotos, {
       onError: () => {
         if (openErrorModal) openErrorModal();

--- a/src/frontend/sharedTypes.ts
+++ b/src/frontend/sharedTypes.ts
@@ -44,10 +44,7 @@ export type Position = Observation['metadata']['position'];
 
 export type Provider = Observation['metadata']['positionProvider'];
 
-export type ClientGeneratedObservation = Omit<
-  ObservationValue,
-  'schemaName' | 'attachments'
->;
+export type ClientGeneratedObservation = Omit<ObservationValue, 'schemaName'>;
 
 export type Attachment = Observation['attachments'][0];
 


### PR DESCRIPTION
Closes #119 

This PR implements the following query hooks:

- `useCreateBlobMutation()`: mutation that accepts a photo object (presumably coming from a observation draft) and saves it as a blob

- `useAttachmentUrlQueries()`: query that accepts a list of observation attachments and performs a query to get the http url for each of them

Perhaps out of scope, but this PR also uses `useCreateBlobMutation()` in the `SaveButton` implementation. `useAttachmentUrlQueries()` is currently not used anywhere.