### PR TITLE
chore: patch @electron/asar to avoid issue with non-existent dependency

### DIFF
--- a/src/backend/patches/@electron+asar+3.2.9+001+remove-original-fs-require.patch
+++ b/src/backend/patches/@electron+asar+3.2.9+001+remove-original-fs-require.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@electron/asar/lib/wrapped-fs.js b/node_modules/@electron/asar/lib/wrapped-fs.js
+index 24f59d0..dfb3fc6 100644
+--- a/node_modules/@electron/asar/lib/wrapped-fs.js
++++ b/node_modules/@electron/asar/lib/wrapped-fs.js
+@@ -1,6 +1,6 @@
+ 'use strict'
+ 
+-const fs = process.versions.electron ? require('original-fs') : require('fs')
++const fs = require('fs')
+ 
+ const promisifiedMethods = [
+   'lstat',

--- a/src/backend/patches/README.md
+++ b/src/backend/patches/README.md
@@ -8,3 +8,9 @@ These patches use [patch-package](https://github.com/ds300/patch-package) to upd
 
 - Rollup complains about the dynamic require of `quickbit-universal` in this file. Easier to just simplify the import
 - Temporary workaround for peer discovery issues. To be "properly" solved by @mapeo/core soon.
+
+## `@electron/asar`
+
+### [Remove conditional `original-fs` import](./@electron+asar+3.2.9+001+remove-original-fs-require.patch)
+
+`original-fs` is conditionally imported (based on Electron-specific checks) but Rollup is not smart enough to lazily require the module in the bundled output. This causes errors at runtime because an import of a non-existent module occurs.

--- a/src/backend/scripts/bundle-backend.mjs
+++ b/src/backend/scripts/bundle-backend.mjs
@@ -34,14 +34,6 @@ const plugins = [
         find: '@node-rs/crc32',
         replacement: path.join(__dirname, '..', 'src', 'node-rs-crc32-shim.js'),
       },
-      // @electron/asar is using 'original-fs' which is breaking mapeo-mobile. @electron/asar 
-      // is being used for map-server which is not currently being used. Merging this in and 
-      // creating an issue to unblock other developers waiting for the @mapeo/core update 
-      // issue: https://github.com/digidem/CoMapeo-mobile/issues/204
-      {
-        find:"@electron/asar",
-        replacement:path.join(__dirname, '..', 'src', 'node-rs-crc32-shim.js')
-      }
     ],
   }),
   nativePaths(),


### PR DESCRIPTION
Closes #204 

Was able to verify that the backend runs as expected after this change. Can also confirm that the bundled output now makes sure that patched code of interest solely relies on `fs` (see `nodejs-assets/index.js` after running `npm run build:backend`)

- line 5:

  ```js
  import require$$0$3, { mkdirSync } from 'fs';
  ```

- lines 11440-11463 (module code from `@electron/asar`):

  ```js
  const fs$9 = require$$0$3;
  
  const promisifiedMethods = [
    'lstat',
    'mkdtemp',
    'readFile',
    'stat',
    'writeFile'
  ];

  const promisified = {};

  for (const method of Object.keys(fs$9)) {
    if (promisifiedMethods.includes(method)) {
      promisified[method] = fs$9.promises[method];
    } else {
      promisified[method] = fs$9[method];
    }
  }
  // To make it more like fs-extra
  promisified.mkdirp = (dir) => fs$9.promises.mkdir(dir, { recursive: true });
  promisified.mkdirpSync = (dir) => fs$9.mkdirSync(dir, { recursive: true });
  
  var wrappedFs = promisified;
  ```