### PR TITLE
fix: missing icon import for save button in manual GPS entry screen

### DIFF
--- a/src/frontend/screens/ManualGpsScreen/index.tsx
+++ b/src/frontend/screens/ManualGpsScreen/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../hooks/persistedState/usePersistedSettings';
 import {BLACK} from '../../lib/styles';
 import {IconButton} from '../../sharedComponents/IconButton';
-import {SaveIcon} from '../../sharedComponents/icons';
+import SaveCheck from '../../images/CheckMark.svg';
 import {Select} from '../../sharedComponents/Select';
 import {Text} from '../../sharedComponents/Text';
 import {
@@ -138,7 +138,7 @@ export const ManualGpsScreen = ({
     navigation.setOptions({
       headerRight: () => (
         <IconButton onPress={handleSavePress}>
-          <SaveIcon inprogress={false} />
+          <SaveCheck />
         </IconButton>
       ),
     });
@@ -211,7 +211,7 @@ export function createNavigationOptions({
       headerTitle: intl(m.title),
       headerRight: () => (
         <IconButton>
-          <SaveIcon inprogress={false} />
+          <SaveCheck />
         </IconButton>
       ),
     };


### PR DESCRIPTION
Icon was removed in https://github.com/digidem/comapeo-mobile/pull/312 but this screen wasn't updated to import the replacement one

---

Preview:

<img width="300" alt="image" src="https://github.com/digidem/comapeo-mobile/assets/18542095/c365be8d-366a-4760-b9a1-f85900aef67a">
