### PR TITLE
chore: organize navigation types

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -5,7 +5,6 @@ import {
 } from '@react-navigation/native';
 import {createMapeoClient} from '@mapeo/ipc';
 import {AppNavigator} from './AppNavigator';
-import {AppStackList} from './Navigation/Stack';
 import {IntlProvider} from './contexts/IntlContext';
 import {MessagePortLike} from './lib/MessagePortLike';
 import {initializeNodejs} from './initializeNodejs';
@@ -14,6 +13,7 @@ import {AppProviders} from './contexts/AppProviders';
 import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
 import {Loading} from './sharedComponents/Loading';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
+import {AppStackList} from './sharedTypes/navigation';
 
 const messagePort = new MessagePortLike();
 const mapeoApi = createMapeoClient(messagePort, {timeout: Infinity});

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -13,7 +13,7 @@ import {AppProviders} from './contexts/AppProviders';
 import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
 import {Loading} from './sharedComponents/Loading';
 import {BottomSheetModalProvider} from '@gorhom/bottom-sheet';
-import {AppStackList} from './sharedTypes/navigation';
+import {AppStackParamsList} from './sharedTypes/navigation';
 
 const messagePort = new MessagePortLike();
 const mapeoApi = createMapeoClient(messagePort, {timeout: Infinity});
@@ -22,7 +22,7 @@ localDiscoveryController.start();
 initializeNodejs();
 
 const App = () => {
-  const navRef = useNavigationContainerRef<AppStackList>();
+  const navRef = useNavigationContainerRef<AppStackParamsList>();
   const [permissionsAsked, setPermissionsAsked] = React.useState(false);
   React.useEffect(() => {
     PermissionsAndroid.requestMultiple([

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -1,4 +1,3 @@
-import {NavigatorScreenParams} from '@react-navigation/native';
 import * as React from 'react';
 import {RootStack} from '.';
 import {MessageDescriptor} from 'react-intl';
@@ -25,7 +24,6 @@ import {ProjectCreated} from '../../screens/Settings/CreateOrJoinProject/CreateP
 import {JoinExistingProject} from '../../screens/Settings/CreateOrJoinProject/JoinExistingProject';
 import {YourTeam} from '../../screens/Settings/ProjectSettings/YourTeam';
 import {SelectDevice} from '../../screens/Settings/ProjectSettings/YourTeam/SelectDevice';
-import {DeviceType} from '../../sharedTypes';
 import {SelectInviteeRole} from '../../screens/Settings/ProjectSettings/YourTeam/SelectInviteeRole';
 import {ReviewInvitation} from '../../screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation';
 import {InviteAccepted} from '../../screens/Settings/ProjectSettings/YourTeam/InviteAccepted';
@@ -42,7 +40,6 @@ import {
   LocationInfoScreen,
   createNavigationOptions as createLocationInfoNavOptions,
 } from '../../screens/LocationInfoScreen';
-import {InviteProps} from '../../sharedTypes';
 import {SaveTrackScreen} from '../../screens/MapScreen/track/SaveTrackScreen';
 import {InviteDeclined} from '../../screens/Settings/ProjectSettings/YourTeam/InviteDeclined';
 import {UnableToCancelInvite} from '../../screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite';
@@ -55,74 +52,9 @@ import {
   ManualGpsScreen,
   createNavigationOptions as createManualGpsNavigationOptions,
 } from '../../screens/ManualGpsScreen';
-import {HomeTabs, type HomeTabsList} from '../Tab';
+import {HomeTabs} from '../Tab';
 
 export const TAB_BAR_HEIGHT = 70;
-
-export type AppList = {
-  Home: NavigatorScreenParams<HomeTabsList>;
-  GpsModal: undefined;
-  Settings: undefined;
-  ProjectConfig: undefined;
-  AboutMapeo: undefined;
-  LanguageSettings: undefined;
-  CoordinateFormat: undefined;
-  Experiments: undefined;
-  PhotosModal: {
-    photoIndex: number;
-    observationId?: string;
-    editing: boolean;
-  };
-  PhotoView: undefined;
-  PresetChooser: undefined;
-  AddPhoto: undefined;
-  Observation: {observationId: string};
-  ObservationEdit: {observationId?: string} | undefined;
-  ManualGpsScreen: undefined;
-  ObservationDetails: {question: number};
-  LeaveProjectScreen: undefined;
-  AlreadyOnProj: undefined;
-  AddToProjectScreen: undefined;
-  UnableToLinkScreen: undefined;
-  ConnectingToDeviceScreen: {task: () => Promise<void>};
-  ConfirmLeavePracticeModeScreen: {projectAction: 'join' | 'create'};
-  CreateProject: undefined;
-  Security: undefined;
-  DirectionalArrow: undefined;
-  P2pUpgrade: undefined;
-  MapSettings: undefined;
-  BackgroundMaps: undefined;
-  BackgroundMapInfo: {
-    bytesStored: number;
-    id: string;
-    styleUrl: string;
-    name: string;
-  };
-  BGMapsSettings: undefined;
-  AuthScreen: undefined;
-  AppPasscode: undefined;
-  ObscurePasscode: undefined;
-  ConfirmPasscodeSheet: {passcode: string};
-  DisablePasscode: undefined;
-  SetPasscode: undefined;
-  EnterPassToTurnOff: undefined;
-  AppSettings: undefined;
-  ProjectSettings: undefined;
-  CreateOrJoinProject: undefined;
-  ProjectCreated: {name: string};
-  JoinExistingProject: undefined;
-  YourTeam: undefined;
-  SelectDevice: undefined;
-  SelectInviteeRole: {name: string; deviceType: DeviceType; deviceId: string};
-  ReviewAndInvite: InviteProps;
-  InviteAccepted: InviteProps;
-  InviteDeclined: InviteProps;
-  UnableToCancelInvite: InviteProps;
-  DeviceNameDisplay: undefined;
-  DeviceNameEdit: undefined;
-  SaveTrack: undefined;
-  Sync: undefined;
-};
 
 // **NOTE**: No hooks allowed here (this is not a component, it is a function
 // that returns a react element)

--- a/src/frontend/Navigation/Stack/DeviceNamingScreens.tsx
+++ b/src/frontend/Navigation/Stack/DeviceNamingScreens.tsx
@@ -4,12 +4,6 @@ import {IntroToCoMapeo} from '../../screens/IntroToCoMapeo';
 import {DeviceNaming} from '../../screens/DeviceNaming';
 import {Success} from '../../screens/Success';
 
-export type DeviceNamingSceens = {
-  IntroToCoMapeo: undefined;
-  DeviceNaming: undefined;
-  Success: {deviceName: string};
-};
-
 export const createDeviceNamingScreens = () => (
   <RootStack.Group key="deviceNaming">
     <RootStack.Screen

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -2,11 +2,8 @@ import React from 'react';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack/lib/typescript/src/types';
 import {WHITE} from '../../lib/styles';
-import {AppList} from './AppScreens';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
-import {DeviceNamingSceens} from './DeviceNamingScreens';
-
-export type AppStackList = AppList & DeviceNamingSceens;
+import {AppStackList} from '../../sharedTypes/navigation';
 
 export const RootStack = createNativeStackNavigator<AppStackList>();
 

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -3,9 +3,9 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack/lib/typescript/src/types';
 import {WHITE} from '../../lib/styles';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
-import {AppStackList} from '../../sharedTypes/navigation';
+import {AppStackParamsList} from '../../sharedTypes/navigation';
 
-export const RootStack = createNativeStackNavigator<AppStackList>();
+export const RootStack = createNativeStackNavigator<AppStackParamsList>();
 
 export const NavigatorScreenOptions: NativeStackNavigationOptions = {
   presentation: 'card',

--- a/src/frontend/Navigation/Tab/TabBar/CameraTabBarIcon.tsx
+++ b/src/frontend/Navigation/Tab/TabBar/CameraTabBarIcon.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import {TabBarIconProps} from '../../../sharedTypes';
+import {TabBarIconProps} from '../../../sharedTypes/navigation';
 import {TabBarIcon} from './TabBarIcon';
 import {useTabNavigationStore} from '../../../hooks/useTabNavigationStore';
 

--- a/src/frontend/Navigation/Tab/TabBar/MapTabBarIcon.tsx
+++ b/src/frontend/Navigation/Tab/TabBar/MapTabBarIcon.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import {TabBarIconProps} from '../../../sharedTypes';
+import {TabBarIconProps} from '../../../sharedTypes/navigation';
 import {TabBarIcon} from './TabBarIcon';
 import {useTabNavigationStore} from '../../../hooks/useTabNavigationStore';
 

--- a/src/frontend/Navigation/Tab/TabBar/ObservationsListTabBarIcon.tsx
+++ b/src/frontend/Navigation/Tab/TabBar/ObservationsListTabBarIcon.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import {TabBarIconProps} from '../../../sharedTypes';
+import {TabBarIconProps} from '../../../sharedTypes/navigation';
 import {useTabNavigationStore} from '../../../hooks/useTabNavigationStore';
 import ObservationListIcon from '../../../images/ObservationList.svg';
 import {COMAPEO_BLUE, MEDIUM_GREY} from '../../../lib/styles';

--- a/src/frontend/Navigation/Tab/TabBar/TabBarIcon.tsx
+++ b/src/frontend/Navigation/Tab/TabBar/TabBarIcon.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
-import {TabBarIconProps} from '../../../sharedTypes';
+import {TabBarIconProps} from '../../../sharedTypes/navigation';
 import {COMAPEO_BLUE, MEDIUM_GREY} from '../../../lib/styles';
 
 export interface TabBarIcon extends TabBarIconProps {

--- a/src/frontend/Navigation/Tab/TabBar/TrackingTabBarIcon.tsx
+++ b/src/frontend/Navigation/Tab/TabBar/TrackingTabBarIcon.tsx
@@ -3,7 +3,7 @@ import {StyleSheet, View} from 'react-native';
 import {TabBarIcon} from './TabBarIcon';
 import {useTracking} from '../../../hooks/tracks/useTracking';
 import {Text} from '../../../sharedComponents/Text';
-import {TabBarIconProps} from '../../../sharedTypes';
+import {TabBarIconProps} from '../../../sharedTypes/navigation';
 import {useTrackTimerContext} from '../../../contexts/TrackTimerContext';
 import {useTabNavigationStore} from '../../../hooks/useTabNavigationStore';
 

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -16,9 +16,9 @@ import {TAB_BAR_HEIGHT} from '../Stack/AppScreens';
 import {CameraTabBarIcon} from './TabBar/CameraTabBarIcon';
 import {MapTabBarIcon} from './TabBar/MapTabBarIcon';
 import {TrackingTabBarIcon} from './TabBar/TrackingTabBarIcon';
-import {HomeTabsList} from '../../sharedTypes/navigation';
+import {HomeTabsParamsList} from '../../sharedTypes/navigation';
 
-const Tab = createBottomTabNavigator<HomeTabsList>();
+const Tab = createBottomTabNavigator<HomeTabsParamsList>();
 
 export const HomeTabs = () => {
   const {handleTabPress} = useCurrentTab();
@@ -68,7 +68,7 @@ export const HomeTabs = () => {
           listeners={({
             navigation,
           }: {
-            navigation: BottomTabNavigationProp<HomeTabsList>;
+            navigation: BottomTabNavigationProp<HomeTabsParamsList>;
           }) => ({
             tabPress: e => {
               e.preventDefault();

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -16,13 +16,7 @@ import {TAB_BAR_HEIGHT} from '../Stack/AppScreens';
 import {CameraTabBarIcon} from './TabBar/CameraTabBarIcon';
 import {MapTabBarIcon} from './TabBar/MapTabBarIcon';
 import {TrackingTabBarIcon} from './TabBar/TrackingTabBarIcon';
-
-export type HomeTabsList = {
-  Map: undefined;
-  Camera: undefined;
-  Tracking: undefined;
-  ObservationsList: undefined;
-};
+import {HomeTabsList} from '../../sharedTypes/navigation';
 
 const Tab = createBottomTabNavigator<HomeTabsList>();
 

--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -1,10 +1,10 @@
-import {AppStackList, HomeTabsParamsList} from './sharedTypes/navigation';
+import {AppStackParamsList, HomeTabsParamsList} from './sharedTypes/navigation';
 
 // this has to be a string because js does not recognize 00000 as being 5 digits
 export const OBSCURE_PASSCODE = '00000';
 
 export const EDITING_SCREEN_NAMES:
-  | Omit<keyof AppStackList, 'Home'>[]
+  | Omit<keyof AppStackParamsList, 'Home'>[]
   | (keyof HomeTabsParamsList)[] = [
   'AddPhoto',
   'PresetChooser',

--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -1,11 +1,11 @@
-import {AppStackList, HomeTabsList} from './sharedTypes/navigation';
+import {AppStackList, HomeTabsParamsList} from './sharedTypes/navigation';
 
 // this has to be a string because js does not recognize 00000 as being 5 digits
 export const OBSCURE_PASSCODE = '00000';
 
 export const EDITING_SCREEN_NAMES:
   | Omit<keyof AppStackList, 'Home'>[]
-  | (keyof HomeTabsList)[] = [
+  | (keyof HomeTabsParamsList)[] = [
   'AddPhoto',
   'PresetChooser',
   'ManualGpsScreen',

--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -1,5 +1,5 @@
-import {AppStackList} from './Navigation/Stack';
 import {type HomeTabsList} from './Navigation/Tab';
+import {AppStackList} from './sharedTypes/navigation';
 
 // this has to be a string because js does not recognize 00000 as being 5 digits
 export const OBSCURE_PASSCODE = '00000';

--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -1,5 +1,4 @@
-import {type HomeTabsList} from './Navigation/Tab';
-import {AppStackList} from './sharedTypes/navigation';
+import {AppStackList, HomeTabsList} from './sharedTypes/navigation';
 
 // this has to be a string because js does not recognize 00000 as being 5 digits
 export const OBSCURE_PASSCODE = '00000';

--- a/src/frontend/hooks/useCurrentTab.ts
+++ b/src/frontend/hooks/useCurrentTab.ts
@@ -1,7 +1,7 @@
 import {EventArg} from '@react-navigation/native';
 import {useGPSModalContext} from '../contexts/GPSModalContext';
 import {useTabNavigationStore} from './useTabNavigationStore';
-import {TabName} from '../sharedTypes';
+import {TabName} from '../sharedTypes/navigation';
 
 const tabNames: Set<TabName> = new Set([
   'Map',

--- a/src/frontend/hooks/useNavigationWithTypes.ts
+++ b/src/frontend/hooks/useNavigationWithTypes.ts
@@ -1,8 +1,8 @@
 import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
 import {CompositeNavigationProp, useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {AppStackList} from '../Navigation/Stack';
 import {type HomeTabsList} from '../Navigation/Tab';
+import {AppStackList} from '../sharedTypes/navigation';
 
 export const useNavigationFromRoot = () =>
   useNavigation<NativeStackNavigationProp<AppStackList>>();

--- a/src/frontend/hooks/useNavigationWithTypes.ts
+++ b/src/frontend/hooks/useNavigationWithTypes.ts
@@ -1,16 +1,19 @@
 import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
 import {CompositeNavigationProp, useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {AppStackList, HomeTabsParamsList} from '../sharedTypes/navigation';
+import {
+  AppStackParamsList,
+  HomeTabsParamsList,
+} from '../sharedTypes/navigation';
 
 export const useNavigationFromRoot = () =>
-  useNavigation<NativeStackNavigationProp<AppStackList>>();
+  useNavigation<NativeStackNavigationProp<AppStackParamsList>>();
 
 export function useNavigationFromHomeTabs() {
   return useNavigation<
     CompositeNavigationProp<
       BottomTabNavigationProp<HomeTabsParamsList>,
-      NativeStackNavigationProp<AppStackList>
+      NativeStackNavigationProp<AppStackParamsList>
     >
   >();
 }

--- a/src/frontend/hooks/useNavigationWithTypes.ts
+++ b/src/frontend/hooks/useNavigationWithTypes.ts
@@ -1,7 +1,7 @@
 import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
 import {CompositeNavigationProp, useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {AppStackList, HomeTabsList} from '../sharedTypes/navigation';
+import {AppStackList, HomeTabsParamsList} from '../sharedTypes/navigation';
 
 export const useNavigationFromRoot = () =>
   useNavigation<NativeStackNavigationProp<AppStackList>>();
@@ -9,7 +9,7 @@ export const useNavigationFromRoot = () =>
 export function useNavigationFromHomeTabs() {
   return useNavigation<
     CompositeNavigationProp<
-      BottomTabNavigationProp<HomeTabsList>,
+      BottomTabNavigationProp<HomeTabsParamsList>,
       NativeStackNavigationProp<AppStackList>
     >
   >();

--- a/src/frontend/hooks/useNavigationWithTypes.ts
+++ b/src/frontend/hooks/useNavigationWithTypes.ts
@@ -1,8 +1,7 @@
 import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
 import {CompositeNavigationProp, useNavigation} from '@react-navigation/native';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
-import {type HomeTabsList} from '../Navigation/Tab';
-import {AppStackList} from '../sharedTypes/navigation';
+import {AppStackList, HomeTabsList} from '../sharedTypes/navigation';
 
 export const useNavigationFromRoot = () =>
   useNavigation<NativeStackNavigationProp<AppStackList>>();

--- a/src/frontend/hooks/useTabNavigationStore.ts
+++ b/src/frontend/hooks/useTabNavigationStore.ts
@@ -1,5 +1,5 @@
 import {create} from 'zustand';
-import {TabName} from '../sharedTypes';
+import {TabName} from '../sharedTypes/navigation';
 
 type NavigationStoreState = {
   currentTab: TabName;

--- a/src/frontend/screens/AddPhoto.tsx
+++ b/src/frontend/screens/AddPhoto.tsx
@@ -6,7 +6,7 @@ import {defineMessages, FormattedMessage} from 'react-intl';
 
 import {CameraView} from '../sharedComponents/CameraView';
 import {useDraftObservation} from '../hooks/useDraftObservation';
-import {NativeRootNavigationProps} from '../sharedTypes';
+import {NativeRootNavigationProps} from '../sharedTypes/navigation';
 import {CapturedPictureMM} from '../contexts/PhotoPromiseContext/types';
 
 const m = defineMessages({

--- a/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
+++ b/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {defineMessages} from 'react-intl';
 
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {InputPasscode} from './InputPasscode';
 import {useSecurityContext} from '../../contexts/SecurityContext';
 

--- a/src/frontend/screens/AppPasscode/SetPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/SetPasscode.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {InputPasscode} from './InputPasscode';
 import {defineMessages} from 'react-intl';
 import {OBSCURE_PASSCODE} from '../../constants';
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 
 const m = defineMessages({
   titleSet: {

--- a/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
@@ -15,7 +15,7 @@ import {
 import {MEDIUM_GREY, RED, WHITE} from '../../lib/styles';
 import {ErrorIcon} from '../../sharedComponents/icons';
 import {Button} from '../../sharedComponents/Button';
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {useFocusEffect, StackActions} from '@react-navigation/native';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
 import {HeaderButtonProps} from '@react-navigation/native-stack/lib/typescript/src/types';

--- a/src/frontend/screens/AppPasscode/index.tsx
+++ b/src/frontend/screens/AppPasscode/index.tsx
@@ -3,7 +3,7 @@ import {defineMessages} from 'react-intl';
 import {StyleSheet, View} from 'react-native';
 
 import {WHITE} from '../../lib/styles';
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {PasscodeIntro} from './PasscodeIntro';
 import {useSecurityContext} from '../../contexts/SecurityContext';
 

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -11,8 +11,8 @@ import {
 import {DARK_BLUE, RED, WHITE} from '../lib/styles';
 import {PasscodeInput} from '../sharedComponents/PasscodeInput';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {AppStackList} from '../Navigation/Stack';
 import {useSecurityContext} from '../contexts/SecurityContext';
+import {AppStackList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   enterPass: {

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -12,7 +12,7 @@ import {DARK_BLUE, RED, WHITE} from '../lib/styles';
 import {PasscodeInput} from '../sharedComponents/PasscodeInput';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {useSecurityContext} from '../contexts/SecurityContext';
-import {AppStackList} from '../sharedTypes/navigation';
+import {AppStackParamsList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   enterPass: {
@@ -27,7 +27,7 @@ const m = defineMessages({
 
 export const AuthScreen = ({
   navigation,
-}: NativeStackScreenProps<AppStackList, 'AuthScreen'>) => {
+}: NativeStackScreenProps<AppStackParamsList, 'AuthScreen'>) => {
   const [error, setError] = React.useState(false);
   const {authenticate, authState} = useSecurityContext();
   const [inputtedPass, setInputtedPass] = React.useState('');

--- a/src/frontend/screens/CameraScreen.tsx
+++ b/src/frontend/screens/CameraScreen.tsx
@@ -3,9 +3,9 @@ import {View, StyleSheet} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 
 import {CameraView} from '../sharedComponents/CameraView';
-import {NativeHomeTabsNavigationProps} from '../sharedTypes';
 import {CapturedPictureMM} from '../contexts/PhotoPromiseContext/types';
 import {useDraftObservation} from '../hooks/useDraftObservation';
+import {NativeHomeTabsNavigationProps} from '../sharedTypes/navigation';
 
 export const CameraScreen = ({
   navigation,

--- a/src/frontend/screens/DeviceNaming.tsx
+++ b/src/frontend/screens/DeviceNaming.tsx
@@ -13,7 +13,7 @@ import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {TouchableWithoutFeedback} from 'react-native-gesture-handler';
 import {defineMessages, useIntl} from 'react-intl';
-import {DeviceNamingSceens} from '../Navigation/Stack/DeviceNamingScreens';
+import {DeviceNamingSceens} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   header: {

--- a/src/frontend/screens/DeviceNaming.tsx
+++ b/src/frontend/screens/DeviceNaming.tsx
@@ -13,7 +13,7 @@ import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {TouchableWithoutFeedback} from 'react-native-gesture-handler';
 import {defineMessages, useIntl} from 'react-intl';
-import {DeviceNamingSceens} from '../sharedTypes/navigation';
+import {DeviceNamingParamList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   header: {
@@ -33,7 +33,7 @@ const m = defineMessages({
 
 export const DeviceNaming = ({
   navigation,
-}: NativeStackScreenProps<DeviceNamingSceens, 'DeviceNaming'>) => {
+}: NativeStackScreenProps<DeviceNamingParamList, 'DeviceNaming'>) => {
   const [name, setName] = React.useState('');
   const [errorTimeout, setErrorTimeout] = useTemporaryError();
   const invalidName = name.length === 0 || name.length > 60;

--- a/src/frontend/screens/DeviceNaming.tsx
+++ b/src/frontend/screens/DeviceNaming.tsx
@@ -13,7 +13,7 @@ import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {TouchableWithoutFeedback} from 'react-native-gesture-handler';
 import {defineMessages, useIntl} from 'react-intl';
-import {DeviceNamingParamList} from '../sharedTypes/navigation';
+import {DeviceNamingParamsList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   header: {
@@ -33,7 +33,7 @@ const m = defineMessages({
 
 export const DeviceNaming = ({
   navigation,
-}: NativeStackScreenProps<DeviceNamingParamList, 'DeviceNaming'>) => {
+}: NativeStackScreenProps<DeviceNamingParamsList, 'DeviceNaming'>) => {
   const [name, setName] = React.useState('');
   const [errorTimeout, setErrorTimeout] = useTemporaryError();
   const invalidName = name.length === 0 || name.length > 60;

--- a/src/frontend/screens/IntroToCoMapeo.tsx
+++ b/src/frontend/screens/IntroToCoMapeo.tsx
@@ -8,7 +8,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {DeviceNamingSceens} from '../sharedTypes/navigation';
+import {DeviceNamingParamList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   isNow: {
@@ -34,7 +34,7 @@ const m = defineMessages({
 
 export const IntroToCoMapeo = ({
   navigation,
-}: NativeStackScreenProps<DeviceNamingSceens, 'IntroToCoMapeo'>) => {
+}: NativeStackScreenProps<DeviceNamingParamList, 'IntroToCoMapeo'>) => {
   const {formatMessage} = useIntl();
   return (
     <View style={{backgroundColor: COMAPEO_DARK_BLUE}}>

--- a/src/frontend/screens/IntroToCoMapeo.tsx
+++ b/src/frontend/screens/IntroToCoMapeo.tsx
@@ -8,7 +8,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {DeviceNamingSceens} from '../Navigation/Stack/DeviceNamingScreens';
+import {DeviceNamingSceens} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   isNow: {

--- a/src/frontend/screens/IntroToCoMapeo.tsx
+++ b/src/frontend/screens/IntroToCoMapeo.tsx
@@ -8,7 +8,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {DeviceNamingParamList} from '../sharedTypes/navigation';
+import {DeviceNamingParamsList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   isNow: {
@@ -34,7 +34,7 @@ const m = defineMessages({
 
 export const IntroToCoMapeo = ({
   navigation,
-}: NativeStackScreenProps<DeviceNamingParamList, 'IntroToCoMapeo'>) => {
+}: NativeStackScreenProps<DeviceNamingParamsList, 'IntroToCoMapeo'>) => {
   const {formatMessage} = useIntl();
   return (
     <View style={{backgroundColor: COMAPEO_DARK_BLUE}}>

--- a/src/frontend/screens/ManualGpsScreen/index.tsx
+++ b/src/frontend/screens/ManualGpsScreen/index.tsx
@@ -24,10 +24,7 @@ import {IconButton} from '../../sharedComponents/IconButton';
 import SaveCheck from '../../images/CheckMark.svg';
 import {Select} from '../../sharedComponents/Select';
 import {Text} from '../../sharedComponents/Text';
-import {
-  type NativeRootNavigationProps,
-  type CoordinateFormat,
-} from '../../sharedTypes';
+import {type CoordinateFormat} from '../../sharedTypes';
 
 import {
   latitudeIsValid,
@@ -38,6 +35,7 @@ import {DdForm} from './DdForm';
 import {DmsForm} from './DmsForm';
 import {UtmForm} from './UtmForm';
 import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
+import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/ObscurePasscode.tsx
+++ b/src/frontend/screens/ObscurePasscode.tsx
@@ -6,10 +6,10 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import {OBSCURE_PASSCODE} from '../constants';
 import {LIGHT_GREY} from '../lib/styles';
 import {Text} from '../sharedComponents/Text';
-import {NativeNavigationComponent} from '../sharedTypes';
 import {ScrollView, TouchableOpacity} from 'react-native-gesture-handler';
 import {useSecurityContext} from '../contexts/SecurityContext';
 import {usePersistedPasscode} from '../hooks/persistedState/usePersistedPasscode';
+import {NativeNavigationComponent} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -12,7 +12,7 @@ import {useFieldsQuery} from '../../hooks/server/fields';
 import {FieldDetails} from './FieldDetails';
 import {InsetMapView} from './InsetMapView';
 import {ButtonFields} from './Buttons';
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {ObservationHeaderRight} from './ObservationHeaderRight';
 
 const m = defineMessages({

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {MessageDescriptor, defineMessages, useIntl} from 'react-intl';
 
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
 import {View, ScrollView, StyleSheet} from 'react-native';
 import {LocationView} from './LocationView';

--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -4,12 +4,12 @@ import {ObservationListItem} from './ObservationListItem';
 import ObservationEmptyView from './ObservationsEmptyView';
 
 import {Observation} from '@mapeo/schema';
-import {NativeHomeTabsNavigationProps} from '../../sharedTypes';
 import {useAllObservations} from '../../hooks/useAllObservations';
 import {MessageDescriptor, defineMessages} from 'react-intl';
 import {BottomTabNavigationOptions} from '@react-navigation/bottom-tabs';
 import {ObservationsListBarIcon} from '../../Navigation/Tab/TabBar/ObservationsListTabBarIcon';
 import {ObservationListHeaderLeft} from './ObservationListHeaderLeft';
+import {NativeHomeTabsNavigationProps} from '../../sharedTypes/navigation';
 
 const m = defineMessages({
   loading: {

--- a/src/frontend/screens/PresetChooser.tsx
+++ b/src/frontend/screens/PresetChooser.tsx
@@ -12,7 +12,7 @@ import {defineMessages, FormattedMessage} from 'react-intl';
 import {useDraftObservation} from '../hooks/useDraftObservation';
 import {CategoryCircleIcon} from '../sharedComponents/icons/CategoryIcon';
 import {WHITE} from '../lib/styles';
-import {NativeNavigationComponent} from '../sharedTypes';
+import {NativeNavigationComponent} from '../sharedTypes/navigation';
 import {CustomHeaderLeftClose} from '../sharedComponents/CustomHeaderLeftClose';
 import {CustomHeaderLeft} from '../sharedComponents/CustomHeaderLeft';
 import {Preset} from '@mapeo/schema';

--- a/src/frontend/screens/Security/index.tsx
+++ b/src/frontend/screens/Security/index.tsx
@@ -4,7 +4,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {FormattedMessage, defineMessages} from 'react-intl';
 
 import {List, ListItem, ListItemText} from '../../sharedComponents/List';
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {MEDIUM_GREY, RED} from '../../lib/styles';
 import {Text} from 'react-native';
 import {useSecurityContext} from '../../contexts/SecurityContext';

--- a/src/frontend/screens/Settings/AppSettings/index.tsx
+++ b/src/frontend/screens/Settings/AppSettings/index.tsx
@@ -6,7 +6,7 @@ import {
   ListItemIcon,
 } from '../../../sharedComponents/List';
 import {FormattedMessage, defineMessages} from 'react-intl';
-import {NativeNavigationComponent} from '../../../sharedTypes';
+import {NativeNavigationComponent} from '../../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {BackHandler, StyleSheet, View} from 'react-native';
 import GreenCheck from '../../../../images/GreenCheck.svg';
-import {NativeRootNavigationProps} from '../../../../sharedTypes';
+import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {Text} from '../../../../sharedComponents/Text';
 import {Button} from '../../../../sharedComponents/Button';
 import {CommonActions, useFocusEffect} from '@react-navigation/native';

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -1,5 +1,5 @@
 import {defineMessages, useIntl} from 'react-intl';
-import {NativeNavigationComponent} from '../../../../sharedTypes';
+import {NativeNavigationComponent} from '../../../../sharedTypes/navigation';
 import {Keyboard, KeyboardAvoidingView, StyleSheet, View} from 'react-native';
 import {useForm} from 'react-hook-form';
 import {Text} from '../../../../sharedComponents/Text';

--- a/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
@@ -3,7 +3,7 @@ import {Text} from '../../../sharedComponents/Text';
 import {defineMessages, useIntl} from 'react-intl';
 import {Button} from '../../../sharedComponents/Button';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {AppStackList} from '../../../Navigation/Stack';
+import {AppStackList} from '../../../sharedTypes/navigation';
 
 const m = defineMessages({
   howTo: {

--- a/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
@@ -3,7 +3,7 @@ import {Text} from '../../../sharedComponents/Text';
 import {defineMessages, useIntl} from 'react-intl';
 import {Button} from '../../../sharedComponents/Button';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {AppStackList} from '../../../sharedTypes/navigation';
+import {AppStackParamsList} from '../../../sharedTypes/navigation';
 
 const m = defineMessages({
   howTo: {
@@ -23,7 +23,7 @@ const m = defineMessages({
 
 export const JoinExistingProject = ({
   navigation,
-}: NativeStackScreenProps<AppStackList, 'JoinExistingProject'>) => {
+}: NativeStackScreenProps<AppStackParamsList, 'JoinExistingProject'>) => {
   const {formatMessage} = useIntl();
   return (
     <View style={styles.container}>

--- a/src/frontend/screens/Settings/ProjectSettings/DeviceName/DisplayScreen.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/DeviceName/DisplayScreen.tsx
@@ -3,7 +3,7 @@ import {ScrollView, StyleSheet} from 'react-native';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import {MessageDescriptor, defineMessages, useIntl} from 'react-intl';
 
-import {NativeRootNavigationProps} from '../../../../sharedTypes';
+import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {useDeviceInfo} from '../../../../hooks/server/deviceInfo';
 import {Text} from '../../../../sharedComponents/Text';
 import {IconButton} from '../../../../sharedComponents/IconButton';

--- a/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
@@ -5,7 +5,7 @@ import {MessageDescriptor, defineMessages, useIntl} from 'react-intl';
 import {useForm} from 'react-hook-form';
 import {UIActivityIndicator} from 'react-native-indicators';
 
-import {NativeRootNavigationProps} from '../../../../sharedTypes';
+import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {
   useDeviceInfo,
   useEditDeviceInfo,

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
@@ -3,7 +3,7 @@ import GreenCheck from '../../../../images/GreenCheck.svg';
 import {Text} from '../../../../sharedComponents/Text';
 import {defineMessages, useIntl} from 'react-intl';
 import React from 'react';
-import {NativeRootNavigationProps} from '../../../../sharedTypes';
+import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {DeviceNameWithIcon} from '../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../sharedComponents/RoleWithIcon';
 import {Button} from '../../../../sharedComponents/Button';

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
@@ -5,7 +5,7 @@ import ErrorIcon from '../../../../images/Error.svg';
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../../../../sharedComponents/Text';
 import {DeviceNameWithIcon} from '../../../../sharedComponents/DeviceNameWithIcon';
-import {NativeRootNavigationProps} from '../../../../sharedTypes';
+import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {useFocusEffect} from '@react-navigation/native';
 
 const m = defineMessages({

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
@@ -7,9 +7,8 @@ import {WHITE} from '../../../../../lib/styles';
 import {Button} from '../../../../../sharedComponents/Button';
 import {DeviceNameWithIcon} from '../../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../../sharedComponents/RoleWithIcon';
-import {DeviceType} from '../../../../../sharedTypes';
 import {MEMBER_ROLE_ID} from '../../../../../sharedTypes';
-import {DeviceRole} from '../../../../../sharedTypes/navigation';
+import {DeviceRole, DeviceType} from '../../../../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
@@ -7,8 +7,9 @@ import {WHITE} from '../../../../../lib/styles';
 import {Button} from '../../../../../sharedComponents/Button';
 import {DeviceNameWithIcon} from '../../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../../sharedComponents/RoleWithIcon';
-import {DeviceRole, DeviceType} from '../../../../../sharedTypes';
+import {DeviceType} from '../../../../../sharedTypes';
 import {MEMBER_ROLE_ID} from '../../../../../sharedTypes';
+import {DeviceRole} from '../../../../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
@@ -7,8 +7,8 @@ import {WHITE} from '../../../../../lib/styles';
 import {Button} from '../../../../../sharedComponents/Button';
 import {DeviceNameWithIcon} from '../../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../../sharedComponents/RoleWithIcon';
-import {MEMBER_ROLE_ID} from '../../../../../sharedTypes';
-import {DeviceRole, DeviceType} from '../../../../../sharedTypes/navigation';
+import {DeviceType, MEMBER_ROLE_ID} from '../../../../../sharedTypes';
+import {DeviceRole} from '../../../../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/ReviewInvitation.tsx
@@ -8,7 +8,7 @@ import {Button} from '../../../../../sharedComponents/Button';
 import {DeviceNameWithIcon} from '../../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../../sharedComponents/RoleWithIcon';
 import {DeviceType, MEMBER_ROLE_ID} from '../../../../../sharedTypes';
-import {DeviceRole} from '../../../../../sharedTypes/navigation';
+import {DeviceRole} from '../../../../../sharedTypes';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
@@ -6,11 +6,9 @@ import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../../../../../sharedComponents/Text';
 import {DeviceNameWithIcon} from '../../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../../sharedComponents/RoleWithIcon';
-import {
-  COORDINATOR_ROLE_ID,
-  NativeRootNavigationProps,
-} from '../../../../../sharedTypes';
+import {COORDINATOR_ROLE_ID} from '../../../../../sharedTypes';
 import {useProjectSettings} from '../../../../../hooks/server/projects';
+import {NativeRootNavigationProps} from '../../../../../sharedTypes/navigation';
 
 const m = defineMessages({
   unableToCancel: {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {NativeNavigationComponent} from '../../../../../sharedTypes';
+import {NativeNavigationComponent} from '../../../../../sharedTypes/navigation';
 import {defineMessages} from 'react-intl';
 import {useBottomSheetModal} from '../../../../../sharedComponents/BottomSheetModal';
 import {ErrorModal} from '../../../../../sharedComponents/ErrorModal';

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -1,5 +1,5 @@
 import {defineMessages, useIntl} from 'react-intl';
-import {NativeNavigationComponent} from '../../../../sharedTypes';
+import {NativeNavigationComponent} from '../../../../sharedTypes/navigation';
 import {ScrollView, StyleSheet, View} from 'react-native';
 import WifiIcon from '../../../../images/WifiIcon.svg';
 import {Text} from '../../../../sharedComponents/Text';

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -1,7 +1,7 @@
 import {ScrollView} from 'react-native';
 import {List, ListItem, ListItemText} from '../../../sharedComponents/List';
 import {FormattedMessage, defineMessages} from 'react-intl';
-import {NativeNavigationComponent} from '../../../sharedTypes';
+import {NativeNavigationComponent} from '../../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -8,7 +8,7 @@ import {
   ListItemText,
   ListItemIcon,
 } from '../../sharedComponents/List';
-import {NativeNavigationComponent} from '../../sharedTypes';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 const m = defineMessages({

--- a/src/frontend/screens/Success.tsx
+++ b/src/frontend/screens/Success.tsx
@@ -11,7 +11,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {useEditDeviceInfo} from '../hooks/server/deviceInfo';
 import {Loading} from '../sharedComponents/Loading';
 import {WHITE} from '../lib/styles';
-import {DeviceNamingParamList} from '../sharedTypes/navigation';
+import {DeviceNamingParamsList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   success: {
@@ -30,7 +30,7 @@ const m = defineMessages({
 
 export const Success = ({
   route,
-}: NativeStackScreenProps<DeviceNamingParamList, 'Success'>) => {
+}: NativeStackScreenProps<DeviceNamingParamsList, 'Success'>) => {
   const setDeviceName = useEditDeviceInfo();
   const deviceName = route.params.deviceName;
   const {formatMessage: t} = useIntl();

--- a/src/frontend/screens/Success.tsx
+++ b/src/frontend/screens/Success.tsx
@@ -11,7 +11,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {useEditDeviceInfo} from '../hooks/server/deviceInfo';
 import {Loading} from '../sharedComponents/Loading';
 import {WHITE} from '../lib/styles';
-import {DeviceNamingSceens} from '../sharedTypes/navigation';
+import {DeviceNamingParamList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   success: {
@@ -30,7 +30,7 @@ const m = defineMessages({
 
 export const Success = ({
   route,
-}: NativeStackScreenProps<DeviceNamingSceens, 'Success'>) => {
+}: NativeStackScreenProps<DeviceNamingParamList, 'Success'>) => {
   const setDeviceName = useEditDeviceInfo();
   const deviceName = route.params.deviceName;
   const {formatMessage: t} = useIntl();

--- a/src/frontend/screens/Success.tsx
+++ b/src/frontend/screens/Success.tsx
@@ -8,10 +8,10 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {Text} from '../sharedComponents/Text';
 import {Button} from '../sharedComponents/Button';
 import {defineMessages, useIntl} from 'react-intl';
-import {DeviceNamingSceens} from '../Navigation/Stack/DeviceNamingScreens';
 import {useEditDeviceInfo} from '../hooks/server/deviceInfo';
 import {Loading} from '../sharedComponents/Loading';
 import {WHITE} from '../lib/styles';
+import {DeviceNamingSceens} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   success: {

--- a/src/frontend/screens/Sync/index.tsx
+++ b/src/frontend/screens/Sync/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 
-import {NativeRootNavigationProps} from '../../sharedTypes';
+import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {IconButton} from '../../sharedComponents/IconButton';
 import {SettingsIcon} from '../../sharedComponents/icons';
 import {useAllProjects, useProjectSettings} from '../../hooks/server/projects';

--- a/src/frontend/sharedComponents/DeviceCard.tsx
+++ b/src/frontend/sharedComponents/DeviceCard.tsx
@@ -1,9 +1,10 @@
 import {StyleSheet} from 'react-native';
 import {LIGHT_GREY} from '../lib/styles';
-import {DeviceType, ViewStyleProp} from '../sharedTypes';
+import {ViewStyleProp} from '../sharedTypes';
 import {defineMessages, useIntl} from 'react-intl';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {DeviceNameWithIcon} from './DeviceNameWithIcon';
+import {DeviceType} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   thisDevice: {

--- a/src/frontend/sharedComponents/DeviceCard.tsx
+++ b/src/frontend/sharedComponents/DeviceCard.tsx
@@ -1,10 +1,9 @@
 import {StyleSheet} from 'react-native';
 import {LIGHT_GREY} from '../lib/styles';
-import {ViewStyleProp} from '../sharedTypes';
+import {DeviceType, ViewStyleProp} from '../sharedTypes';
 import {defineMessages, useIntl} from 'react-intl';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {DeviceNameWithIcon} from './DeviceNameWithIcon';
-import {DeviceType} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   thisDevice: {

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -6,7 +6,7 @@ import {ViewStyleProp} from '../sharedTypes';
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from './Text';
 import {MEDIUM_GREY} from '../lib/styles';
-import {DeviceType} from '../sharedTypes/navigation';
+import {DeviceType} from '../sharedTypes';
 
 const m = defineMessages({
   thisDevice: {

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import {View, StyleSheet} from 'react-native';
 import DeviceMobile from '../images/DeviceMobile.svg';
 import DeviceDesktop from '../images/DeviceDesktop.svg';
-import {DeviceType, ViewStyleProp} from '../sharedTypes';
+import {ViewStyleProp} from '../sharedTypes';
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from './Text';
 import {MEDIUM_GREY} from '../lib/styles';
+import {DeviceType} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   thisDevice: {

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,7 +1,6 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {Observation, ObservationValue} from '@mapeo/schema';
-import {AppStackList, HomeTabsList} from './navigation';
+import {HomeTabsList} from './navigation';
 export interface TabBarIconProps {
   size: number;
   focused: boolean;
@@ -15,9 +14,6 @@ export type TextStyleProp = StyleProp<TextStyle>;
 export type ImageStyleProp = StyleProp<ImageStyle>;
 
 export type IconSize = 'small' | 'medium' | 'large';
-
-export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
-  NativeStackScreenProps<AppStackList, ScreenName>;
 
 export type Status = 'idle' | 'loading' | 'error' | 'success' | void;
 

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,8 +1,5 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
-import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
-import {CompositeScreenProps} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-
 import {MessageDescriptor} from 'react-intl';
 import {Observation, ObservationValue} from '@mapeo/schema';
 import {AppStackList, HomeTabsList} from './navigation';
@@ -34,13 +31,6 @@ export type NativeNavigationScreenWithProps<
 > = React.FC<NativeStackScreenProps<AppStackList, ScreenName> & T> & {
   navTitle: MessageDescriptor;
 };
-
-export type NativeHomeTabsNavigationProps<
-  ScreenName extends keyof HomeTabsList,
-> = CompositeScreenProps<
-  BottomTabScreenProps<HomeTabsList, ScreenName>,
-  NativeStackScreenProps<AppStackList>
->;
 
 export type Status = 'idle' | 'loading' | 'error' | 'success' | void;
 

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -5,7 +5,6 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {MessageDescriptor} from 'react-intl';
 import {Observation, ObservationValue} from '@mapeo/schema';
-import type {RoleId} from '@mapeo/core/dist/roles';
 import {AppStackList, HomeTabsList} from './navigation';
 export interface TabBarIconProps {
   size: number;
@@ -57,8 +56,6 @@ export type PhotoVariant = 'original' | 'thumbnail' | 'preview';
 
 export type CoordinateFormat = 'utm' | 'dd' | 'dms';
 export type DeviceType = 'mobile' | 'desktop';
-
-export type DeviceRole = RoleId;
 
 // Copied form /@mapeo/core/src/roles.js. Created an issue to eventuall expose this: https://github.com/digidem/mapeo-core-next/issues/532
 export const CREATOR_ROLE_ID = 'a12a6702b93bd7ff';

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -6,8 +6,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {MessageDescriptor} from 'react-intl';
 import {Observation, ObservationValue} from '@mapeo/schema';
 import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
-import {type HomeTabsList} from '../Navigation/Tab';
-import {AppStackList} from './navigation';
+import {AppStackList, HomeTabsList} from './navigation';
 export interface TabBarIconProps {
   size: number;
   focused: boolean;

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,4 +1,3 @@
-// TS port of /src/frontend/types.js
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
 import {CompositeScreenProps} from '@react-navigation/native';

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,6 +1,5 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
-import {MessageDescriptor} from 'react-intl';
 import {Observation, ObservationValue} from '@mapeo/schema';
 import {AppStackList, HomeTabsList} from './navigation';
 export interface TabBarIconProps {
@@ -19,11 +18,6 @@ export type IconSize = 'small' | 'medium' | 'large';
 
 export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
   NativeStackScreenProps<AppStackList, ScreenName>;
-
-export type NativeNavigationComponent<ScreenName extends keyof AppStackList> =
-  React.FC<NativeRootNavigationProps<ScreenName>> & {
-    navTitle: MessageDescriptor;
-  };
 
 export type Status = 'idle' | 'loading' | 'error' | 'success' | void;
 

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -55,7 +55,6 @@ export type Attachment = Observation['attachments'][0];
 export type PhotoVariant = 'original' | 'thumbnail' | 'preview';
 
 export type CoordinateFormat = 'utm' | 'dd' | 'dms';
-export type DeviceType = 'mobile' | 'desktop';
 
 // Copied form /@mapeo/core/src/roles.js. Created an issue to eventuall expose this: https://github.com/digidem/mapeo-core-next/issues/532
 export const CREATOR_ROLE_ID = 'a12a6702b93bd7ff';

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -25,13 +25,6 @@ export type NativeNavigationComponent<ScreenName extends keyof AppStackList> =
     navTitle: MessageDescriptor;
   };
 
-export type NativeNavigationScreenWithProps<
-  ScreenName extends keyof AppStackList,
-  T,
-> = React.FC<NativeStackScreenProps<AppStackList, ScreenName> & T> & {
-  navTitle: MessageDescriptor;
-};
-
 export type Status = 'idle' | 'loading' | 'error' | 'success' | void;
 
 export type Position = Observation['metadata']['position'];

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -15,13 +15,6 @@ export interface TabBarIconProps {
 
 export type TabName = keyof HomeTabsList;
 
-export type InviteProps = {
-  name: string;
-  deviceType: DeviceType;
-  deviceId: string;
-  role: DeviceRoleForNewInvite;
-};
-
 export type ViewStyleProp = StyleProp<ViewStyle>;
 export type TextStyleProp = StyleProp<TextStyle>;
 export type ImageStyleProp = StyleProp<ImageStyle>;

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -4,10 +4,10 @@ import {CompositeScreenProps} from '@react-navigation/native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {MessageDescriptor} from 'react-intl';
-import {AppStackList} from '../Navigation/Stack';
 import {Observation, ObservationValue} from '@mapeo/schema';
 import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
 import {type HomeTabsList} from '../Navigation/Tab';
+import {AppStackList} from './navigation';
 export interface TabBarIconProps {
   size: number;
   focused: boolean;

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,13 +1,10 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {Observation, ObservationValue} from '@mapeo/schema';
-import {HomeTabsList} from './navigation';
 export interface TabBarIconProps {
   size: number;
   focused: boolean;
   color: string;
 }
-
-export type TabName = keyof HomeTabsList;
 
 export type ViewStyleProp = StyleProp<ViewStyle>;
 export type TextStyleProp = StyleProp<TextStyle>;

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -5,7 +5,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {MessageDescriptor} from 'react-intl';
 import {Observation, ObservationValue} from '@mapeo/schema';
-import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
+import type {RoleId} from '@mapeo/core/dist/roles';
 import {AppStackList, HomeTabsList} from './navigation';
 export interface TabBarIconProps {
   size: number;
@@ -59,7 +59,6 @@ export type CoordinateFormat = 'utm' | 'dd' | 'dms';
 export type DeviceType = 'mobile' | 'desktop';
 
 export type DeviceRole = RoleId;
-export type DeviceRoleForNewInvite = RoleIdForNewInvite;
 
 // Copied form /@mapeo/core/src/roles.js. Created an issue to eventuall expose this: https://github.com/digidem/mapeo-core-next/issues/532
 export const CREATOR_ROLE_ID = 'a12a6702b93bd7ff';

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,10 +1,5 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {Observation, ObservationValue} from '@mapeo/schema';
-export interface TabBarIconProps {
-  size: number;
-  focused: boolean;
-  color: string;
-}
 
 export type ViewStyleProp = StyleProp<ViewStyle>;
 export type TextStyleProp = StyleProp<TextStyle>;

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,6 +1,8 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {Observation, ObservationValue} from '@mapeo/schema';
 
+export type DeviceType = 'mobile' | 'desktop';
+
 export type ViewStyleProp = StyleProp<ViewStyle>;
 export type TextStyleProp = StyleProp<TextStyle>;
 export type ImageStyleProp = StyleProp<ImageStyle>;

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,7 +1,12 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {Observation, ObservationValue} from '@mapeo/schema';
+import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
 
 export type DeviceType = 'mobile' | 'desktop';
+
+export type DeviceRole = RoleId;
+
+export type DeviceRoleForNewInvite = RoleIdForNewInvite;
 
 export type ViewStyleProp = StyleProp<ViewStyle>;
 export type TextStyleProp = StyleProp<TextStyle>;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -35,7 +35,7 @@ export type HomeTabsList = {
 
 export type TabName = keyof HomeTabsList;
 
-export type AppList = {
+export type RootStackParamList = {
   Home: NavigatorScreenParams<HomeTabsList>;
   GpsModal: undefined;
   Settings: undefined;
@@ -100,13 +100,13 @@ export type AppList = {
   Sync: undefined;
 };
 
-export type DeviceNamingParamList = {
+export type DeviceNamingParamsList = {
   IntroToCoMapeo: undefined;
   DeviceNaming: undefined;
   Success: {deviceName: string};
 };
 
-export type AppStackList = AppList & DeviceNamingParamList;
+export type AppStackList = RootStackParamList & DeviceNamingParamsList;
 
 export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
   NativeStackScreenProps<AppStackList, ScreenName>;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -1,5 +1,11 @@
-import {NavigatorScreenParams} from '@react-navigation/native';
+import {
+  CompositeScreenProps,
+  NavigatorScreenParams,
+} from '@react-navigation/native';
 import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {MessageDescriptor} from 'react-intl';
+import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
 
 export type InviteProps = {
   name: string;
@@ -85,3 +91,33 @@ export type AppList = {
   SaveTrack: undefined;
   Sync: undefined;
 };
+
+export type DeviceNamingSceens = {
+  IntroToCoMapeo: undefined;
+  DeviceNaming: undefined;
+  Success: {deviceName: string};
+};
+
+export type AppStackList = AppList & DeviceNamingSceens;
+
+export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
+  NativeStackScreenProps<AppStackList, ScreenName>;
+
+export type NativeNavigationComponent<ScreenName extends keyof AppStackList> =
+  React.FC<NativeRootNavigationProps<ScreenName>> & {
+    navTitle: MessageDescriptor;
+  };
+
+export type NativeNavigationScreenWithProps<
+  ScreenName extends keyof AppStackList,
+  T,
+> = React.FC<NativeStackScreenProps<AppStackList, ScreenName> & T> & {
+  navTitle: MessageDescriptor;
+};
+
+export type NativeHomeTabsNavigationProps<
+  ScreenName extends keyof HomeTabsList,
+> = CompositeScreenProps<
+  BottomTabScreenProps<HomeTabsList, ScreenName>,
+  NativeStackScreenProps<AppStackList>
+>;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -7,18 +7,18 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {MessageDescriptor} from 'react-intl';
 import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
 
+export type DeviceType = 'mobile' | 'desktop';
+
+export type DeviceRole = RoleId;
+
+export type DeviceRoleForNewInvite = RoleIdForNewInvite;
+
 export type InviteProps = {
   name: string;
   deviceType: DeviceType;
   deviceId: string;
   role: DeviceRoleForNewInvite;
 };
-
-export type DeviceType = 'mobile' | 'desktop';
-
-export type DeviceRole = RoleId;
-
-export type DeviceRoleForNewInvite = RoleIdForNewInvite;
 
 export type HomeTabsList = {
   Map: undefined;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -100,13 +100,13 @@ export type AppList = {
   Sync: undefined;
 };
 
-export type DeviceNamingSceens = {
+export type DeviceNamingParamList = {
   IntroToCoMapeo: undefined;
   DeviceNaming: undefined;
   Success: {deviceName: string};
 };
 
-export type AppStackList = AppList & DeviceNamingSceens;
+export type AppStackList = AppList & DeviceNamingParamList;
 
 export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
   NativeStackScreenProps<AppStackList, ScreenName>;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -26,17 +26,17 @@ export type InviteProps = {
   role: DeviceRoleForNewInvite;
 };
 
-export type HomeTabsList = {
+export type HomeTabsParamsList = {
   Map: undefined;
   Camera: undefined;
   Tracking: undefined;
   ObservationsList: undefined;
 };
 
-export type TabName = keyof HomeTabsList;
+export type TabName = keyof HomeTabsParamsList;
 
 export type RootStackParamList = {
-  Home: NavigatorScreenParams<HomeTabsList>;
+  Home: NavigatorScreenParams<HomeTabsParamsList>;
   GpsModal: undefined;
   Settings: undefined;
   ProjectConfig: undefined;
@@ -117,8 +117,8 @@ export type NativeNavigationComponent<ScreenName extends keyof AppStackList> =
   };
 
 export type NativeHomeTabsNavigationProps<
-  ScreenName extends keyof HomeTabsList,
+  ScreenName extends keyof HomeTabsParamsList,
 > = CompositeScreenProps<
-  BottomTabScreenProps<HomeTabsList, ScreenName>,
+  BottomTabScreenProps<HomeTabsParamsList, ScreenName>,
   NativeStackScreenProps<AppStackList>
 >;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -29,7 +29,7 @@ export type HomeTabsParamsList = {
 
 export type TabName = keyof HomeTabsParamsList;
 
-export type RootStackParamList = {
+export type RootStackParamsList = {
   Home: NavigatorScreenParams<HomeTabsParamsList>;
   GpsModal: undefined;
   Settings: undefined;
@@ -100,7 +100,7 @@ export type DeviceNamingParamsList = {
   Success: {deviceName: string};
 };
 
-export type AppStackList = RootStackParamList & DeviceNamingParamsList;
+export type AppStackList = RootStackParamsList & DeviceNamingParamsList;
 
 export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
   NativeStackScreenProps<AppStackList, ScreenName>;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -2,21 +2,16 @@ import {
   CompositeScreenProps,
   NavigatorScreenParams,
 } from '@react-navigation/native';
-import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {MessageDescriptor} from 'react-intl';
 import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
-import {DeviceType} from '.';
+import {DeviceRoleForNewInvite, DeviceType} from '.';
 
 export interface TabBarIconProps {
   size: number;
   focused: boolean;
   color: string;
 }
-
-export type DeviceRole = RoleId;
-
-export type DeviceRoleForNewInvite = RoleIdForNewInvite;
 
 export type InviteProps = {
   name: string;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -108,13 +108,6 @@ export type NativeNavigationComponent<ScreenName extends keyof AppStackList> =
     navTitle: MessageDescriptor;
   };
 
-export type NativeNavigationScreenWithProps<
-  ScreenName extends keyof AppStackList,
-  T,
-> = React.FC<NativeStackScreenProps<AppStackList, ScreenName> & T> & {
-  navTitle: MessageDescriptor;
-};
-
 export type NativeHomeTabsNavigationProps<
   ScreenName extends keyof HomeTabsList,
 > = CompositeScreenProps<

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -1,0 +1,87 @@
+import {NavigatorScreenParams} from '@react-navigation/native';
+import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
+
+export type InviteProps = {
+  name: string;
+  deviceType: DeviceType;
+  deviceId: string;
+  role: DeviceRoleForNewInvite;
+};
+
+export type DeviceType = 'mobile' | 'desktop';
+
+export type DeviceRole = RoleId;
+
+export type DeviceRoleForNewInvite = RoleIdForNewInvite;
+
+export type HomeTabsList = {
+  Map: undefined;
+  Camera: undefined;
+  Tracking: undefined;
+  ObservationsList: undefined;
+};
+
+export type AppList = {
+  Home: NavigatorScreenParams<HomeTabsList>;
+  GpsModal: undefined;
+  Settings: undefined;
+  ProjectConfig: undefined;
+  AboutMapeo: undefined;
+  LanguageSettings: undefined;
+  CoordinateFormat: undefined;
+  Experiments: undefined;
+  PhotosModal: {
+    photoIndex: number;
+    observationId?: string;
+    editing: boolean;
+  };
+  PhotoView: undefined;
+  PresetChooser: undefined;
+  AddPhoto: undefined;
+  Observation: {observationId: string};
+  ObservationEdit: {observationId?: string} | undefined;
+  ManualGpsScreen: undefined;
+  ObservationDetails: {question: number};
+  LeaveProjectScreen: undefined;
+  AlreadyOnProj: undefined;
+  AddToProjectScreen: undefined;
+  UnableToLinkScreen: undefined;
+  ConnectingToDeviceScreen: {task: () => Promise<void>};
+  ConfirmLeavePracticeModeScreen: {projectAction: 'join' | 'create'};
+  CreateProject: undefined;
+  Security: undefined;
+  DirectionalArrow: undefined;
+  P2pUpgrade: undefined;
+  MapSettings: undefined;
+  BackgroundMaps: undefined;
+  BackgroundMapInfo: {
+    bytesStored: number;
+    id: string;
+    styleUrl: string;
+    name: string;
+  };
+  BGMapsSettings: undefined;
+  AuthScreen: undefined;
+  AppPasscode: undefined;
+  ObscurePasscode: undefined;
+  ConfirmPasscodeSheet: {passcode: string};
+  DisablePasscode: undefined;
+  SetPasscode: undefined;
+  EnterPassToTurnOff: undefined;
+  AppSettings: undefined;
+  ProjectSettings: undefined;
+  CreateOrJoinProject: undefined;
+  ProjectCreated: {name: string};
+  JoinExistingProject: undefined;
+  YourTeam: undefined;
+  SelectDevice: undefined;
+  SelectInviteeRole: {name: string; deviceType: DeviceType; deviceId: string};
+  ReviewAndInvite: InviteProps;
+  InviteAccepted: InviteProps;
+  InviteDeclined: InviteProps;
+  UnableToCancelInvite: InviteProps;
+  DeviceNameDisplay: undefined;
+  DeviceNameEdit: undefined;
+  SaveTrack: undefined;
+  Sync: undefined;
+};

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -6,14 +6,13 @@ import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {MessageDescriptor} from 'react-intl';
 import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
+import {DeviceType} from '.';
 
 export interface TabBarIconProps {
   size: number;
   focused: boolean;
   color: string;
 }
-
-export type DeviceType = 'mobile' | 'desktop';
 
 export type DeviceRole = RoleId;
 

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -100,19 +100,21 @@ export type DeviceNamingParamsList = {
   Success: {deviceName: string};
 };
 
-export type AppStackList = RootStackParamsList & DeviceNamingParamsList;
+export type AppStackParamsList = RootStackParamsList & DeviceNamingParamsList;
 
-export type NativeRootNavigationProps<ScreenName extends keyof AppStackList> =
-  NativeStackScreenProps<AppStackList, ScreenName>;
+export type NativeRootNavigationProps<
+  ScreenName extends keyof AppStackParamsList,
+> = NativeStackScreenProps<AppStackParamsList, ScreenName>;
 
-export type NativeNavigationComponent<ScreenName extends keyof AppStackList> =
-  React.FC<NativeRootNavigationProps<ScreenName>> & {
-    navTitle: MessageDescriptor;
-  };
+export type NativeNavigationComponent<
+  ScreenName extends keyof AppStackParamsList,
+> = React.FC<NativeRootNavigationProps<ScreenName>> & {
+  navTitle: MessageDescriptor;
+};
 
 export type NativeHomeTabsNavigationProps<
   ScreenName extends keyof HomeTabsParamsList,
 > = CompositeScreenProps<
   BottomTabScreenProps<HomeTabsParamsList, ScreenName>,
-  NativeStackScreenProps<AppStackList>
+  NativeStackScreenProps<AppStackParamsList>
 >;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -7,6 +7,12 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {MessageDescriptor} from 'react-intl';
 import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
 
+export interface TabBarIconProps {
+  size: number;
+  focused: boolean;
+  color: string;
+}
+
 export type DeviceType = 'mobile' | 'desktop';
 
 export type DeviceRole = RoleId;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -27,6 +27,8 @@ export type HomeTabsList = {
   ObservationsList: undefined;
 };
 
+export type TabName = keyof HomeTabsList;
+
 export type AppList = {
   Home: NavigatorScreenParams<HomeTabsList>;
   GpsModal: undefined;

--- a/src/frontend/utils/navigation.ts
+++ b/src/frontend/utils/navigation.ts
@@ -1,7 +1,7 @@
 import {ClientGeneratedObservation} from '../sharedTypes';
 import {Observation, Preset} from '@mapeo/schema';
 import {matchPreset} from '../lib/utils';
-import {AppList, DeviceNamingSceens} from '../sharedTypes/navigation';
+import {AppList, DeviceNamingParamList} from '../sharedTypes/navigation';
 
 export function getInitialRouteName(
   initialInfo:
@@ -11,7 +11,7 @@ export function getInitialRouteName(
         existingObservation: null | ClientGeneratedObservation | Observation;
         presets: Preset[];
       },
-): keyof AppList | keyof DeviceNamingSceens {
+): keyof AppList | keyof DeviceNamingParamList {
   // if user has not set a name, navigate to intro screen where they will be prompted to set a name
   if (!initialInfo.hasDeviceName) {
     return 'IntroToCoMapeo';

--- a/src/frontend/utils/navigation.ts
+++ b/src/frontend/utils/navigation.ts
@@ -1,7 +1,10 @@
 import {ClientGeneratedObservation} from '../sharedTypes';
 import {Observation, Preset} from '@mapeo/schema';
 import {matchPreset} from '../lib/utils';
-import {AppList, DeviceNamingParamList} from '../sharedTypes/navigation';
+import {
+  RootStackParamList,
+  DeviceNamingParamsList,
+} from '../sharedTypes/navigation';
 
 export function getInitialRouteName(
   initialInfo:
@@ -11,7 +14,7 @@ export function getInitialRouteName(
         existingObservation: null | ClientGeneratedObservation | Observation;
         presets: Preset[];
       },
-): keyof AppList | keyof DeviceNamingParamList {
+): keyof RootStackParamList | keyof DeviceNamingParamsList {
   // if user has not set a name, navigate to intro screen where they will be prompted to set a name
   if (!initialInfo.hasDeviceName) {
     return 'IntroToCoMapeo';

--- a/src/frontend/utils/navigation.ts
+++ b/src/frontend/utils/navigation.ts
@@ -1,8 +1,8 @@
-import {DeviceNamingSceens} from '../Navigation/Stack/DeviceNamingScreens';
 import {ClientGeneratedObservation} from '../sharedTypes';
 import {Observation, Preset} from '@mapeo/schema';
 import {AppList} from '../Navigation/Stack/AppScreens';
 import {matchPreset} from '../lib/utils';
+import {DeviceNamingSceens} from '../sharedTypes/navigation';
 
 export function getInitialRouteName(
   initialInfo:

--- a/src/frontend/utils/navigation.ts
+++ b/src/frontend/utils/navigation.ts
@@ -1,8 +1,7 @@
 import {ClientGeneratedObservation} from '../sharedTypes';
 import {Observation, Preset} from '@mapeo/schema';
-import {AppList} from '../Navigation/Stack/AppScreens';
 import {matchPreset} from '../lib/utils';
-import {DeviceNamingSceens} from '../sharedTypes/navigation';
+import {AppList, DeviceNamingSceens} from '../sharedTypes/navigation';
 
 export function getInitialRouteName(
   initialInfo:

--- a/src/frontend/utils/navigation.ts
+++ b/src/frontend/utils/navigation.ts
@@ -2,7 +2,7 @@ import {ClientGeneratedObservation} from '../sharedTypes';
 import {Observation, Preset} from '@mapeo/schema';
 import {matchPreset} from '../lib/utils';
 import {
-  RootStackParamList,
+  RootStackParamsList,
   DeviceNamingParamsList,
 } from '../sharedTypes/navigation';
 
@@ -14,7 +14,7 @@ export function getInitialRouteName(
         existingObservation: null | ClientGeneratedObservation | Observation;
         presets: Preset[];
       },
-): keyof RootStackParamList | keyof DeviceNamingParamsList {
+): keyof RootStackParamsList | keyof DeviceNamingParamsList {
   // if user has not set a name, navigate to intro screen where they will be prompted to set a name
   if (!initialInfo.hasDeviceName) {
     return 'IntroToCoMapeo';


### PR DESCRIPTION
creates a `sharedTypes/navigation.ts` file, and updates all the types related to navigation to live in this file.

PR was created with atomic commits, so can be reviewed by commit.