### PR TITLE
Es/saved observations

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -19,6 +19,7 @@ import {
   LocalDiscoveryProvider,
   createLocalDiscoveryController,
 } from './contexts/LocalDiscoveryContext';
+import {Loading} from './sharedComponents/Loading';
 
 const queryClient = new QueryClient();
 const messagePort = new MessagePortLike();
@@ -56,7 +57,9 @@ const App = () => {
               <ActiveProjectProvider>
                 <PhotoPromiseProvider>
                   <SecurityProvider>
-                    <AppNavigator permissionAsked={permissionsAsked} />
+                    <React.Suspense fallback={<Loading />}>
+                      <AppNavigator permissionAsked={permissionsAsked} />
+                    </React.Suspense>
                   </SecurityProvider>
                 </PhotoPromiseProvider>
               </ActiveProjectProvider>

--- a/src/frontend/Navigation/AppNavigator.tsx
+++ b/src/frontend/Navigation/AppNavigator.tsx
@@ -13,6 +13,7 @@ import {useDeviceInfo} from '../hooks/server/deviceInfo';
 import {Loading} from '../sharedComponents/Loading';
 import {createDeviceNamingScreens} from './ScreenGroups/DeviceNamingScreens';
 import {usePrefetchLastKnownLocation} from '../hooks/useLastSavedLocation';
+import {usePersistedDraftObservation} from '../hooks/persistedState/usePersistedDraftObservation';
 
 // import {devExperiments} from '../lib/DevExperiments';
 
@@ -34,6 +35,9 @@ import {usePrefetchLastKnownLocation} from '../hooks/useLastSavedLocation';
 
 export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   const {formatMessage} = useIntl();
+  const existingObservation = usePersistedDraftObservation(
+    store => store.value,
+  );
 
   const deviceInfo = useDeviceInfo();
   usePrefetchLastKnownLocation();
@@ -50,9 +54,15 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   return (
     <React.Suspense fallback={<Loading />}>
       <RootStack.Navigator
-        initialRouteName="IntroToCoMapeo"
+        initialRouteName={
+          !deviceInfo.data?.name
+            ? 'IntroToCoMapeo'
+            : existingObservation
+              ? 'ObservationEdit'
+              : 'Home'
+        }
         screenOptions={NavigatorScreenOptions}>
-        {deviceInfo.data && deviceInfo.data.name
+        {deviceInfo.data?.name
           ? createDefaultScreenGroup(formatMessage)
           : createDeviceNamingScreens(formatMessage)}
       </RootStack.Navigator>

--- a/src/frontend/Navigation/AppNavigator.tsx
+++ b/src/frontend/Navigation/AppNavigator.tsx
@@ -61,7 +61,7 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
 
   return (
     <RootStack.Navigator
-      initialRouteName={setInitialRouteName({
+      initialRouteName={getInitialRouteName({
         hasDeviceName: !!deviceInfo.data?.name,
         existingObservation,
         presets,
@@ -74,7 +74,7 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   );
 };
 
-function setInitialRouteName(
+function getInitialRouteName(
   initialInfo:
     | {hasDeviceName: false}
     | {

--- a/src/frontend/Navigation/AppNavigator.tsx
+++ b/src/frontend/Navigation/AppNavigator.tsx
@@ -62,7 +62,7 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   return (
     <RootStack.Navigator
       initialRouteName={setInitialRouteName({
-        hasName: !!deviceInfo.data?.name,
+        hasDeviceName: !!deviceInfo.data?.name,
         existingObservation,
         presets,
       })}
@@ -76,15 +76,15 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
 
 function setInitialRouteName(
   initialInfo:
-    | {hasName: false}
+    | {hasDeviceName: false}
     | {
-        hasName: true;
+        hasDeviceName: true;
         existingObservation: null | ClientGeneratedObservation | Observation;
         presets: Preset[];
       },
 ): keyof AppList | keyof DeviceNamingSceens {
   // if user has not set a name, navigate to intro screen where they will be prompted to set a name
-  if (!initialInfo.hasName) {
+  if (!initialInfo.hasDeviceName) {
     return 'IntroToCoMapeo';
   }
 

--- a/src/frontend/screens/PresetChooser.tsx
+++ b/src/frontend/screens/PresetChooser.tsx
@@ -47,10 +47,10 @@ export const PresetChooser: NativeNavigationComponent<'PresetChooser'> = ({
   React.useLayoutEffect(() => {
     navigation.setOptions({
       headerLeft: props =>
-        prevRouteNameInStack === 'Home' ? (
-          <CustomHeaderLeftClose headerBackButtonProps={props} />
-        ) : (
+        prevRouteNameInStack === 'ObservationEdit' ? (
           <CustomHeaderLeft headerBackButtonProps={props} />
+        ) : (
+          <CustomHeaderLeftClose headerBackButtonProps={props} />
         ),
     });
   }, [prevRouteNameInStack, CustomHeaderLeft, CustomHeaderLeftClose]);

--- a/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
@@ -100,7 +100,9 @@ const HeaderBackNewObservation = ({
         text: t(m.discardConfirm),
         onPress: () => {
           clearDraft();
-          navigation.dispatch(CommonActions.navigate('Home', {screen: 'map'}));
+          navigation.dispatch(
+            CommonActions.reset({index: 0, routes: [{name: 'Home'}]}),
+          );
         },
       },
       {text: t(m.discardCancel), onPress: () => {}},


### PR DESCRIPTION
Loads initial screen based on following factors
- if the user has no name set, user is navigated to intro screen where they will be prompted to add a name
- if the user has a name set, and no saved observation, they are navigated to the home (map) screen
- if the user has a saved observation, but no matching preset, implies user has started and observation and has not chosen a preset yet. User will be navigated to `PresetChooser` screen
- If the user has a saved observation with a matching preset, the user is navigated to `ObservationEdit` Screen