### PR TITLE
chore: use noUncheckedIndexedAccess option in TSConfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@react-native/typescript-config/tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/frontend/**/*"],
   "exclude": [


### PR DESCRIPTION
Adding this because it's not included when defining `strict: true`, but it's easily one of the more helpful options when it comes to avoiding runtime errors

https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess