### PR TITLE
feat: add GPS pill and screen with GPS-related info

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -229,6 +229,42 @@
   "screens.FatalError.somethingWrong": {
     "message": "Something Went Wrong"
   },
+  "screens.GpsModal.details": {
+    "description": "Section title for details about current position",
+    "message": "Details"
+  },
+  "screens.GpsModal.gpsHeader": {
+    "description": "Header for GPS screen",
+    "message": "Current GPS Location"
+  },
+  "screens.GpsModal.lastUpdate": {
+    "description": "Section title for time of last GPS update",
+    "message": "Last update"
+  },
+  "screens.GpsModal.locationDD": {
+    "description": "Section title for DD coordinates",
+    "message": "Coordinates Decimal Degrees"
+  },
+  "screens.GpsModal.locationDMS": {
+    "description": "Section title for DMS coordinates",
+    "message": "Coordinates DMS"
+  },
+  "screens.GpsModal.locationSensors": {
+    "description": "Heading for section about location sensor status",
+    "message": "Sensor Status"
+  },
+  "screens.GpsModal.locationUTM": {
+    "description": "Section title for UTM coordinates",
+    "message": "Coordinates UTM"
+  },
+  "screens.GpsModal.no": {
+    "description": "if a location sensor is active yes/no",
+    "message": "No"
+  },
+  "screens.GpsModal.yes": {
+    "description": "if a location sensor is active yes/no",
+    "message": "Yes"
+  },
   "screens.IntroToCoMapeo.collaborate": {
     "message": "Collaborate on mapping and monitoring projects"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -569,6 +569,12 @@
   "sharedComponents.ErrorModal.tryAgain": {
     "message": "Please go back and try again"
   },
+  "sharedComponents.GpsPill.noGps": {
+    "message": "No GPS"
+  },
+  "sharedComponents.GpsPill.searching": {
+    "message": "Searching…"
+  },
   "sharedComponents.RoleWithIcon.coordinator": {
     "message": "Coordinator"
   },

--- a/src/frontend/Navigation/ScreenGroups/AppScreens.tsx
+++ b/src/frontend/Navigation/ScreenGroups/AppScreens.tsx
@@ -45,6 +45,10 @@ import {
   EditScreen as DeviceNameEditScreen,
   createNavigationOptions as createDeviceNameEditNavOptions,
 } from '../../screens/Settings/ProjectSettings/DeviceName/EditScreen';
+import {
+  GpsModal,
+  createNavigationOptions as createGpsModalNavigationOptions,
+} from '../../screens/GpsModal';
 
 export type HomeTabsList = {
   Map: undefined;
@@ -299,6 +303,11 @@ export const createDefaultScreenGroup = (
       name="DeviceNameEdit"
       component={DeviceNameEditScreen}
       options={createDeviceNameEditNavOptions({intl})}
+    />
+    <RootStack.Screen
+      name="GpsModal"
+      component={GpsModal}
+      options={createGpsModalNavigationOptions({intl})}
     />
   </RootStack.Group>
 );

--- a/src/frontend/Navigation/ScreenGroups/AppScreens.tsx
+++ b/src/frontend/Navigation/ScreenGroups/AppScreens.tsx
@@ -2,6 +2,7 @@ import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {NavigatorScreenParams} from '@react-navigation/native';
 import * as React from 'react';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import {useForegroundPermissions} from 'expo-location';
 
 import {HomeHeader} from '../../sharedComponents/HomeHeader';
 import {RootStack} from '../AppStack';
@@ -49,6 +50,9 @@ import {
   GpsModal,
   createNavigationOptions as createGpsModalNavigationOptions,
 } from '../../screens/GpsModal';
+import {useLocation} from '../../hooks/useLocation';
+import {useLocationProviderStatus} from '../../hooks/useLocationProviderStatus';
+import {getLocationStatus} from '../../lib/utils';
 
 export type HomeTabsList = {
   Map: undefined;
@@ -130,23 +134,46 @@ export type AppList = {
 
 const Tab = createBottomTabNavigator<HomeTabsList>();
 
-const HomeTabs = () => (
-  <Tab.Navigator
-    screenOptions={({route}) => ({
-      tabBarIcon: ({color}) => {
-        const iconName = route.name === 'Map' ? 'map' : 'photo-camera';
-        return <MaterialIcons name={iconName} size={30} color={color} />;
-      },
-      header: () => <HomeHeader />,
-      headerTransparent: true,
-      tabBarTestID: 'tabBarButton' + route.name,
-    })}
-    initialRouteName="Map"
-    backBehavior="initialRoute">
-    <Tab.Screen name="Map" component={MapScreen} />
-    <Tab.Screen name="Camera" component={CameraScreen} />
-  </Tab.Navigator>
-);
+const HomeTabs = () => {
+  const locationState = useLocation({maxDistanceInterval: 0});
+  const [permissions] = useForegroundPermissions();
+  const locationProviderStatus = useLocationProviderStatus();
+
+  const precision = locationState.location?.coords.accuracy;
+
+  const locationStatus =
+    !!locationState.error || !permissions?.granted
+      ? 'error'
+      : getLocationStatus({
+          location: locationState.location,
+          providerStatus: locationProviderStatus,
+        });
+
+  return (
+    <Tab.Navigator
+      screenOptions={({route}) => ({
+        tabBarIcon: ({color}) => {
+          const iconName = route.name === 'Map' ? 'map' : 'photo-camera';
+          return <MaterialIcons name={iconName} size={30} color={color} />;
+        },
+        header: () => (
+          <HomeHeader
+            locationStatus={locationStatus}
+            precision={
+              typeof precision === 'number' ? Math.round(precision) : undefined
+            }
+          />
+        ),
+        headerTransparent: true,
+        tabBarTestID: 'tabBarButton' + route.name,
+      })}
+      initialRouteName="Map"
+      backBehavior="initialRoute">
+      <Tab.Screen name="Map" component={MapScreen} />
+      <Tab.Screen name="Camera" component={CameraScreen} />
+    </Tab.Navigator>
+  );
+};
 
 // **NOTE**: No hooks allowed here (this is not a component, it is a function
 // that returns a react element)

--- a/src/frontend/hooks/useLocation.ts
+++ b/src/frontend/hooks/useLocation.ts
@@ -19,7 +19,7 @@ interface LocationOptions {
   maxTimeInterval?: number;
 }
 
-interface LocationState {
+export interface LocationState {
   location: LocationObject | undefined;
   error: Error | undefined;
 }

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -62,10 +62,10 @@ export function getLocationStatus({
   location?: LocationObject;
   providerStatus?: LocationProviderStatus;
 }): LocationStatus {
-  const gpsNotAvailable = !providerStatus?.gpsAvailable;
-  const locationServicesDisabled = !providerStatus?.locationServicesEnabled;
+  const gpsAvailable = !!providerStatus?.gpsAvailable;
+  const locationServicesEnabled = !!providerStatus?.locationServicesEnabled;
 
-  if (gpsNotAvailable || locationServicesDisabled) return 'error';
+  if (!gpsAvailable || !locationServicesEnabled) return 'error';
 
   const positionStale =
     location && Date.now() - location.timestamp > STALE_TIMEOUT;

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -2,6 +2,11 @@
 import {fromLatLon} from 'utm';
 import {SelectOptions, LabeledSelectOption} from '../sharedTypes/PresetTypes';
 import {Preset, Observation} from '@mapeo/schema';
+import {
+  LocationObject,
+  LocationPermissionResponse,
+  LocationProviderStatus,
+} from 'expo-location';
 
 // import type {
 //   ObservationValue,
@@ -19,15 +24,6 @@ import {Preset, Observation} from '@mapeo/schema';
 // export function getDisplayName(WrappedComponent: any) {
 //   return WrappedComponent.displayName || WrappedComponent.name || "Component";
 // }
-
-// // If the current position on the app state is more than 60 seconds old then we
-// // consider it stale and show that the GPS is searching for a new position
-// const STALE_TIMEOUT = 60 * 1000; // 60 seconds
-// // If the precision is less than 10 meters then we consider this to be a "good
-// // position" and we change the UI accordingly
-// const GOOD_PRECISION = 10; // 10 meters
-
-export type LocationStatus = 'searching' | 'improving' | 'good' | 'error';
 
 // Little helper to timeout a promise
 // export function promiseTimeout<T>(
@@ -50,30 +46,40 @@ export type LocationStatus = 'searching' | 'improving' | 'good' | 'error';
 //   return isNaN(major) ? 0 : major;
 // }
 
-// export function getLocationStatus({
-//   position,
-//   provider,
-//   permission,
-//   error,
-// }: Type): LocationStatus {
-//   const precision = position && position.coords.accuracy;
-//   const gpsUnavailable = provider && !provider.gpsAvailable;
-//   const locationServicesDisabled =
-//     provider && !provider.locationServicesEnabled;
-//   const noPermission = permission && permission !== "granted";
-//   const positionStale =
-//     position && Date.now() - position.timestamp > STALE_TIMEOUT;
-//   if (error || gpsUnavailable || locationServicesDisabled || noPermission)
-//     return "error";
-//   else if (positionStale) return "searching";
-//   else if (
-//     typeof precision === "number" &&
-//     Math.round(precision) <= GOOD_PRECISION
-//   )
-//     return "good";
-//   else if (typeof precision === "number") return "improving";
-//   return "searching";
-// }
+// If the current position on the app state is more than 60 seconds old then we
+// consider it stale and show that the GPS is searching for a new position
+const STALE_TIMEOUT = 60 * 1000; // 60 seconds
+// // If the precision is less than 10 meters then we consider this to be a "good
+// // position" and we change the UI accordingly
+const GOOD_PRECISION = 10; // 10 meters
+
+export type LocationStatus = 'searching' | 'improving' | 'good' | 'error';
+
+export function getLocationStatus({
+  location,
+  providerStatus,
+}: {
+  location?: LocationObject;
+  providerStatus?: LocationProviderStatus;
+}): LocationStatus {
+  const gpsNotAvailable = !providerStatus?.gpsAvailable;
+  const locationServicesDisabled = !providerStatus?.locationServicesEnabled;
+
+  if (gpsNotAvailable || locationServicesDisabled) return 'error';
+
+  const positionStale =
+    location && Date.now() - location.timestamp > STALE_TIMEOUT;
+
+  if (positionStale) return 'searching';
+
+  const precision = location?.coords.accuracy;
+
+  if (typeof precision === 'number') {
+    return Math.round(precision) <= GOOD_PRECISION ? 'good' : 'improving';
+  }
+
+  return 'searching';
+}
 
 // export function addFieldDefinitions(
 //   preset: Preset,

--- a/src/frontend/screens/GpsModal.tsx
+++ b/src/frontend/screens/GpsModal.tsx
@@ -74,7 +74,7 @@ const GpsModalRow = ({label, value}: {label: string; value: string}) => (
 );
 
 export const GpsModal = () => {
-  const {location} = useLocation({maxDistanceInterval: 15});
+  const {location} = useLocation({maxDistanceInterval: 0});
   const lastKnownLocationQuery = useLastKnownLocation();
   const provider = useLocationProviderStatus();
   const {coordinateFormat} = usePersistedSettings();

--- a/src/frontend/screens/GpsModal.tsx
+++ b/src/frontend/screens/GpsModal.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import {View, ScrollView, StyleSheet} from 'react-native';
+import {
+  defineMessages,
+  FormattedMessage,
+  MessageDescriptor,
+  useIntl,
+} from 'react-intl';
+import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
+
+import {useLocation} from '../hooks/useLocation';
+import {useLastKnownLocation} from '../hooks/useLastSavedLocation';
+import {useLocationProviderStatus} from '../hooks/useLocationProviderStatus';
+import {usePersistedSettings} from '../hooks/persistedState/usePersistedSettings';
+import {GPS_MODAL_TEXT, WHITE} from '../lib/styles';
+import {CustomHeaderLeft} from '../sharedComponents/CustomHeaderLeft';
+import {DateDistance} from '../sharedComponents/DateDistance';
+import {FormattedCoords} from '../sharedComponents/FormattedData';
+import {Text} from '../sharedComponents/Text';
+
+const m = defineMessages({
+  gpsHeader: {
+    id: 'screens.GpsModal.gpsHeader',
+    defaultMessage: 'Current GPS Location',
+    description: 'Header for GPS screen',
+  },
+  lastUpdate: {
+    id: 'screens.GpsModal.lastUpdate',
+    defaultMessage: 'Last update',
+    description: 'Section title for time of last GPS update',
+  },
+  utm: {
+    id: 'screens.GpsModal.locationUTM',
+    defaultMessage: 'Coordinates UTM',
+    description: 'Section title for UTM coordinates',
+  },
+  dms: {
+    id: 'screens.GpsModal.locationDMS',
+    defaultMessage: 'Coordinates DMS',
+    description: 'Section title for DMS coordinates',
+  },
+  dd: {
+    id: 'screens.GpsModal.locationDD',
+    defaultMessage: 'Coordinates Decimal Degrees',
+    description: 'Section title for DD coordinates',
+  },
+  details: {
+    id: 'screens.GpsModal.details',
+    defaultMessage: 'Details',
+    description: 'Section title for details about current position',
+  },
+  yes: {
+    id: 'screens.GpsModal.yes',
+    defaultMessage: 'Yes',
+    description: 'if a location sensor is active yes/no',
+  },
+  no: {
+    id: 'screens.GpsModal.no',
+    defaultMessage: 'No',
+    description: 'if a location sensor is active yes/no',
+  },
+  locationSensors: {
+    id: 'screens.GpsModal.locationSensors',
+    defaultMessage: 'Sensor Status',
+    description: 'Heading for section about location sensor status',
+  },
+});
+
+const GpsModalRow = ({label, value}: {label: string; value: string}) => (
+  <View style={styles.row}>
+    <Text style={styles.rowLabel}>{label}</Text>
+    <Text style={styles.rowValue}>{value}</Text>
+  </View>
+);
+
+export const GpsModal = () => {
+  const {location} = useLocation({maxDistanceInterval: 15});
+  const lastKnownLocationQuery = useLastKnownLocation();
+  const provider = useLocationProviderStatus();
+  const {coordinateFormat} = usePersistedSettings();
+  const {formatMessage: t} = useIntl();
+
+  const locationTimestamp =
+    location?.timestamp || lastKnownLocationQuery.data?.timestamp;
+
+  return (
+    <ScrollView style={styles.container} testID="gpsScreenScrollView">
+      <View style={styles.infoArea}>
+        <Text style={styles.sectionTitle}>
+          <FormattedMessage {...m.lastUpdate} />
+        </Text>
+        <DateDistance
+          style={styles.rowValue}
+          date={locationTimestamp ? new Date(locationTimestamp) : new Date()}
+        />
+        {location && (
+          <>
+            <Text style={styles.sectionTitle}>
+              <FormattedMessage {...m[coordinateFormat]} />
+            </Text>
+            <Text style={styles.rowValue}>
+              <FormattedCoords
+                lon={location.coords.longitude}
+                lat={location.coords.latitude}
+                format={coordinateFormat}
+              />
+            </Text>
+            <Text style={styles.sectionTitle}>
+              <FormattedMessage {...m.details} />
+            </Text>
+            {Object.entries(location.coords).map(([key, value]) => (
+              <GpsModalRow
+                key={key}
+                label={key}
+                value={typeof value === 'number' ? value.toFixed(5) : ''}
+              />
+            ))}
+          </>
+        )}
+        {provider && (
+          <>
+            <Text style={styles.sectionTitle}>
+              <FormattedMessage {...m.locationSensors} />
+            </Text>
+            {Object.entries(provider).map(([key, value]) => (
+              <GpsModalRow
+                key={key}
+                label={key}
+                value={value != null ? t(m.yes) : t(m.no)}
+              />
+            ))}
+          </>
+        )}
+      </View>
+    </ScrollView>
+  );
+};
+
+export function createNavigationOptions({
+  intl,
+}: {
+  intl: (title: MessageDescriptor) => string;
+}) {
+  return (): NativeStackNavigationOptions => {
+    return {
+      headerTitle: intl(m.gpsHeader),
+      headerStyle: {backgroundColor: GPS_MODAL_TEXT},
+      headerTintColor: WHITE,
+      headerLeft: props => (
+        <CustomHeaderLeft headerBackButtonProps={props} tintColor={WHITE} />
+      ),
+    };
+  };
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: GPS_MODAL_TEXT,
+    flexDirection: 'column',
+  },
+  row: {flexDirection: 'row'},
+  sectionTitle: {
+    color: 'white',
+    fontWeight: '700',
+    marginTop: 10,
+    marginBottom: 5,
+    fontSize: 16,
+  },
+  rowLabel: {
+    color: 'white',
+    fontWeight: '700',
+    minWidth: '50%',
+  },
+  rowValue: {
+    color: 'white',
+    fontWeight: '400',
+  },
+  infoArea: {
+    paddingLeft: 15,
+    paddingRight: 15,
+  },
+});

--- a/src/frontend/screens/GpsModal.tsx
+++ b/src/frontend/screens/GpsModal.tsx
@@ -126,7 +126,7 @@ export const GpsModal = () => {
               <GpsModalRow
                 key={key}
                 label={key}
-                value={value != null ? t(m.yes) : t(m.no)}
+                value={t(value ? m.yes : m.no)}
               />
             ))}
           </>

--- a/src/frontend/sharedComponents/DateDistance.tsx
+++ b/src/frontend/sharedComponents/DateDistance.tsx
@@ -17,7 +17,7 @@ const MINUTE = 60;
 const HOUR = 60 * 60;
 const DAY = 60 * 60 * 24;
 
-export const DateDistance = ({date = new Date(), style}: Props) => {
+export const DateDistance = ({date, style}: Props) => {
   // Round distance to nearest 10 seconds
   const distanceInSeconds =
     Math.floor((Date.now() - date.getTime()) / 10000) * 10;

--- a/src/frontend/sharedComponents/GpsPill.tsx
+++ b/src/frontend/sharedComponents/GpsPill.tsx
@@ -3,12 +3,8 @@ import {View, StyleSheet} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import {useIsFocused} from '@react-navigation/native';
 import {TouchableOpacity} from 'react-native-gesture-handler';
-import {useForegroundPermissions} from 'expo-location';
 
 import {BLACK, WHITE} from '../lib/styles';
-import {useLocationProviderStatus} from '../hooks/useLocationProviderStatus';
-import {useLocation} from '../hooks/useLocation';
-import {getLocationStatus} from '../lib/utils';
 import type {LocationStatus} from '../lib/utils';
 import {Text} from './Text';
 import {GpsIcon} from './icons';
@@ -24,13 +20,13 @@ const m = defineMessages({
   },
 });
 
-type Props = {
+interface Props {
   onPress?: () => void;
   precision?: number;
   variant: LocationStatus;
-};
+}
 
-const MemoizedGpsPill = React.memo<Props>(
+export const GpsPill = React.memo<Props>(
   ({onPress, variant, precision}: Props) => {
     const isFocused = useIsFocused();
     const {formatMessage: t} = useIntl();
@@ -57,32 +53,6 @@ const MemoizedGpsPill = React.memo<Props>(
     );
   },
 );
-
-export const GpsPill = ({onPress}: Pick<Props, 'onPress'>) => {
-  const locationState = useLocation({maxDistanceInterval: 0});
-  const [permissions] = useForegroundPermissions();
-  const locationProviderStatus = useLocationProviderStatus();
-
-  const precision = locationState?.location?.coords.accuracy;
-
-  const locationStatus =
-    !!locationState.error || !permissions?.granted
-      ? 'error'
-      : getLocationStatus({
-          location: locationState.location,
-          providerStatus: locationProviderStatus,
-        });
-
-  return (
-    <MemoizedGpsPill
-      onPress={onPress}
-      precision={
-        typeof precision === 'number' ? Math.round(precision) : undefined
-      }
-      variant={locationStatus}
-    />
-  );
-};
 
 const styles = StyleSheet.create({
   container: {

--- a/src/frontend/sharedComponents/GpsPill.tsx
+++ b/src/frontend/sharedComponents/GpsPill.tsx
@@ -59,7 +59,7 @@ const MemoizedGpsPill = React.memo<Props>(
 );
 
 export const GpsPill = ({onPress}: Pick<Props, 'onPress'>) => {
-  const locationState = useLocation({maxDistanceInterval: 15});
+  const locationState = useLocation({maxDistanceInterval: 0});
   const [permissions] = useForegroundPermissions();
   const locationProviderStatus = useLocationProviderStatus();
 

--- a/src/frontend/sharedComponents/GpsPill.tsx
+++ b/src/frontend/sharedComponents/GpsPill.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import {View, StyleSheet} from 'react-native';
+import {defineMessages, useIntl} from 'react-intl';
+import {useIsFocused} from '@react-navigation/native';
+import {TouchableOpacity} from 'react-native-gesture-handler';
+import {useForegroundPermissions} from 'expo-location';
+
+import {BLACK, WHITE} from '../lib/styles';
+import {useLocationProviderStatus} from '../hooks/useLocationProviderStatus';
+import {useLocation} from '../hooks/useLocation';
+import {getLocationStatus} from '../lib/utils';
+import type {LocationStatus} from '../lib/utils';
+import {Text} from './Text';
+import {GpsIcon} from './icons';
+
+const m = defineMessages({
+  noGps: {
+    id: 'sharedComponents.GpsPill.noGps',
+    defaultMessage: 'No GPS',
+  },
+  searching: {
+    id: 'sharedComponents.GpsPill.searching',
+    defaultMessage: 'Searching…',
+  },
+});
+
+type Props = {
+  onPress?: () => void;
+  precision?: number;
+  variant: LocationStatus;
+};
+
+const MemoizedGpsPill = React.memo<Props>(
+  ({onPress, variant, precision}: Props) => {
+    const isFocused = useIsFocused();
+    const {formatMessage: t} = useIntl();
+    let text: string;
+    if (variant === 'error') text = t(m.noGps);
+    else if (variant === 'searching' || typeof precision === 'undefined')
+      text = t(m.searching);
+    else text = `± ${precision} m`;
+    return (
+      <TouchableOpacity onPress={onPress || undefined} testID="gpsPillButton">
+        <View
+          style={[
+            styles.container,
+            variant === 'error' ? styles.error : undefined,
+          ]}>
+          <View style={styles.icon}>
+            {isFocused && <GpsIcon variant={variant} />}
+          </View>
+          <Text style={styles.text} numberOfLines={1}>
+            {text}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  },
+);
+
+export const GpsPill = ({onPress}: Pick<Props, 'onPress'>) => {
+  const locationState = useLocation({maxDistanceInterval: 15});
+  const [permissions] = useForegroundPermissions();
+  const locationProviderStatus = useLocationProviderStatus();
+
+  const precision = locationState?.location?.coords.accuracy;
+
+  const locationStatus =
+    !!locationState.error || !permissions?.granted
+      ? 'error'
+      : getLocationStatus({
+          location: locationState.location,
+          providerStatus: locationProviderStatus,
+        });
+
+  return (
+    <MemoizedGpsPill
+      onPress={onPress}
+      precision={
+        typeof precision === 'number' ? Math.round(precision) : undefined
+      }
+      variant={locationStatus}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 0,
+    minWidth: 100,
+    maxWidth: 200,
+    borderRadius: 18,
+    height: 36,
+    paddingLeft: 32,
+    paddingRight: 20,
+    borderWidth: 3,
+    borderColor: '#33333366',
+    backgroundColor: BLACK,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  error: {backgroundColor: '#FF0000'},
+  text: {color: WHITE},
+  icon: {position: 'absolute', left: 6},
+});

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -16,7 +16,11 @@ export const HomeHeader = () => {
         colors={['#0006', '#0000']}
       />
       <View style={styles.leftButton}>{/* Placeholder for left button */}</View>
-      <GpsPill onPress={() => {}} />
+      <GpsPill
+        onPress={() => {
+          navigation.navigate('GpsModal');
+        }}
+      />
       <IconButton
         style={styles.rightButton}
         onPress={() => {

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -4,7 +4,7 @@ import LinearGradient from 'react-native-linear-gradient';
 import {IconButton} from './IconButton';
 import {ObservationListIcon} from './icons';
 import {useNavigationFromHomeTabs} from '../hooks/useNavigationWithTypes';
-import {Text} from './Text';
+import {GpsPill} from './GpsPill';
 
 export const HomeHeader = () => {
   const navigation = useNavigationFromHomeTabs();
@@ -15,8 +15,8 @@ export const HomeHeader = () => {
         style={styles.linearGradient}
         colors={['#0006', '#0000']}
       />
-      {/* Stand in for styling,  */}
-      <Text>""</Text>
+      <View style={styles.leftButton}>{/* Placeholder for left button */}</View>
+      <GpsPill onPress={() => {}} />
       <IconButton
         style={styles.rightButton}
         onPress={() => {

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -5,8 +5,14 @@ import {IconButton} from './IconButton';
 import {ObservationListIcon} from './icons';
 import {useNavigationFromHomeTabs} from '../hooks/useNavigationWithTypes';
 import {GpsPill} from './GpsPill';
+import {LocationStatus} from '../lib/utils';
 
-export const HomeHeader = () => {
+interface Props {
+  locationStatus: LocationStatus;
+  precision?: number;
+}
+
+export const HomeHeader = ({locationStatus, precision}: Props) => {
   const navigation = useNavigationFromHomeTabs();
 
   return (
@@ -17,6 +23,8 @@ export const HomeHeader = () => {
       />
       <View style={styles.leftButton}>{/* Placeholder for left button */}</View>
       <GpsPill
+        variant={locationStatus}
+        precision={precision}
         onPress={() => {
           navigation.navigate('GpsModal');
         }}


### PR DESCRIPTION
Closes #199

Mostly a direct port of the implementation from Mapeo Mobile, although a few adjustments are made to account for the differences in hooks.

---

Preview:

- Map screen (location services enabled):

  <img width="300" alt="image" src="https://github.com/digidem/CoMapeo-mobile/assets/18542095/cf3ba4f7-16f3-4292-8dfd-68282be1fe43">

- Map screen (location services disabled):
  
  <img width="300" alt="image" src="https://github.com/digidem/CoMapeo-mobile/assets/18542095/77dff1da-cd6f-471d-9bbc-83a9fc165762">

- GPS modal (location services enabled):

  <img width="300" alt="image" src="https://github.com/digidem/CoMapeo-mobile/assets/18542095/00eec46c-ea6b-4db7-9275-362cdba375d9">

- GPS modal (location services disabled):

  <img width="300" alt="image" src="https://github.com/digidem/comapeo-mobile/assets/18542095/cc7e04dd-8310-45cb-acab-bdf7687ad657">

