### PR TITLE
chore: fix type error in `ObservationMapLayer` component

### DIFF
--- a/src/frontend/screens/MapScreen/ObsevationMapLayer.tsx
+++ b/src/frontend/screens/MapScreen/ObsevationMapLayer.tsx
@@ -2,7 +2,6 @@ import {Observation} from '@mapeo/schema';
 import React from 'react';
 import MapboxGL from '@rnmapbox/maps';
 import {useAllObservations} from '../../hooks/useAllObservations';
-import {OnPressEvent} from '@rnmapbox/maps/lib/typescript/types/OnPressEvent';
 import {useNavigationFromHomeTabs} from '../../hooks/useNavigationWithTypes';
 
 const DEFAULT_MARKER_COLOR = '#F29D4B';
@@ -23,17 +22,15 @@ export const ObservationMapLayer = () => {
     features: mapObservationsToFeatures(observations),
   };
 
-  function handlePressEvent(event: OnPressEvent) {
-    const properties = event.features[0].properties;
-    if (!properties) return;
-    if (!('id' in properties)) return;
-
-    navigate('Observation', {observationId: properties.id});
-  }
-
   return (
     <MapboxGL.ShapeSource
-      onPress={handlePressEvent}
+      onPress={event => {
+        const properties = event.features[0]?.properties;
+        if (!properties) return;
+        if (!('id' in properties)) return;
+
+        navigate('Observation', {observationId: properties.id});
+      }}
       id="observations-source"
       shape={featureCollection}>
       <MapboxGL.CircleLayer id="circles" style={layerStyles} />


### PR DESCRIPTION
_I recommend [reviewing this with whitespace changes disabled](https://github.com/digidem/comapeo-mobile/pull/279/files?w=1)._

Our `onPress` handler code was failing to import a type from `@rnmapbox/maps`.

This fixes that by moving the handler into the component directly, avoiding the need to import the type.