### PR TITLE
chore: fix 40 trivial "unused variables" lint violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,12 @@ module.exports = {
       files: ['*.ts', '*.tsx'],
       rules: {
         '@typescript-eslint/no-shadow': ['error'],
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            ignoreRestSiblings: true,
+          },
+        ],
         'no-shadow': 'off',
         'no-undef': 'off',
       },

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -45,7 +45,7 @@ const App = () => {
       'android.permission.CAMERA',
       'android.permission.ACCESS_FINE_LOCATION',
       'android.permission.ACCESS_COARSE_LOCATION',
-    ]).then(val => setPermissionsAsked(true));
+    ]).then(() => setPermissionsAsked(true));
   }, []);
 
   return (

--- a/src/frontend/Navigation/AppNavigator.tsx
+++ b/src/frontend/Navigation/AppNavigator.tsx
@@ -69,7 +69,7 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
       screenOptions={NavigatorScreenOptions}>
       {deviceInfo.data?.name
         ? createDefaultScreenGroup(formatMessage)
-        : createDeviceNamingScreens(formatMessage)}
+        : createDeviceNamingScreens()}
     </RootStack.Navigator>
   );
 };

--- a/src/frontend/Navigation/ScreenGroups/DeviceNamingScreens.tsx
+++ b/src/frontend/Navigation/ScreenGroups/DeviceNamingScreens.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {MessageDescriptor} from 'react-intl';
 import {RootStack} from '../AppStack';
 import {IntroToCoMapeo} from '../../screens/IntroToCoMapeo';
 import {DeviceNaming} from '../../screens/DeviceNaming';
@@ -11,9 +10,7 @@ export type DeviceNamingSceens = {
   Success: {deviceName: string};
 };
 
-export const createDeviceNamingScreens = (
-  intl: (title: MessageDescriptor) => string,
-) => (
+export const createDeviceNamingScreens = () => (
   <RootStack.Group key="deviceNaming">
     <RootStack.Screen
       name="IntroToCoMapeo"

--- a/src/frontend/contexts/PhotoPromiseContext/index.tsx
+++ b/src/frontend/contexts/PhotoPromiseContext/index.tsx
@@ -70,7 +70,7 @@ export const PhotoPromiseProvider = ({
     const newPhotoPromiseArray = photoPromises.map(async photo => {
       const resolvedPhoto = await photo;
       if (resolvedPhoto.originalUri === uri) {
-        const deletedPhoto: Promise<DraftPhoto> = new Promise((res, rej) => {
+        const deletedPhoto: Promise<DraftPhoto> = new Promise(res => {
           resolvedPhoto.deleted = true;
           res(resolvedPhoto);
         });

--- a/src/frontend/contexts/ProjectContext.tsx
+++ b/src/frontend/contexts/ProjectContext.tsx
@@ -40,7 +40,7 @@ export const ActiveProjectProvider = ({
         if (cancelled) return;
         setActiveProject(project);
       })
-      .catch(error => {
+      .catch(() => {
         if (cancelled) return;
 
         setActiveProjectId(undefined);

--- a/src/frontend/contexts/SecurityContext.tsx
+++ b/src/frontend/contexts/SecurityContext.tsx
@@ -94,8 +94,3 @@ export const SecurityProvider = ({children}: {children: React.ReactNode}) => {
     </SecurityContext.Provider>
   );
 };
-
-function validPasscode(passcode: string | null): boolean {
-  if (passcode === null) return true;
-  return passcode.length === 5 && !isNaN(parseInt(passcode, 10));
-}

--- a/src/frontend/hooks/useSyncState.ts
+++ b/src/frontend/hooks/useSyncState.ts
@@ -56,8 +56,8 @@ function createSyncState(project: MapeoProjectApi) {
   const listeners = new Set<() => void>();
   let error: Error | undefined;
 
-  function onSyncState(state: SyncState) {
-    state = state;
+  function onSyncState(newState: SyncState) {
+    state = newState;
     error = undefined;
     listeners.forEach(listener => listener());
   }

--- a/src/frontend/mockdata.ts
+++ b/src/frontend/mockdata.ts
@@ -1,6 +1,6 @@
 // @ts-check
 
-import {FieldValue, Observation, Preset, PresetValue} from '@mapeo/schema';
+import {FieldValue, Observation, PresetValue} from '@mapeo/schema';
 
 export const mockObservations: Observation[] = [
   {

--- a/src/frontend/screens/AddPhoto.tsx
+++ b/src/frontend/screens/AddPhoto.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  View,
-  StyleSheet,
-  GestureResponderEvent,
-  TouchableNativeFeedback,
-} from 'react-native';
+import {View, StyleSheet, TouchableNativeFeedback} from 'react-native';
 import {Text} from '../sharedComponents/Text';
 import debug from 'debug';
 import {defineMessages, FormattedMessage} from 'react-intl';
@@ -34,7 +29,7 @@ export const AddPhotoScreen = ({
     navigation.pop();
   };
 
-  const handleCancelPress = (e: GestureResponderEvent) => {
+  const handleCancelPress = () => {
     log('cancelled');
     navigation.pop();
   };

--- a/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
+++ b/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
@@ -7,7 +7,6 @@ import {
   BottomSheetModal,
 } from '../../sharedComponents/BottomSheetModal';
 import {ErrorIcon} from '../../sharedComponents/icons';
-import {NativeRootNavigationProps} from '../../sharedTypes';
 import {usePersistedPasscode} from '../../hooks/persistedState/usePersistedPasscode';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';

--- a/src/frontend/screens/AppPasscode/SetPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/SetPasscode.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import {InputPasscode} from './InputPasscode';
 import {defineMessages} from 'react-intl';
 import {OBSCURE_PASSCODE} from '../../constants';
-import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {NativeNavigationComponent} from '../../sharedTypes';
-import {ConfirmPasscodeSheet} from './ConfirmPasscodeSheet';
-import {useBottomSheetModal} from '../../sharedComponents/BottomSheetModal';
 
 const m = defineMessages({
   titleSet: {

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -58,7 +58,7 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
       }, defaultAcc);
 
   const deviceId = '';
-  const {lat, lon, createdBy, attachments} = observation;
+  const {lat, lon, createdBy} = observation;
   const isMine = deviceId === createdBy;
   // Currently only show photo attachments
   const photos = [];

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -9,13 +9,7 @@ import {
   TouchableOpacity,
 } from 'react-native-gesture-handler';
 import {Button} from '../../../../sharedComponents/Button';
-import {
-  BLACK,
-  LIGHT_GREY,
-  MEDIUM_GREY,
-  RED,
-  WHITE,
-} from '../../../../lib/styles';
+import {BLACK, LIGHT_GREY} from '../../../../lib/styles';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import {HookFormTextInput} from '../../../../sharedComponents/HookFormTextInput';
 import {useCreateProject} from '../../../../hooks/server/projects';
@@ -70,7 +64,7 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
     mutate(val.projectName, {
       onSuccess: () =>
         navigation.navigate('ProjectCreated', {name: val.projectName}),
-      onError: err => {
+      onError: () => {
         openSheet();
       },
     });

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
@@ -41,7 +41,7 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
           return;
         }
       })
-      .catch(err => {
+      .catch(() => {
         openSheet();
       });
   }

--- a/src/frontend/sharedComponents/AddButton.tsx
+++ b/src/frontend/sharedComponents/AddButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  ActivityIndicator,
   GestureResponderEvent,
   Image,
   StyleProp,
@@ -10,7 +9,6 @@ import {
   ViewStyle,
 } from 'react-native';
 import {Loading} from './Loading';
-import {BLACK, DARK_MANGO, DARK_ORANGE, COMAPEO_BLUE} from '../lib/styles';
 
 interface AddButtonProps {
   style?: StyleProp<ViewStyle>;

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 
-import {DARK_GREY, LIGHT_GREY} from '../../lib/styles';
+import {DARK_GREY} from '../../lib/styles';
 
 export const MODAL_NAVIGATION_OPTIONS: NativeStackNavigationOptions = {
   presentation: 'transparentModal',

--- a/src/frontend/sharedComponents/DeviceCard.tsx
+++ b/src/frontend/sharedComponents/DeviceCard.tsx
@@ -1,8 +1,5 @@
-import {StyleSheet, View} from 'react-native';
-import DeviceMobile from '../images/DeviceMobile.svg';
-import DeviceDesktop from '../images/DeviceDesktop.svg';
-import {Text} from './Text';
-import {LIGHT_GREY, MEDIUM_GREY} from '../lib/styles';
+import {StyleSheet} from 'react-native';
+import {LIGHT_GREY} from '../lib/styles';
 import {DeviceType, ViewStyleProp} from '../sharedTypes';
 import {defineMessages, useIntl} from 'react-intl';
 import {TouchableOpacity} from 'react-native-gesture-handler';

--- a/src/frontend/sharedComponents/FormattedData.tsx
+++ b/src/frontend/sharedComponents/FormattedData.tsx
@@ -5,11 +5,10 @@ import {
   defineMessages,
   useIntl,
 } from 'react-intl';
-import {Field, Observation, Preset} from '@mapeo/schema';
+import {Field, Preset} from '@mapeo/schema';
 
 import {formatCoords, convertSelectOptionsToLabeled} from '../lib/utils';
 import {DateDistance} from './DateDistance';
-import {formats} from '../contexts/IntlContext';
 import {CoordinateFormat} from '../sharedTypes';
 
 const m = defineMessages({

--- a/src/frontend/sharedComponents/List/ListItemIcon.tsx
+++ b/src/frontend/sharedComponents/List/ListItemIcon.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
-import Icon from 'react-native-vector-icons/MaterialIcons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 type ListItemIconProps =

--- a/src/frontend/sharedComponents/Loading.tsx
+++ b/src/frontend/sharedComponents/Loading.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {View, StyleSheet, Easing} from 'react-native';
 import {DotIndicator} from 'react-native-indicators';
-import {WHITE} from '../lib/styles';
 import {ViewStyleProp} from '../sharedTypes';
 
 export const Loading = ({

--- a/src/frontend/sharedComponents/Pill.tsx
+++ b/src/frontend/sharedComponents/Pill.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import {FormattedMessage, MessageDescriptor} from 'react-intl';
 import {View, Text, StyleSheet} from 'react-native';
 
-import {
-  LIGHT_BLUE,
-  LIGHT_GREY,
-  COMAPEO_BLUE,
-  MEDIUM_BLUE,
-  WHITE,
-} from '../lib/styles';
+import {LIGHT_GREY, COMAPEO_BLUE, WHITE} from '../lib/styles';
 import {TextStyleProp, ViewStyleProp} from '../sharedTypes';
 
 interface PillProps {

--- a/src/frontend/sharedComponents/RoleWithIcon.tsx
+++ b/src/frontend/sharedComponents/RoleWithIcon.tsx
@@ -4,7 +4,7 @@ import MaterialCommunity from 'react-native-vector-icons/MaterialCommunityIcons'
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from './Text';
 import {BLACK} from '../lib/styles';
-import {DeviceRole, ViewStyleProp} from '../sharedTypes';
+import {ViewStyleProp} from '../sharedTypes';
 
 const m = defineMessages({
   coordinator: {

--- a/src/frontend/sharedComponents/icons/CategoryIcon.tsx
+++ b/src/frontend/sharedComponents/icons/CategoryIcon.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {Image} from 'react-native';
-import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import {Circle} from './Circle';
 import {IconSize} from '../../sharedTypes';


### PR DESCRIPTION
This fixes several violations of [@typescript-eslint/no-unused-vars][0]. There are still several that I didn't feel comfortable changing, but these ones were easy to fix.

[0]: https://typescript-eslint.io/rules/no-unused-vars/