### PR TITLE
feat: add support for custom offline maps

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -50,7 +50,7 @@
     "message": "Start Tracks"
   },
   "Modal.GPSEnable.button.loading": {
-    "message": "Loading..."
+    "message": "Loading…"
   },
   "Modal.GPSEnable.button.stop": {
     "message": "Stop Tracks"

--- a/messages/en.json
+++ b/messages/en.json
@@ -50,7 +50,7 @@
     "message": "Start Tracks"
   },
   "Modal.GPSEnable.button.loading": {
-    "message": "Loading…"
+    "message": "Loading..."
   },
   "Modal.GPSEnable.button.stop": {
     "message": "Stop Tracks"

--- a/scripts/build-backend.mjs
+++ b/scripts/build-backend.mjs
@@ -75,7 +75,9 @@ const KEEP_THESE = [
   // Static folders referenced by @mapeo/core code
   'node_modules/@mapeo/core/drizzle',
   // zip file that is the default config
-  'node_modules/@mapeo/default-config/dist/mapeo-default-config.mapeoconfig'
+  'node_modules/@mapeo/default-config/dist/mapeo-default-config.mapeoconfig',
+  // Offline fallback map
+  'node_modules/mapeo-offline-map',
 ];
 
 for (const name of KEEP_THESE) {

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -10,7 +10,7 @@ const MIGRATIONS_FOLDER_PATH = new URL(
   import.meta.url,
 ).pathname
 const FALLBACK_MAP_PATH = new URL(
-  '../../node_modules/mapeo-offline-map',
+  './node_modules/mapeo-offline-map',
   import.meta.url,
 ).pathname
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,6 +1,6 @@
-import {parseArgs} from 'util';
+import { parseArgs } from 'util'
 
-import {init} from './src/app.js';
+import { init } from './src/app.js'
 
 // We define this here so we don't need to do additional bundling adjustments to get the path correct when running on the device
 // This assumes that we keep the relevant directory as part of the built assets when building for nodejs mobile
@@ -8,34 +8,34 @@ import {init} from './src/app.js';
 const MIGRATIONS_FOLDER_PATH = new URL(
   './node_modules/@mapeo/core/drizzle',
   import.meta.url,
-).pathname;
+).pathname
 const FALLBACK_MAP_PATH = new URL(
-  './node_modules/mapeo-offline-map',
+  '../../node_modules/mapeo-offline-map',
   import.meta.url,
-).pathname;
+).pathname
 
 const DEFAULT_CONFIG_PATH = new URL(
   './node_modules/@mapeo/default-config/dist/mapeo-default-config.mapeoconfig',
   import.meta.url,
-).pathname;
+).pathname
 
 try {
-  const {values} = parseArgs({
+  const { values } = parseArgs({
     options: {
-      version: {type: 'string'},
-      rootKey: {type: 'string'},
-      sharedStoragePath: {type: 'string'},
+      version: { type: 'string' },
+      rootKey: { type: 'string' },
+      sharedStoragePath: { type: 'string' },
     },
-  });
+  })
 
   if (typeof values.rootKey !== 'string') {
-    throw new Error('backend did not receive root key from front end');
+    throw new Error('backend did not receive root key from front end')
   }
 
   if (typeof values.sharedStoragePath !== 'string') {
     throw new Error(
       'backend did not receive shared storage path from front end',
-    );
+    )
   }
 
   // Do not await this as we want this to run indefinitely
@@ -46,9 +46,9 @@ try {
     sharedStoragePath: values.sharedStoragePath,
     defaultConfigPath: DEFAULT_CONFIG_PATH,
     fallbackMapPath: FALLBACK_MAP_PATH,
-  }).catch(err => {
-    console.error('Server startup error:', err);
-  });
+  }).catch((err) => {
+    console.error('Server startup error:', err)
+  })
 } catch (err) {
-  console.error('Server startup error:', err);
+  console.error('Server startup error:', err)
 }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,6 +1,6 @@
-import { parseArgs } from 'util'
+import {parseArgs} from 'util';
 
-import { init } from './src/app.js'
+import {init} from './src/app.js';
 
 // We define this here so we don't need to do additional bundling adjustments to get the path correct when running on the device
 // This assumes that we keep the relevant directory as part of the built assets when building for nodejs mobile
@@ -8,30 +8,34 @@ import { init } from './src/app.js'
 const MIGRATIONS_FOLDER_PATH = new URL(
   './node_modules/@mapeo/core/drizzle',
   import.meta.url,
-).pathname
+).pathname;
+const FALLBACK_MAP_PATH = new URL(
+  '../../node_modules/mapeo-offline-map',
+  import.meta.url,
+).pathname;
 
 const DEFAULT_CONFIG_PATH = new URL(
   './node_modules/@mapeo/default-config/dist/mapeo-default-config.mapeoconfig',
   import.meta.url,
-).pathname
+).pathname;
 
 try {
-  const { values } = parseArgs({
+  const {values} = parseArgs({
     options: {
-      version: { type: 'string' },
-      rootKey: { type: 'string' },
-      sharedStoragePath: { type: 'string' },
+      version: {type: 'string'},
+      rootKey: {type: 'string'},
+      sharedStoragePath: {type: 'string'},
     },
-  })
+  });
 
   if (typeof values.rootKey !== 'string') {
-    throw new Error('backend did not receive root key from front end')
+    throw new Error('backend did not receive root key from front end');
   }
 
   if (typeof values.sharedStoragePath !== 'string') {
     throw new Error(
       'backend did not receive shared storage path from front end',
-    )
+    );
   }
 
   // Do not await this as we want this to run indefinitely
@@ -41,9 +45,10 @@ try {
     migrationsFolderPath: MIGRATIONS_FOLDER_PATH,
     sharedStoragePath: values.sharedStoragePath,
     defaultConfigPath: DEFAULT_CONFIG_PATH,
-  }).catch((err) => {
-    console.error('Server startup error:', err)
-  })
+    fallbackMapPath: FALLBACK_MAP_PATH,
+  }).catch(err => {
+    console.error('Server startup error:', err);
+  });
 } catch (err) {
-  console.error('Server startup error:', err)
+  console.error('Server startup error:', err);
 }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -10,7 +10,7 @@ const MIGRATIONS_FOLDER_PATH = new URL(
   import.meta.url,
 ).pathname;
 const FALLBACK_MAP_PATH = new URL(
-  '../../node_modules/mapeo-offline-map',
+  './node_modules/mapeo-offline-map',
   import.meta.url,
 ).pathname;
 

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -13,7 +13,8 @@
         "@mapeo/core": "9.0.0-alpha.9",
         "@mapeo/default-config": "^4.0.0-alpha.2",
         "@mapeo/ipc": "0.5.0",
-        "debug": "^4.3.4"
+        "debug": "^4.3.4",
+        "mapeo-offline-map": "^2.0.0"
       },
       "devDependencies": {
         "@digidem/types": "~2.1.0",
@@ -3731,6 +3732,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mapeo-offline-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mapeo-offline-map/-/mapeo-offline-map-2.0.0.tgz",
+      "integrity": "sha512-/a2BVgSwcL0EGqNxc7MWaApEJ0uLxr/scaZimd/2RvihDtvaNsLQurHIAjXJnY5lj4to5fBFBpcWXntdZoRBdg=="
     },
     "node_modules/marked": {
       "version": "4.3.0",
@@ -8466,6 +8472,11 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz",
       "integrity": "sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A=="
+    },
+    "mapeo-offline-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mapeo-offline-map/-/mapeo-offline-map-2.0.0.tgz",
+      "integrity": "sha512-/a2BVgSwcL0EGqNxc7MWaApEJ0uLxr/scaZimd/2RvihDtvaNsLQurHIAjXJnY5lj4to5fBFBpcWXntdZoRBdg=="
     },
     "marked": {
       "version": "4.3.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -16,7 +16,8 @@
     "@mapeo/core": "9.0.0-alpha.9",
     "@mapeo/default-config": "^4.0.0-alpha.2",
     "@mapeo/ipc": "0.5.0",
-    "debug": "^4.3.4"
+    "debug": "^4.3.4",
+    "mapeo-offline-map": "^2.0.0"
   },
   "devDependencies": {
     "@digidem/types": "~2.1.0",

--- a/src/backend/src/app.js
+++ b/src/backend/src/app.js
@@ -75,7 +75,7 @@ export async function init({
   const privateStorageDir = rnBridge.app.datadir()
   const dbDir = join(privateStorageDir, DB_DIR_NAME)
   const indexDir = join(privateStorageDir, CORE_STORAGE_DIR_NAME)
-  const staticStylesDir = join(sharedStoragePath, 'styles', 'default')
+  const staticStylesDir = join(sharedStoragePath, 'styles')
 
   mkdirSync(dbDir, { recursive: true })
   mkdirSync(indexDir, { recursive: true })

--- a/src/backend/src/app.js
+++ b/src/backend/src/app.js
@@ -5,7 +5,13 @@ import { createRequire } from 'module'
 const require = createRequire(import.meta.url)
 /** @type {import('../types/rn-bridge.js')} */
 const rnBridge = require('rn-bridge')
-import { MapeoManager, FastifyController } from '@mapeo/core'
+import {
+  MapeoManager,
+  FastifyController,
+  MapeoMapsFastifyPlugin,
+  MapeoStaticMapsFastifyPlugin,
+  MapeoOfflineFallbackMapFastifyPlugin,
+} from '@mapeo/core'
 import { createMapeoServer } from '@mapeo/ipc'
 import Fastify from 'fastify'
 
@@ -15,6 +21,10 @@ import { ServerStatus } from './status.js'
 // Do not touch these!
 const DB_DIR_NAME = 'sqlite-dbs'
 const CORE_STORAGE_DIR_NAME = 'core-storage'
+
+const MAPBOX_ACCESS_TOKEN =
+  'pk.eyJ1IjoiZGlnaWRlbSIsImEiOiJjbHRyaGh3cm0wN3l4Mmpsam95NDI3c2xiIn0.daq2iZFZXQ08BD0VZWAGUw'
+const DEFAULT_ONLINE_MAP_STYLE_URL = `https://api.mapbox.com/styles/v1/mapbox/outdoors-v11?access_token=${MAPBOX_ACCESS_TOKEN}`
 
 const log = debug('mapeo:app')
 
@@ -48,6 +58,7 @@ process.on('exit', (code) => {
  * @param {string} options.migrationsFolderPath
  * @param {string} options.sharedStoragePath Path to app-specific external file storage folder
  * @param {string} options.defaultConfigPath
+ * @param {string} options.fallbackMapPath Path to app-specific external file storage folder
  *
  */
 export async function init({
@@ -56,6 +67,7 @@ export async function init({
   migrationsFolderPath,
   sharedStoragePath,
   defaultConfigPath,
+  fallbackMapPath,
 }) {
   log('Starting app...')
   log(`Device version is ${version}`)
@@ -63,12 +75,29 @@ export async function init({
   const privateStorageDir = rnBridge.app.datadir()
   const dbDir = join(privateStorageDir, DB_DIR_NAME)
   const indexDir = join(privateStorageDir, CORE_STORAGE_DIR_NAME)
+  const staticStylesDir = join(sharedStoragePath, 'styles', 'default')
 
   mkdirSync(dbDir, { recursive: true })
   mkdirSync(indexDir, { recursive: true })
+  mkdirSync(staticStylesDir, { recursive: true })
 
   const fastify = Fastify()
   const fastifyController = new FastifyController({ fastify })
+
+  // Register maps plugins
+  fastify.register(MapeoStaticMapsFastifyPlugin, {
+    prefix: 'static',
+    staticRootDir: staticStylesDir,
+  })
+  fastify.register(MapeoOfflineFallbackMapFastifyPlugin, {
+    prefix: 'fallback',
+    styleJsonPath: join(fallbackMapPath, 'style.json'),
+    sourcesDir: join(fallbackMapPath, 'dist'),
+  })
+  fastify.register(MapeoMapsFastifyPlugin, {
+    prefix: 'maps',
+    defaultOnlineStyleUrl: DEFAULT_ONLINE_MAP_STYLE_URL,
+  })
 
   const manager = new MapeoManager({
     rootKey,

--- a/src/frontend/hooks/server/mapStyleUrl.ts
+++ b/src/frontend/hooks/server/mapStyleUrl.ts
@@ -1,0 +1,16 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {useApi} from '../../contexts/ApiContext';
+
+export const MAP_STYLE_URL_KEY = 'map_style_url';
+
+export function useMapStyleUrl() {
+  const api = useApi();
+
+  return useQuery({
+    queryKey: [MAP_STYLE_URL_KEY],
+    queryFn: () => {
+      return api.getMapStyleJsonUrl();
+    },
+  });
+}

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -32,8 +32,6 @@ const DEFAULT_ZOOM = 12;
 Mapbox.setAccessToken(config.mapboxAccessToken);
 const MIN_DISPLACEMENT = 3;
 
-export const MAP_STYLE = Mapbox.StyleURL.Outdoors;
-
 export const MapScreen = () => {
   const [zoom, setZoom] = React.useState(DEFAULT_ZOOM);
   const [isFinishedLoading, setIsFinishedLoading] = React.useState(false);

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Mapbox from '@rnmapbox/maps';
-import {useNetInfo} from '@react-native-community/netinfo';
 
 import config from '../../../config.json';
 import {IconButton} from '../../sharedComponents/IconButton';
@@ -48,7 +47,7 @@ export const MapScreen = () => {
   const locationServicesEnabled =
     !!locationProviderStatus?.locationServicesEnabled;
 
-  const styleUrl = useMapStyle();
+  const styleUrlQuery = useMapStyleUrl();
 
   const handleAddPress = () => {
     newDraft();
@@ -80,7 +79,7 @@ export const MapScreen = () => {
         attributionPosition={{right: 8, bottom: 8}}
         compassEnabled={false}
         scaleBarEnabled={false}
-        styleURL={styleUrl}
+        styleURL={styleUrlQuery.data}
         onDidFinishLoadingStyle={handleDidFinishLoadingStyle}
         onMoveShouldSetResponder={() => {
           if (following) setFollowing(false);
@@ -139,18 +138,3 @@ const styles = StyleSheet.create({
     bottom: 20,
   },
 });
-
-// We need a way for the MapView to internally re-request the StyleJSON from the backend when the internet connection changes.
-// There's no user-facing API from the mapping library to do this, so the solution is to use a benign search parameter to indicate
-// to the mapping library that the style URL has changed and should thus re-fetch. The backend does not use the search parameter for the route of interest.
-function useMapStyle() {
-  const mapStyleUrlQuery = useMapStyleUrl();
-  const {isInternetReachable} = useNetInfo();
-
-  if (!mapStyleUrlQuery.data) return undefined;
-
-  // TODO: Should this be a proper nonce? i.e. do we always want to bust HTTP caching?
-  if (!isInternetReachable) return mapStyleUrlQuery.data + '?offline=true';
-
-  return mapStyleUrlQuery.data;
-}

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -21,6 +21,7 @@ import {GPSPermissionsModal} from './GPSPermissions/GPSPermissionsModal';
 import {TrackPathLayer} from './track/TrackPathLayer';
 import {UserLocation} from './UserLocation';
 import {useSharedLocationContext} from '../../contexts/SharedLocationContext';
+import {useMapStyleUrl} from '../../hooks/server/mapStyleUrl';
 
 // This is the default zoom used when the map first loads, and also the zoom
 // that the map will zoom to if the user clicks the "Locate" button and the
@@ -44,6 +45,8 @@ export const MapScreen = () => {
   const locationProviderStatus = useLocationProviderStatus();
   const locationServicesEnabled =
     !!locationProviderStatus?.locationServicesEnabled;
+
+  const mapStyleUrlQuery = useMapStyleUrl();
 
   const handleAddPress = () => {
     newDraft();
@@ -75,7 +78,7 @@ export const MapScreen = () => {
         attributionPosition={{right: 8, bottom: 8}}
         compassEnabled={false}
         scaleBarEnabled={false}
-        styleURL={MAP_STYLE}
+        styleURL={mapStyleUrlQuery?.data}
         onDidFinishLoadingStyle={handleDidFinishLoadingStyle}
         onMoveShouldSetResponder={() => {
           if (following) setFollowing(false);

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -140,6 +140,9 @@ const styles = StyleSheet.create({
   },
 });
 
+// We need a way for the MapView to internally re-request the StyleJSON from the backend when the internet connection changes.
+// There's no user-facing API from the mapping library to do this, so the solution is to use a benign search parameter to indicate
+// to the mapping library that the style URL has changed and should thus re-fetch. The backend does not use the search parameter for the route of interest.
 function useMapStyle() {
   const mapStyleUrlQuery = useMapStyleUrl();
   const {isInternetReachable} = useNetInfo();

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -78,7 +78,8 @@ export const MapScreen = () => {
         attributionPosition={{right: 8, bottom: 8}}
         compassEnabled={false}
         scaleBarEnabled={false}
-        styleURL={mapStyleUrlQuery?.data}
+        // TODO: Add a nonce as query param to bust the cache when network state changes?
+        styleURL={mapStyleUrlQuery.data}
         onDidFinishLoadingStyle={handleDidFinishLoadingStyle}
         onMoveShouldSetResponder={() => {
           if (following) setFollowing(false);

--- a/src/frontend/screens/Observation/InsetMapView.tsx
+++ b/src/frontend/screens/Observation/InsetMapView.tsx
@@ -4,7 +4,7 @@ import {View, Text, StyleSheet, Dimensions, Image} from 'react-native';
 import {BLACK, WHITE} from '../../lib/styles';
 import {usePersistedSettings} from '../../hooks/persistedState/usePersistedSettings';
 import {FormattedCoords} from '../../sharedComponents/FormattedData';
-import {MAP_STYLE} from '../MapScreen';
+import {useMapStyleUrl} from '../../hooks/server/mapStyleUrl';
 
 const MAP_HEIGHT = 175;
 const ICON_OFFSET = {x: 22, y: 21};
@@ -16,6 +16,8 @@ type MapProps = {
 
 export const InsetMapView = React.memo<MapProps>(({lon, lat}: MapProps) => {
   const format = usePersistedSettings(store => store.coordinateFormat);
+  const styleUrlQuery = useMapStyleUrl();
+
   return (
     <View>
       <Image
@@ -37,7 +39,7 @@ export const InsetMapView = React.memo<MapProps>(({lon, lat}: MapProps) => {
         rotateEnabled={false}
         compassEnabled={false}
         scaleBarEnabled={false}
-        styleURL={MAP_STYLE}>
+        styleURL={styleUrlQuery.data}>
         <MapboxGL.Camera
           centerCoordinate={[lon, lat]}
           zoomLevel={12}


### PR DESCRIPTION
Closes #243 

Notes:

- decision tree for which map's style.json to serve (EDIT: when map initially loads/renders):
  
    ![image](https://github.com/digidem/comapeo-mobile/assets/18542095/2d9235e2-b3bf-4913-8c1f-a75ee853bee6)

Remaining items:

- [X] on my Pixel 2 Android 11, zooming out eventually causes the app to crash. have only tried this with one example map so not sure if it's specific to this map or a general issue. i get the following some cryptic logs from adb but not sure how to debug:


    ```sh
    NODEJS-MOBILE: exiting due to SIG_DFL handler for signal 11
    ```
    
    ```sh
    backtrace:
      #00 pc 000000000004e0f4  /apex/com.android.runtime/lib64/bionic/libc.so (abort+180) (BuildId:   
      #01 pc 00000000000050b8  /system/bin/app_process64 (art::SignalChain::Handler(int, siginfo*, void*)+1120) (BuildId:   
      #02 pc 00000000000008b0  [vdso] (__kernel_rt_sigreturn)
      #03 pc 0000000000118c3c  [anon:scudo:primary]
    ```
    
    One thing to try next: upload same map to Mapeo Mobile and see if same crash happens.
    
    EDIT: I'm no longer getting the crash for mysterious reasons...

- [ ] ~attempting to test this on my Pixel 6 Android 14 is very difficult due to storage permission changes introduced in Android 13+14. Basically almost impossible without using adb and even then, it requires some complicated workarounds that I have yet to figure out (think other members of our team have done it before).~ EDIT: will not test on pixel 6 for now