### PR TITLE
chore: downgrade expo-updates to expected version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "expo-status-bar": "~1.11.1",
         "expo-system-ui": "^2.9.4",
         "expo-task-manager": "~11.7.3",
-        "expo-updates": "^0.25.9",
+        "expo-updates": "~0.24.12",
         "geojson": "^0.5.0",
         "geojson-geometries-lookup": "^0.5.0",
         "lodash.isequal": "^4.5.0",
@@ -12873,9 +12873,9 @@
       }
     },
     "node_modules/expo-eas-client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.12.0.tgz",
-      "integrity": "sha512-Jkww9Cwpv0z7DdLYiRX0r4fqBEcI9cKqTn7cHx63S09JaZ2rcwEE4zYHgrXwjahO+tU2VW8zqH+AJl6RhhW4zA=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.11.2.tgz",
+      "integrity": "sha512-SY7rVFxb4ut/OMTgR7A39Jg+8+hXwQNRpZd+RBpB+B5XV2STj/pWXHnGFhBayEF4umI4SxrOvisY90rlPWVO9Q=="
     },
     "node_modules/expo-file-system": {
       "version": "16.0.9",
@@ -13087,9 +13087,9 @@
       "integrity": "sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg=="
     },
     "node_modules/expo-structured-headers": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-3.8.0.tgz",
-      "integrity": "sha512-R+gFGn0x5CWl4OVlk2j1bJTJIz4KO8mPoCHpRHmfqMjmrMvrOM0qQSY3V5NHXwp1yT/L2v8aUmFQsBRIdvi1XA=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-3.7.2.tgz",
+      "integrity": "sha512-/nGOyeWUXSUy4aIYKJTwQOznRNs0yKqKPAyEE6jtwvOl9qvfDWx9xskNtShioggBhFAssFkV6RBbPn+xZMQtvw=="
     },
     "node_modules/expo-system-ui": {
       "version": "2.9.4",
@@ -13115,24 +13115,20 @@
       }
     },
     "node_modules/expo-updates": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.25.9.tgz",
-      "integrity": "sha512-o2pyHhMYoTINIyqFNJq1gJOIKwySbZqxSI01bhHrOgVXJIPJmmqTFvD7p/s+XzG/NcHeyjCCS6VucR7Tif3h2g==",
+      "version": "0.24.12",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.24.12.tgz",
+      "integrity": "sha512-35ZpAMSqHIyVGT5mEptaZJBxytu0mv4PIG28i3BQe+GG4ifQtY94aCOCrUwZe8Myzaf4dNVGEUXWTPo+JPCgcw==",
       "dependencies": {
         "@expo/code-signing-certificates": "0.0.5",
-        "@expo/config": "~9.0.0-beta.0",
-        "@expo/config-plugins": "~8.0.0-beta.0",
-        "@expo/fingerprint": "^0.7.0",
-        "@expo/spawn-async": "^1.7.2",
+        "@expo/config": "~8.5.0",
+        "@expo/config-plugins": "~7.8.0",
         "arg": "4.1.0",
         "chalk": "^4.1.2",
-        "expo-eas-client": "~0.12.0",
-        "expo-manifests": "~0.14.0",
-        "expo-structured-headers": "~3.8.0",
-        "expo-updates-interface": "~0.16.0",
-        "fast-glob": "^3.3.2",
+        "expo-eas-client": "~0.11.0",
+        "expo-manifests": "~0.13.0",
+        "expo-structured-headers": "~3.7.0",
+        "expo-updates-interface": "~0.15.1",
         "fbemitter": "^3.0.0",
-        "ignore": "^5.3.1",
         "resolve-from": "^5.0.0"
       },
       "bin": {
@@ -13150,117 +13146,34 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-updates/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/expo-updates/node_modules/@expo/config": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-9.0.1.tgz",
-      "integrity": "sha512-0tjaXBstTbXmD4z+UMFBkh2SZFwilizSQhW6DlaTMnPG5ezuw93zSFEWAuEC3YzkpVtNQTmYzxAYjxwh6seOGg==",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~8.0.0-beta.0",
-        "@expo/config-types": "^51.0.0-unreleased",
-        "@expo/json-file": "^8.3.0",
-        "getenv": "^1.0.0",
-        "glob": "7.1.6",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "3.34.0"
-      }
-    },
     "node_modules/expo-updates/node_modules/@expo/config-plugins": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.4.tgz",
-      "integrity": "sha512-Hi+xuyNWE2LT4LVbGttHJgl9brnsdWAhEB42gWKb5+8ae86Nr/KwUBQJsJppirBYTeLjj5ZlY0glYnAkDa2jqw==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.8.4.tgz",
+      "integrity": "sha512-hv03HYxb/5kX8Gxv/BTI8TLc9L06WzqAfHRRXdbar4zkLcP2oTzvsLEF4/L/TIpD3rsnYa0KU42d0gWRxzPCJg==",
       "dependencies": {
-        "@expo/config-types": "^51.0.0-unreleased",
+        "@expo/config-types": "^50.0.0-alpha.1",
+        "@expo/fingerprint": "^0.6.0",
         "@expo/json-file": "~8.3.0",
         "@expo/plist": "^0.1.0",
         "@expo/sdk-runtime-versions": "^1.0.0",
+        "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.1",
         "find-up": "~5.0.0",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
+        "semver": "^7.5.3",
         "slash": "^3.0.0",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/expo-updates/node_modules/@expo/config-types": {
-      "version": "51.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-51.0.0.tgz",
-      "integrity": "sha512-acn03/u8mQvBhdTQtA7CNhevMltUhbSrpI01FYBJwpVntufkU++ncQujWKlgY/OwIajcfygk1AY4xcNZ5ImkRA=="
-    },
-    "node_modules/expo-updates/node_modules/@expo/fingerprint": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.7.1.tgz",
-      "integrity": "sha512-lbTwFiIk0lOm9zzPRvnC45GfPqXqPB3w4hDDKVma+8FDAbPCWhNN42ltLhx/ekwcHFQxURmg0fHm59k0Vy+jtw==",
-      "dependencies": {
-        "@expo/spawn-async": "^1.7.2",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.4",
-        "find-up": "^5.0.0",
-        "minimatch": "^3.0.4",
-        "p-limit": "^3.1.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0"
-      },
-      "bin": {
-        "fingerprint": "bin/cli.js"
-      }
-    },
-    "node_modules/expo-updates/node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
-    },
-    "node_modules/expo-updates/node_modules/expo-json-utils": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.13.1.tgz",
-      "integrity": "sha512-mlfaSArGVb+oJmUcR22jEONlgPp0wj4iNIHfQ2je9Q8WTOqMc0Ws9tUciz3JdJnhffdHqo/k8fpvf0IRmN5HPA=="
-    },
-    "node_modules/expo-updates/node_modules/expo-manifests": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.14.2.tgz",
-      "integrity": "sha512-hFrwIGr76/zGVhZ+vcjDZpOePd7uYNB6yCaiJcm7/bcrt2ne7cHyKQ8l+3n26/v1OuXfBfjxNH+PHIpkClszoQ==",
-      "dependencies": {
-        "@expo/config": "~9.0.0-beta.0",
-        "expo-json-utils": "~0.13.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-updates/node_modules/expo-updates-interface": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.16.1.tgz",
-      "integrity": "sha512-yyG0y9HcifF0ptovHKvRyU7zz5/neGnJQI9BXrshpMwrtIGncQMpuL7vXVmmK2cg32enziPkIPDtu/bG0KoF1g==",
-      "peerDependencies": {
-        "expo": "*"
-      }
     },
     "node_modules/expo-updates/node_modules/find-up": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "expo-status-bar": "~1.11.1",
     "expo-system-ui": "^2.9.4",
     "expo-task-manager": "~11.7.3",
-    "expo-updates": "^0.25.9",
+    "expo-updates": "~0.24.12",
     "geojson": "^0.5.0",
     "geojson-geometries-lookup": "^0.5.0",
     "lodash.isequal": "^4.5.0",


### PR DESCRIPTION
Noticed this build issue when running `npx expo run:android`:

```sh
Could not find method useDefaultAndroidSdkVersions() for arguments [] on project ':expo-eas-client' of type org.gradle.api.Project.
```

Running `npx expo install --fix` downgraded `expo-updates`, which seems to have resolved the issue for me.