### PR TITLE
chore: disable "no-bitwise" ESLint rule for CRC32 shim

### DIFF
--- a/src/backend/src/node-rs-crc32-shim.js
+++ b/src/backend/src/node-rs-crc32-shim.js
@@ -6,6 +6,8 @@
  * @module
  */
 
+/* eslint-disable no-bitwise */
+
 /** @type {undefined | Uint32Array} */
 let crcTable
 


### PR DESCRIPTION
We have a shim for `@node-rs/crc32`. It makes heavy use of bitwise operators, such as `>>>`.

This disables the `no-bitwise` ESLint rule for this file because we still want to use bitwise operators here.