### PR TITLE
chore: fix misspelled "border color" prop

### DIFF
--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -147,6 +147,6 @@ const styles = StyleSheet.create({
     padding: 20,
     borderTopWidth: 1,
     borderBottomWidth: 1,
-    boderColor: LIGHT_GREY,
+    borderColor: LIGHT_GREY,
   },
 });


### PR DESCRIPTION
`boderColor` should be `borderColor`.

This fixes a type error.