### PR TITLE
chore: update Prettier to v3.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "jest": "^29.6.3",
         "lint-staged": "^14.0.1",
         "patch-package": "^8.0.0",
-        "prettier": "^3.0.2",
+        "prettier": "^3.2.5",
         "react-native-svg-transformer": "^1.3.0",
         "react-test-renderer": "18.2.0",
         "rollup-plugin-node-polyfills": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "jest": "^29.6.3",
     "lint-staged": "^14.0.1",
     "patch-package": "^8.0.0",
-    "prettier": "^3.0.2",
+    "prettier": "^3.2.5",
     "react-native-svg-transformer": "^1.3.0",
     "react-test-renderer": "18.2.0",
     "rollup-plugin-node-polyfills": "^0.2.1",

--- a/src/frontend/sharedComponents/BottomSheet/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheet/Content.tsx
@@ -70,8 +70,8 @@ export const Content = ({
                   config.variation === 'outlined'
                     ? WHITE
                     : config.dangerous
-                    ? RED
-                    : LIGHT_BLUE
+                      ? RED
+                      : LIGHT_BLUE
                 }
               />
             )}
@@ -81,8 +81,8 @@ export const Content = ({
                 config.variation === 'outlined'
                   ? WHITE
                   : config.dangerous
-                  ? MAGENTA
-                  : COMAPEO_BLUE,
+                    ? MAGENTA
+                    : COMAPEO_BLUE,
               marginTop: index > 0 ? 20 : undefined,
             }}
             variant={config.variation === 'outlined' ? 'outlined' : undefined}>

--- a/src/frontend/sharedComponents/Button.tsx
+++ b/src/frontend/sharedComponents/Button.tsx
@@ -94,8 +94,8 @@ function getButtonStyle(variant?: Variant) {
     return variant === 'contained'
       ? styles.buttonContained
       : variant === 'outlined'
-      ? styles.buttonOutlined
-      : undefined;
+        ? styles.buttonOutlined
+        : undefined;
   }
 }
 


### PR DESCRIPTION
This change should have no user impact.

Notably, this new version changes how nested ternaries are indented. Other than the Prettier version bump, this is just a whitespace change.