### PR TITLE
fix:changes "updateObservationNotes" to "updateTags"

### DIFF
--- a/src/frontend/screens/ObservationEdit/DescriptionField.tsx
+++ b/src/frontend/screens/ObservationEdit/DescriptionField.tsx
@@ -16,14 +16,14 @@ const m = defineMessages({
 export const DescriptionField = () => {
   const {formatMessage: t} = useIntl();
   const notes = usePersistedDraftObservation(store => store.value?.tags.notes);
-  const {updateObservationNotes} = useDraftObservation();
+  const {updateTags} = useDraftObservation();
 
   return (
     <TextInput
       style={styles.textInput}
       value={!notes || typeof notes !== 'string' ? '' : notes}
       onChangeText={newVal => {
-        updateObservationNotes(newVal);
+        updateTags('notes', newVal);
       }}
       placeholder={t(m.descriptionPlaceholder)}
       placeholderTextColor="silver"


### PR DESCRIPTION
For saving notes to an observation, updated the function `updateObservationNotes` to `updateTags`.

Closes #207 