### PR TITLE
feat: add screen for importing config file

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -765,6 +765,30 @@
   "screens.Settings.CreateOrJoinProject.whatIsAProject": {
     "message": "What is a Project"
   },
+  "screens.Settings.ProjectSettings.ProjectConfiguration.alertOkButton": {
+    "description": "Button to dismiss alert after attempting to import a config file",
+    "message": "OK"
+  },
+  "screens.Settings.ProjectSettings.ProjectConfiguration.configErrorTitle": {
+    "description": "Title of error dialog when there is an error importing a config file",
+    "message": "Import Error"
+  },
+  "screens.Settings.ProjectSettings.ProjectConfiguration.configImportAlertSuccessMessage": {
+    "description": "Message for alert after successful config import",
+    "message": "Successfully imported config"
+  },
+  "screens.Settings.ProjectSettings.ProjectConfiguration.configImportErrorMessage": {
+    "description": "Description of error dialog when there is an error importing a config file",
+    "message": "There was an error trying to import this config file"
+  },
+  "screens.Settings.ProjectSettings.ProjectConfiguration.importConfigButtonText": {
+    "description": "Button to import Mapeo config file",
+    "message": "Import Config"
+  },
+  "screens.Settings.ProjectSettings.ProjectConfiguration.screenTitle": {
+    "description": "Title of project configuration screen",
+    "message": "Project Configuration"
+  },
   "screens.Settings.YourTeam.InviteDeclined": {
     "message": "Invitation Declined"
   },
@@ -873,7 +897,7 @@
     "message": "Go Back"
   },
   "sharedComponents.ErrorModal.somethingWrong": {
-    "message": "Something\n Went Wrong"
+    "message": "Something Went Wrong"
   },
   "sharedComponents.ErrorModal.tryAgain": {
     "message": "Try Again"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "expo-camera": "~14.1.3",
         "expo-crypto": "~12.8.1",
         "expo-dev-client": "~3.3.11",
+        "expo-document-picker": "~11.10.1",
+        "expo-file-system": "~16.0.9",
         "expo-localization": "~14.8.4",
         "expo-location": "~16.5.5",
         "expo-secure-store": "~12.8.1",
@@ -12480,6 +12482,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-11.10.1.tgz",
+      "integrity": "sha512-A1MiLfyXQ+KxanRO5lYxYQy3ryV+25JHe5Ai/BLV+FJU0QXByUF+Y/dn35WVPx5gpdZXC8UJ4ejg5SKSoeconw==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-eas-client": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,9 @@
     "uint8array-extras": "^0.5.0",
     "utm": "^1.1.1",
     "validate-color": "^2.2.4",
-    "zustand": "^4.4.6"
+    "zustand": "^4.4.6",
+    "expo-file-system": "~16.0.9",
+    "expo-document-picker": "~11.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -54,6 +54,10 @@ import {
 import {HomeTabs} from '../Tab';
 import {SaveTrackScreen} from '../../screens/SaveTrack/SaveTrackScreen';
 import {ObservationFields} from '../../screens/ObservationFields';
+import {
+  ProjectConfigurationScreen,
+  createNavigationOptions as createProjectConfigurationNavOptions,
+} from '../../screens/Settings/ProjectSettings/ProjectConfiguration';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -239,5 +243,10 @@ export const createDefaultScreenGroup = (
       options={createManualGpsNavigationOptions({intl})}
     />
     <RootStack.Screen name="ObservationFields" component={ObservationFields} />
+    <RootStack.Screen
+      name="ProjectConfiguration"
+      component={ProjectConfigurationScreen}
+      options={createProjectConfigurationNavOptions({intl})}
+    />
   </RootStack.Group>
 );

--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -4,7 +4,11 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import {useApi} from '../../contexts/ApiContext';
-import {PROJECTS_KEY, useProject, useUpdateActiveProjectId} from './projects';
+import {
+  ALL_PROJECTS_KEY,
+  useProject,
+  useUpdateActiveProjectId,
+} from './projects';
 
 export const INVITE_KEY = 'pending_invites';
 
@@ -32,7 +36,7 @@ export function useAcceptInvite(projectId?: string) {
       // This is a workaround. There is a race condition where the project in not available when the invite is accepted. This is temporary and is currently being worked on.
       setTimeout(() => {
         queryClient
-          .invalidateQueries({queryKey: [INVITE_KEY, PROJECTS_KEY]})
+          .invalidateQueries({queryKey: [INVITE_KEY, ALL_PROJECTS_KEY]})
           .then(() => {
             if (projectId) {
               switchActiveProject(projectId);

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -2,7 +2,9 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {useApi} from '../../contexts/ApiContext';
 import {useActiveProjectContext} from '../../contexts/ProjectContext';
 
-export const PROJECTS_KEY = 'all_projects';
+export const PROJECT_KEY = 'project';
+export const ALL_PROJECTS_KEY = 'all_projects';
+export const PROJECT_SETTINGS_KEY = 'project_settings';
 
 export function useUpdateActiveProjectId() {
   const projectContext = useActiveProjectContext();
@@ -19,7 +21,7 @@ export function useAllProjects() {
 
   return useQuery({
     queryFn: async () => await api.listProjects(),
-    queryKey: [PROJECTS_KEY],
+    queryKey: [ALL_PROJECTS_KEY],
   });
 }
 
@@ -35,7 +37,9 @@ export function useCreateProject() {
     },
     onSuccess: async data => {
       updateProject(data);
-      return await queryClient.invalidateQueries({queryKey: ['projects']});
+      return await queryClient.invalidateQueries({
+        queryKey: [ALL_PROJECTS_KEY],
+      });
     },
   });
 }
@@ -54,9 +58,24 @@ export function useProjectSettings() {
   const project = useProject();
 
   return useQuery({
-    queryKey: ['projectSettings'],
+    queryKey: [PROJECT_SETTINGS_KEY],
     queryFn: () => {
       return project.$getProjectSettings();
+    },
+  });
+}
+
+export function useImportProjectConfig() {
+  const queryClient = useQueryClient();
+  const project = useProject();
+
+  return useMutation({
+    mutationFn: (configPath: string) => {
+      return project.importConfig({configPath});
+    },
+    onSuccess: () => {
+      // TODO: Invalidate project query too (easier to do when https://github.com/digidem/comapeo-mobile/pull/363 is merged)
+      return queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]});
     },
   });
 }

--- a/src/frontend/lib/file-system.ts
+++ b/src/frontend/lib/file-system.ts
@@ -1,3 +1,7 @@
 import {ExternalDirectoryPath} from '@dr.pogodin/react-native-fs';
 
+export function convertFileUriToPosixPath(fileUri: string) {
+  return fileUri.replace(/^file:\/\//, '');
+}
+
 export {ExternalDirectoryPath as EXTERNAL_FILES_DIR};

--- a/src/frontend/screens/Settings/ProjectSettings/ProjectConfiguration.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/ProjectConfiguration.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+import {MessageDescriptor, defineMessages, useIntl} from 'react-intl';
+import {ActivityIndicator, Alert, StyleSheet, View} from 'react-native';
+
+import {useImportProjectConfig} from '../../../hooks/server/projects';
+import {convertFileUriToPosixPath} from '../../../lib/file-system';
+import {WHITE} from '../../../lib/styles';
+import {Button} from '../../../sharedComponents/Button';
+import {ScreenContentWithDock} from '../../../sharedComponents/ScreenContentWithDock';
+import {Text} from '../../../sharedComponents/Text';
+import {NativeRootNavigationProps} from '../../../sharedTypes/navigation';
+
+const m = defineMessages({
+  screenTitle: {
+    id: 'screens.Settings.ProjectSettings.ProjectConfiguration.screenTitle',
+    defaultMessage: 'Project Configuration',
+    description: 'Title of project configuration screen',
+  },
+  importConfigButtonText: {
+    id: 'screens.Settings.ProjectSettings.ProjectConfiguration.importConfigButtonText',
+    defaultMessage: 'Import Config',
+    description: 'Button to import Mapeo config file',
+  },
+  alertOkButton: {
+    id: 'screens.Settings.ProjectSettings.ProjectConfiguration.alertOkButton',
+    defaultMessage: 'OK',
+    description:
+      'Button to dismiss alert after attempting to import a config file',
+  },
+  configErrorTitle: {
+    id: 'screens.Settings.ProjectSettings.ProjectConfiguration.configErrorTitle',
+    defaultMessage: 'Import Error',
+    description:
+      'Title of error dialog when there is an error importing a config file',
+  },
+  configImportErrorMessage: {
+    id: 'screens.Settings.ProjectSettings.ProjectConfiguration.configImportErrorMessage',
+    defaultMessage: 'There was an error trying to import this config file',
+    description:
+      'Description of error dialog when there is an error importing a config file',
+  },
+  configImportAlertSuccessMessage: {
+    id: 'screens.Settings.ProjectSettings.ProjectConfiguration.configImportAlertSuccessMessage',
+    defaultMessage: 'Successfully imported config',
+    description: 'Message for alert after successful config import',
+  },
+});
+
+export const ProjectConfigurationScreen = ({
+  navigation,
+}: NativeRootNavigationProps<'ProjectConfiguration'>) => {
+  const {formatMessage: t} = useIntl();
+
+  const importProjectConfigMutation = useImportProjectConfig();
+
+  // Prevent navigating away from screen when import is in progress
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', event => {
+      if (importProjectConfigMutation.isPending) {
+        event.preventDefault();
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [navigation, importProjectConfigMutation.isPending]);
+
+  async function importConfigFile() {
+    let result;
+    try {
+      result = await DocumentPicker.getDocumentAsync({
+        copyToCacheDirectory: true,
+        multiple: false,
+      });
+    } catch (_err) {
+      Alert.alert(t(m.configErrorTitle), t(m.configImportErrorMessage), [
+        {text: t(m.alertOkButton)},
+      ]);
+      return;
+    }
+
+    if (result.canceled) {
+      return;
+    }
+
+    const asset = result.assets[0];
+
+    // Shouldn't happen based on how the library works
+    if (!asset) return;
+
+    importProjectConfigMutation.mutate(convertFileUriToPosixPath(asset.uri), {
+      onSuccess: async () => {
+        await FileSystem.deleteAsync(asset.uri).catch((err: unknown) => {
+          // TODO: might be okay for this to just be a no-op?
+          console.log(err);
+        });
+
+        Alert.alert('', t(m.configImportAlertSuccessMessage));
+      },
+      onError: () => {
+        Alert.alert(t(m.configErrorTitle), t(m.configImportErrorMessage), [
+          {text: t(m.alertOkButton)},
+        ]);
+      },
+    });
+  }
+
+  return (
+    <>
+      <ScreenContentWithDock
+        dockContent={
+          <Button
+            fullWidth
+            onPress={importConfigFile}
+            disabled={importProjectConfigMutation.isPending}>
+            <Text style={styles.importButtonText}>
+              {t(m.importConfigButtonText)}
+            </Text>
+          </Button>
+        }
+      />
+      {importProjectConfigMutation.isPending && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+        </View>
+      )}
+    </>
+  );
+};
+
+export function createNavigationOptions({
+  intl,
+}: {
+  intl: (title: MessageDescriptor) => string;
+}) {
+  return (): NativeStackNavigationOptions => {
+    return {headerTitle: intl(m.screenTitle)};
+  };
+}
+
+const styles = StyleSheet.create({
+  root: {flex: 1},
+  scrollContentContainer: {padding: 20},
+  importButtonText: {
+    fontSize: 16,
+    color: WHITE,
+    fontWeight: 'bold',
+  },
+  loadingContainer: {
+    position: 'absolute',
+    width: '100%',
+    top: 0,
+    bottom: 0,
+    right: 0,
+    left: 0,
+    backgroundColor: 'rgba(255,255,255,0.9)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/frontend/screens/Settings/ProjectSettings/ProjectConfiguration.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/ProjectConfiguration.tsx
@@ -101,7 +101,12 @@ export const ProjectConfigurationScreen = ({
 
         Alert.alert('', t(m.configImportAlertSuccessMessage));
       },
-      onError: () => {
+      onError: async () => {
+        await FileSystem.deleteAsync(asset.uri).catch((err: unknown) => {
+          // TODO: might be okay for this to just be a no-op?
+          console.log(err);
+        });
+
         Alert.alert(t(m.configErrorTitle), t(m.configImportErrorMessage), [
           {text: t(m.alertOkButton)},
         ]);

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {ScrollView} from 'react-native';
 import {List, ListItem, ListItemText} from '../../../sharedComponents/List';
 import {FormattedMessage, defineMessages} from 'react-intl';
@@ -34,7 +35,10 @@ export const ProjectSettings: NativeNavigationComponent<'ProjectSettings'> = ({
           }}>
           <ListItemText primary={<FormattedMessage {...m.deviceName} />} />
         </ListItem>
-        <ListItem onPress={() => {}}>
+        <ListItem
+          onPress={() => {
+            navigation.navigate('ProjectConfiguration');
+          }}>
           <ListItemText primary={<FormattedMessage {...m.configuration} />} />
         </ListItem>
         <ListItem

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -25,7 +25,11 @@ export const HomeHeader: FC<BottomTabHeaderProps> = ({navigation}) => {
         <SyncIconCircle />
       </IconButton>
       <GPSPill navigation={navigation} />
-      <IconButton onPress={() => {}} testID="observationListButton">
+      <IconButton
+        onPress={() => {
+          navigation.navigate('Settings');
+        }}
+        testID="observationListButton">
         <ObservationListIcon />
       </IconButton>
     </View>

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -93,6 +93,7 @@ export type RootStackParamsList = {
   DeviceNameEdit: undefined;
   SaveTrack: undefined;
   Sync: undefined;
+  ProjectConfiguration: undefined;
 };
 
 export type DeviceNamingParamsList = {


### PR DESCRIPTION
Closes #161 

As I understand it, config imports in Mapeo are treated differently from config imports in CoMapeo. In Mapeo, imports are entities that have metadata such as the name and version, so we surfaced that information in this screen. In CoMapeo, we do not have access to this metadata, as imports are solely treated as a method of updating information about a project. Due to this, it didn't make sense to directly port what exists in Mapeo.

Open questions to address, maybe as a follow-up:

- [ ] what can/do we want to show in this screen? as currently implemented, i only have the button to import the config and an alert depending on the result of the import.

  - would it be helpful to surface an import history? maybe persist a history of the name of the file and the timestamp for when the import was attempted. how would we persist this history? (e.g. local storage, or in the actual backend)
  
- [ ] how should we surface errors and success? the ticket provides no information about this and i couldn't find the design for this screen in Figma. right now I'm just using alerts, which is what Mapeo more or less did.

---

Preview:

- Screen: 

  <img width="300" alt="image" src="https://github.com/digidem/comapeo-mobile/assets/18542095/11966853-52b4-48f6-9aba-e3cb12184cd9">

- Success flow:

  https://github.com/digidem/comapeo-mobile/assets/18542095/df117de0-ca0c-4929-ae85-0e1cb5fdfc4e

- Failure flow (happens if bad file type, or some error on backend):

  https://github.com/digidem/comapeo-mobile/assets/18542095/d4b4aed2-e7fc-4ec7-bdb1-e588f9bd8d84

