### PR TITLE
fix: update mapbox public access token

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,3 @@
 {
-  "mapboxAccessToken": "pk.eyJ1IjoiZ21hY2xlbm5hbiIsImEiOiJSaWVtd2lRIn0.ASYMZE2HhwkAw4Vt7SavEg"
+  "mapboxAccessToken": "pk.eyJ1IjoiZGlnaWRlbSIsImEiOiJjbHRyaGh3cm0wN3l4Mmpsam95NDI3c2xiIn0.daq2iZFZXQ08BD0VZWAGUw"
 }


### PR DESCRIPTION
Replaces the broken token with a (temporary) public access token created via the org account