### PR TITLE
chore: update translation source to use ellipsis

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -32,7 +32,7 @@
     "message": "Start Tracks"
   },
   "Modal.GPSEnable.button.loading": {
-    "message": "Loading..."
+    "message": "Loading…"
   },
   "Modal.GPSEnable.button.stop": {
     "message": "Stop Tracks"

--- a/src/frontend/screens/MapScreen/GPSPermissions/GPSPermissionsEnabled.tsx
+++ b/src/frontend/screens/MapScreen/GPSPermissions/GPSPermissionsEnabled.tsx
@@ -19,7 +19,7 @@ const m = defineMessages({
   },
   loadingButtonText: {
     id: 'Modal.GPSEnable.button.loading',
-    defaultMessage: 'Loading...',
+    defaultMessage: 'Loading…',
   },
   trackingDescription: {
     id: 'Modal.GPSEnable.trackingDescription',


### PR DESCRIPTION
The rest of the translations that use an ellipsis are using the exact character and not 3 periods `.`. This updates a message string that was introduced with the tracks work to maintain consistency.