### PR TITLE
implement useSyncState hook

### DIFF
--- a/src/frontend/contexts/ProjectContext.tsx
+++ b/src/frontend/contexts/ProjectContext.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import {type MapeoClientApi} from '@mapeo/ipc';
+import {type MapeoClientApi, type MapeoProjectApi} from '@mapeo/ipc';
 import {useApi} from './ApiContext';
 import {usePersistedProjectId} from '../hooks/persistedState/usePersistedProjectId';
 import {Loading} from '../sharedComponents/Loading';
 
-type MapeoProject = Awaited<ReturnType<MapeoClientApi['getProject']>>;
-
 type ActiveProjectContextType = {
-  project: MapeoProject;
+  project: MapeoProjectApi;
   switchProject(projectId: string): void;
 };
 
@@ -28,7 +26,7 @@ export const ActiveProjectProvider = ({
 }: React.PropsWithChildren<{}>) => {
   const mapeoApi = useApi();
   const [activeProject, setActiveProject] = React.useState<
-    MapeoProject | undefined
+    MapeoProjectApi | undefined
   >();
   const activeProjectId = usePersistedProjectId(store => store.projectId);
   const setActiveProjectId = usePersistedProjectId(store => store.setProjectId);

--- a/src/frontend/hooks/useSyncState.ts
+++ b/src/frontend/hooks/useSyncState.ts
@@ -1,0 +1,84 @@
+import {MapeoProjectApi} from '@mapeo/ipc';
+import React from 'react';
+import {useProject} from './server/projects';
+
+type SyncState = Awaited<ReturnType<MapeoProjectApi['$sync']['getState']>>;
+
+const projectStateMap = new WeakMap<
+  MapeoProjectApi,
+  ReturnType<typeof createSyncState>
+>();
+
+/**
+ * Hook to subscribe to the current sync state. Optionally pass a selector to
+ * subscribe to a subset of the state (to avoid unnecessary re-renders)
+ *
+ * Creates a global singleton for each project, to minimize traffic over IPC -
+ * this hook can safely be used in more than one place without attaching
+ * additional listeners across the IPC channel.
+ *
+ * @example
+ * ```
+ * const connectedPeerCount = useSync(state => state.connectedPeers);
+ * ```
+ *
+ * @param selector Select a subset of the state to subscribe to. Defaults to return the entire state.
+ * @returns
+ */
+export function useSyncState(
+  selector: (state: SyncState | undefined) => any = state => state,
+) {
+  const project = useProject();
+  let state = projectStateMap.get(project);
+  if (!state) {
+    state = createSyncState(project);
+    projectStateMap.set(project, state);
+  }
+  const {subscribe, getSnapshot} = state;
+  return React.useSyncExternalStore(subscribe, () => selector(getSnapshot()));
+}
+
+function createSyncState(project: MapeoProjectApi) {
+  let state: SyncState | undefined;
+  let isSubscribedInternal = false;
+  const listeners = new Set<() => void>();
+  let error: Error | undefined;
+
+  function onSyncState(state: SyncState) {
+    state = state;
+    error = undefined;
+    listeners.forEach(listener => listener());
+  }
+
+  function subscribeInternal() {
+    project.$sync.on('sync-state', onSyncState);
+    isSubscribedInternal = true;
+    project.$sync
+      .getState()
+      .then(onSyncState)
+      .catch(e => {
+        error = e;
+        listeners.forEach(listener => listener());
+      });
+  }
+
+  function unsubscribeInternal() {
+    isSubscribedInternal = false;
+    project.$sync.off('sync-state', onSyncState);
+  }
+
+  return {
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      if (!isSubscribedInternal) subscribeInternal();
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) unsubscribeInternal();
+      };
+    },
+    getSnapshot: () => {
+      if (error) throw error;
+      return state;
+    },
+  };
+}

--- a/src/frontend/hooks/useSyncState.ts
+++ b/src/frontend/hooks/useSyncState.ts
@@ -25,9 +25,9 @@ const projectStateMap = new WeakMap<
  * @param selector Select a subset of the state to subscribe to. Defaults to return the entire state.
  * @returns
  */
-export function useSyncState(
-  selector: (state: SyncState | undefined) => any = state => state,
-) {
+export function useSyncState<S = SyncState | undefined>(
+  selector: (state: SyncState | undefined) => S = state => state as any,
+): S {
   const project = useProject();
   let state = projectStateMap.get(project);
   if (!state) {


### PR DESCRIPTION
Closes #148 

Most of the work done by @gmaclennan - I just made some small adjustments. Currently not being used anywhere.

Questions:

- should the returned state also have a `status` field, similar to what's done for the [`LocalDiscoveryState`](https://github.com/digidem/CoMapeo-mobile/blob/ecc62135945d87c44f4f38ec8e0ca962e24b726e/src/frontend/contexts/LocalDiscoveryContext.tsx#L16)? wasn't sure if we need the same level of complexity when dealing with sync state in terms of dealing with lots of async handling, so didn't try to implement that for now