### PR TITLE
chore: replace placeholder buttons

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -723,7 +723,7 @@
     "message": "Success"
   },
   "sharedComponents.ProjectInviteBottomSheet.youHaveJoined": {
-    "message": "You have joined {projName}"
+    "message": "Go To Sync"
   },
   "sharedComponents.RoleWithIcon.coordinator": {
     "message": "Coordinator"

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
@@ -49,6 +49,24 @@ export const ProjectCreated = ({
     );
   }
 
+  //This resets the navigation so the user cannot press back and return to this screen
+  function handleGoToInviteScreen() {
+    navigation.dispatch(state => {
+      const index = state.routes.findIndex(r => r.name === 'Settings');
+      const routes = [
+        ...state.routes.slice(0, index + 1),
+        {name: 'YourTeam'},
+        {name: 'SelectDevice'},
+      ];
+
+      return CommonActions.reset({
+        ...state,
+        routes,
+        index: routes.length - 1,
+      });
+    });
+  }
+
   return (
     <View style={styles.container}>
       <View style={{alignItems: 'center'}}>
@@ -64,7 +82,7 @@ export const ProjectCreated = ({
         </Text>
       </View>
       <View style={{width: '100%'}}>
-        <Button fullWidth variant="outlined" onPress={() => {}}>
+        <Button fullWidth variant="outlined" onPress={handleGoToInviteScreen}>
           {t(m.inviteDevice)}
         </Button>
         <Button style={{marginTop: 20}} fullWidth onPress={handleGoToMap}>

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet.tsx
@@ -43,6 +43,10 @@ const m = defineMessages({
     id: 'sharedComponents.ProjectInviteBottomSheet.youHaveJoined',
     defaultMessage: 'You have joined {projName}',
   },
+  goToSync: {
+    id: 'sharedComponents.ProjectInviteBottomSheet.youHaveJoined',
+    defaultMessage: 'Go To Sync',
+  },
 });
 
 export const ProjectInviteBottomSheet = () => {
@@ -75,6 +79,14 @@ export const ProjectInviteBottomSheet = () => {
                 closeSheet();
               },
               text: formatMessage(m.goToMap),
+            },
+            {
+              onPress: () => {
+                navigation.navigate('Sync');
+                closeSheet();
+              },
+              text: formatMessage(m.goToSync),
+              variation: 'filled',
             },
           ]}
           title={formatMessage(m.success)}


### PR DESCRIPTION
Adds functionality to buttons that navigated to screens that were previously not built.

1. After creating a project, button "invite devices" now navigates to invite device screen
2. After joining a project, button "go to sync" opens up sync screen.