### PR TITLE
chore: allow @node-rs/crc32, a dependency of mapeo-core, to be bundled

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@digidem/types": "~2.1.0",
+        "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-esm-shim": "^0.1.4",
         "@rollup/plugin-json": "^6.0.1",
@@ -722,6 +723,26 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@rollup/plugin-alias": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+      "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+      "dev": true,
+      "dependencies": {
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.7",
@@ -4217,6 +4238,18 @@
         "nanoassert": "^2.0.0"
       }
     },
+    "node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sodium-javascript": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz",
@@ -5440,6 +5473,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@rollup/plugin-alias": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+      "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+      "dev": true,
+      "requires": {
+        "slash": "^4.0.0"
+      }
     },
     "@rollup/plugin-commonjs": {
       "version": "25.0.7",
@@ -8071,6 +8113,12 @@
       "requires": {
         "nanoassert": "^2.0.0"
       }
+    },
+    "slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true
     },
     "sodium-javascript": {
       "version": "0.8.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@digidem/types": "~2.1.0",
+    "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-esm-shim": "^0.1.4",
     "@rollup/plugin-json": "^6.0.1",

--- a/src/backend/scripts/bundle-backend.mjs
+++ b/src/backend/scripts/bundle-backend.mjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 import { parseArgs } from 'util'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { rollup } from 'rollup'
+import alias from '@rollup/plugin-alias'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import esmShim from '@rollup/plugin-esm-shim'
 import { minify } from 'rollup-plugin-esbuild'
 import nativePaths from './rollup-plugin-native-paths.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const { values } = parseArgs({
   options: {
@@ -20,6 +26,16 @@ const { entry, output, minify: shouldMinify } = values
 
 /** @type {import('rollup').RollupOptions['plugins']} */
 const plugins = [
+  alias({
+    entries: [
+      // @mapeo/core (indirectly) depends on @node-rs/crc32, which can't be rolled up.
+      // Replace it with a pure JavaScript implementation.
+      {
+        find: '@node-rs/crc32',
+        replacement: path.join(__dirname, '..', 'src', 'node-rs-crc32-shim.js'),
+      },
+    ],
+  }),
   nativePaths(),
   commonjs({
     ignoreDynamicRequires: true,

--- a/src/backend/src/node-rs-crc32-shim.js
+++ b/src/backend/src/node-rs-crc32-shim.js
@@ -1,5 +1,8 @@
 /**
  * Shim for @node-rs/crc32 written in pure JavaScript.
+ *
+ * Modified from [this sample implementation](https://www.w3.org/TR/2022/WD-png-3-20221025/#D-CRCAppendix).
+ *
  * @module
  */
 

--- a/src/backend/src/node-rs-crc32-shim.js
+++ b/src/backend/src/node-rs-crc32-shim.js
@@ -1,0 +1,37 @@
+/**
+ * Shim for @node-rs/crc32 written in pure JavaScript.
+ * @module
+ */
+
+/** @type {undefined | Uint32Array} */
+let crcTable
+
+/**
+ * @param {string | Buffer} input
+ * @param {number | undefined | null} [initialState]
+ * @returns {number}
+ */
+function crc32(input, initialState = 0) {
+  if (typeof input === 'string') return crc32(Buffer.from(input), initialState)
+
+  if (!crcTable) {
+    crcTable = new Uint32Array(256)
+    for (let i = 0; i < 256; i++) {
+      let b = i
+      for (let j = 0; j < 8; j++) {
+        b = b & 1 ? 0xedb88320 ^ (b >>> 1) : b >>> 1
+      }
+      crcTable[i] = b >>> 0
+    }
+  }
+
+  let crc = ~~initialState ^ -1
+  for (let i = 0; i < input.length; i++) {
+    crc = crcTable[(crc ^ input[i]) & 0xff] ^ (crc >>> 8)
+  }
+  crc ^= -1
+
+  return crc >>> 0
+}
+
+exports.crc32 = crc32


### PR DESCRIPTION
`@mapeo/core` (indirectly) depends on `@node-rs/crc32`, which can't be bundled. Replace it with a pure JavaScript implementation.