### PR TITLE
chore: update lockfile to specify exact version of @mapeo/ipc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@formatjs/intl-pluralrules": "^5.2.4",
         "@formatjs/intl-relativetimeformat": "^11.2.4",
         "@gorhom/bottom-sheet": "^4.5.1",
-        "@mapeo/ipc": "^0.3.0",
+        "@mapeo/ipc": "0.3.0",
         "@react-native-community/hooks": "^2.8.0",
         "@react-native-community/netinfo": "11.1.0",
         "@react-native-picker/picker": "2.6.1",


### PR DESCRIPTION
Got this diff after pulling in changes from https://github.com/digidem/comapeo-mobile/pull/259