### PR TITLE
chore: disable "no inline styles" ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
         '@typescript-eslint/no-shadow': ['error'],
         'no-shadow': 'off',
         'no-undef': 'off',
+        'react-native/no-inline-styles': 'off',
       },
     },
   ],


### PR DESCRIPTION
To quote [the rule's docs][0]:

> It's (subjectively) good practice to separate styles from the view layout, when possible

Though we might want to do this someday, now is not the time. Let's disable this rule to avoid hundreds of warnings.

[0]: https://github.com/Intellicode/eslint-plugin-react-native/blob/master/docs/rules/no-inline-styles.md