### PR TITLE
chore: add basic github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    # By default, a workflow only runs when a pull_request 's activity type is
-    # opened , synchronize , or reopened. Adding ready_for_review here ensures
+    # By default, a workflow only runs when a pull_request's activity type is
+    # opened, synchronize, or reopened. Adding ready_for_review here ensures
     # that CI runs when a PR is marked as not a draft, since we skip CI when a
     # PR is draft
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # By default, a workflow only runs when a pull_request 's activity type is
+    # opened , synchronize , or reopened. Adding ready_for_review here ensures
+    # that CI runs when a PR is marked as not a draft, since we skip CI when a
+    # PR is draft
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+    defaults:
+      run:
+        working-directory: './src/backend'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install deps
+        run: |
+          npm ci --ignore-scripts
+          npm run postinstall
+      - name: Check types
+        run: npm run types
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install deps
+        run: npm ci
+      - name: Build translations
+        run: npm run build:translations
+      - name: Build Intl polyfills
+        run: npm run build:intl-polyfills
+      - name: Check types
+        run: npm run types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,7 @@ jobs:
         run: npm run build:translations
       - name: Build Intl polyfills
         run: npm run build:intl-polyfills
-      - name: Check types
-        run: npm run lint:types
+      - name: Check formatting
+        run: npm run lint:prettier
+      - name: Run unit tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
+  all:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install deps
+        run: npm ci
+      - name: Check formatting
+        run: npm run lint:prettier
+
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -49,7 +65,5 @@ jobs:
         run: npm run build:translations
       - name: Build Intl polyfills
         run: npm run build:intl-polyfills
-      - name: Check formatting
-        run: npm run lint:prettier
       - name: Run unit tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           npm ci --ignore-scripts
           npm run postinstall
       - name: Check types
-        run: npm run types
+        run: npm run lint:types
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Build Intl polyfills
         run: npm run build:intl-polyfills
       - name: Check types
-        run: npm run types
+        run: npm run lint:types

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "deep-clean": "./scripts/deep-clean.sh",
     "build:translations": "node ./scripts/build-translations.js ",
     "build:intl-polyfills": "node ./scripts/build-intl-polyfills.mjs",
-    "extract-messages": "formatjs extract 'src/frontend/**/*.{ts,tsx}' --ignore='**/*.d.ts' --format crowdin --out-file ./messages/en.json"
+    "extract-messages": "formatjs extract 'src/frontend/**/*.{ts,tsx}' --ignore='**/*.d.ts' --format crowdin --out-file ./messages/en.json",
+    "types": "tsc --noEmit"
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "test": "jest",
     "lint:prettier": "prettier \"src/**/*.{js,ts,jsx,tsx}\" --check",
     "lint:eslint": "eslint . --ext .js,.jsx,.ts,.tsx --cache --ignore-path .gitignore",
-    "lint": "npm run lint:prettier && npm run lint:eslint",
+    "lint:types": "tsc --noEmit",
+    "lint": "npm run lint:prettier && npm run lint:eslint && npm run lint:types",
     "postinstall": "patch-package",
     "prepare": "husky install",
     "format": "prettier \"src/**/*.{js,ts,jsx,tsx}\" --write",
     "deep-clean": "./scripts/deep-clean.sh",
     "build:translations": "node ./scripts/build-translations.js ",
     "build:intl-polyfills": "node ./scripts/build-intl-polyfills.mjs",
-    "extract-messages": "formatjs extract 'src/frontend/**/*.{ts,tsx}' --ignore='**/*.d.ts' --format crowdin --out-file ./messages/en.json",
-    "types": "tsc --noEmit"
+    "extract-messages": "formatjs extract 'src/frontend/**/*.{ts,tsx}' --ignore='**/*.d.ts' --format crowdin --out-file ./messages/en.json"
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.7",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node ./scripts/bundle-backend.mjs --entry=index.js --output=index.bundle.js",
-    "lint": "tsc",
+    "types": "tsc --noEmit",
     "postinstall": "patch-package"
   },
   "author": "Digital Democracy",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node ./scripts/bundle-backend.mjs --entry=index.js --output=index.bundle.js",
-    "types": "tsc --noEmit",
+    "lint:types": "tsc --noEmit",
     "postinstall": "patch-package"
   },
   "author": "Digital Democracy",

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -7,7 +7,6 @@
         "./node_modules/@digidem/types/vendor/*/index.d.ts"
       ]
     },
-    "resolveJsonModule": true,
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,


### PR DESCRIPTION
Towards https://github.com/digidem/CoMapeo-mobile/issues/56

Introduces a basic github action that runs on non-draft PRs. ~Currently only does typechecking for both backend and frontend.~

Does the following checks for now:

- all: formatting checks
- backend: type checks
- frontend: unit tests

ESLint (for all) and typechecking (for frontend) to be done as a follow-up