### PR TITLE
chore: downgrade Sentry dep to Expo-compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@react-navigation/native": "^6.1.7",
         "@react-navigation/native-stack": "^6.9.13",
         "@rnmapbox/maps": "^10.1.19",
-        "@sentry/react-native": "^5.22.2",
+        "@sentry/react-native": "~5.20.0",
         "@tanstack/react-query": "^5.12.2",
         "@types/luxon": "^3.4.2",
         "assert": "^2.0.0",
@@ -7312,67 +7312,66 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.113.0.tgz",
-      "integrity": "sha512-eEmL8QXauUnM3FXGv0GT29RpL0Jo0pkn/uMu3aqjhQo7JKNqUGVYIUxJxiGWbVMbDXqPQ7L66bjjMS3FR1GM2g==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
+      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
       "dependencies": {
-        "@sentry/core": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.113.0.tgz",
-      "integrity": "sha512-K8uA42aobNF/BAXf14el15iSAi9fonLBUrjZi6nPDq7zaA8rPvfcTL797hwCbqkETz2zDf52Jz7I3WFCshDoUw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
+      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
       "dependencies": {
-        "@sentry/core": "7.113.0",
-        "@sentry/replay": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.113.0.tgz",
-      "integrity": "sha512-8MDnYENRMnEfQjvN4gkFYFaaBSiMFSU/6SQZfY9pLI3V105z6JQ4D0PGMAUVowXilwNZVpKNYohE7XByuhEC7Q==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
+      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
       "dependencies": {
-        "@sentry/core": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.113.0.tgz",
-      "integrity": "sha512-PdyVHPOprwoxGfKGsP2dXDWO0MBDW1eyP7EZlfZvM1A4hjk6ZRNfCv30g+TrqX4hiZDKzyqN3+AdP7N/J2IX0Q==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
+      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.113.0",
-        "@sentry-internal/replay-canvas": "7.113.0",
-        "@sentry-internal/tracing": "7.113.0",
-        "@sentry/core": "7.113.0",
-        "@sentry/integrations": "7.113.0",
-        "@sentry/replay": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry-internal/feedback": "7.100.1",
+        "@sentry-internal/replay-canvas": "7.100.1",
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.30.4.tgz",
-      "integrity": "sha512-5zYdNGK2sNiP0zbnzMWuwm71KlCWLISbiJDyFQk6YYTKLh2RIYBPLF5mNLBxE2Ns4/wuKuBZjqE2ESLS5FzoOw==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.30.0.tgz",
+      "integrity": "sha512-GTO5e98vy2QwEYQvhE/ZtGUiVrUu4XungLioJbazm+ZOen8cyac8YOapZfozN5mtxjWOWMOwhOqoTeCU3Q8YKQ==",
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
@@ -7388,19 +7387,19 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "2.30.4",
-        "@sentry/cli-linux-arm": "2.30.4",
-        "@sentry/cli-linux-arm64": "2.30.4",
-        "@sentry/cli-linux-i686": "2.30.4",
-        "@sentry/cli-linux-x64": "2.30.4",
-        "@sentry/cli-win32-i686": "2.30.4",
-        "@sentry/cli-win32-x64": "2.30.4"
+        "@sentry/cli-darwin": "2.30.0",
+        "@sentry/cli-linux-arm": "2.30.0",
+        "@sentry/cli-linux-arm64": "2.30.0",
+        "@sentry/cli-linux-i686": "2.30.0",
+        "@sentry/cli-linux-x64": "2.30.0",
+        "@sentry/cli-win32-i686": "2.30.0",
+        "@sentry/cli-win32-x64": "2.30.0"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.30.4.tgz",
-      "integrity": "sha512-d61JxgtPvUtUZ58T4WgzFDsRODAQbKcRxhK9DY7Y/+q7fH1gWc6J8s8RwxxhYu/N/UuWnAcXNtIH9daUanKTjQ==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.30.0.tgz",
+      "integrity": "sha512-JVesQ9PznbHBOOOwuej2X8/onfXdmAEjBH6fTyWxBl6K8mB4KmBX/aHunXWMBX+VR9X32XZghIqj7acwaFUMPA==",
       "optional": true,
       "os": [
         "darwin"
@@ -7410,9 +7409,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.30.4.tgz",
-      "integrity": "sha512-2+L8FVOc8XLD2k4rUklsIG8gCoawOZJv1TdlHcIvsHIt6e55vVil6JDBc7dOD/tzJlJPAs+LMOuHHe8e/F+Y5A==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.30.0.tgz",
+      "integrity": "sha512-MDB3iS31WKg4krCcLo520yxbUERPeA2DCtk9Qs9vSDbQl6Er64dteHllOdx1SDOyX/7GKcxrQEQ6SMmbnOo6wg==",
       "cpu": [
         "arm"
       ],
@@ -7426,9 +7425,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.30.4.tgz",
-      "integrity": "sha512-XxRBiZAj84umr+i4n6zNGkbdJIX76G6SFalv4466XZkbhPuAeSABFQ5PxRVc+j7pLyOBGao4q2yiO8wrBLsJug==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.30.0.tgz",
+      "integrity": "sha512-JNXPkkMubKoZVlcFIoClSmTb9C/I6Bz08DuAZm2jnjRaaOMiCBxI/l50H3dmfVZ6apjEguG9JkjFdb0kqKB90w==",
       "cpu": [
         "arm64"
       ],
@@ -7442,9 +7441,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.30.4.tgz",
-      "integrity": "sha512-ruouCpmxJXumNxvZ4asQzz2gzAKeUhg9dofB9h5PEmemceTLKfOAyfplD5l1iLWL3+JfF88SNeuu2/sWHP7aBg==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.30.0.tgz",
+      "integrity": "sha512-WhVVziFQw/fO0Cc53pY8goPAzJtIs6ORTR89fVbKwa3ZDNkX++mEOECbP7RkmD87kuRxyKzN543RPV971PcAHw==",
       "cpu": [
         "x86",
         "ia32"
@@ -7459,9 +7458,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.30.4.tgz",
-      "integrity": "sha512-Kcb1Fn5wNSQW5bKkF35MpJSATtvgzGAHDzJkuEXPfF9xQMhOaYPnMN/D0aLYZgTpQawL4CM7dcfLuaafGmiazQ==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.30.0.tgz",
+      "integrity": "sha512-QkiVDeSfspotZ0Au5Yauv2DAm/BC1fL9BwPek/WwddM18I2HqnDp6l4TA4bQeEY++o0KEuNF53cPahpepltPjw==",
       "cpu": [
         "x64"
       ],
@@ -7475,9 +7474,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.30.4.tgz",
-      "integrity": "sha512-FJ6IS+N7CsacDiHrFbE4Ic9UmumsiaBSD4SiQMIG2wfM7Ig1hc7+F4xoMC3MjivAIM7F94ZdSt0aZDGwE+zYeg==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.30.0.tgz",
+      "integrity": "sha512-xLY9B1EEGuNYPKpK6M9PMmcu2PzofdvRtbraTcU6Ck2zALS5oXB9kmWc4dDKucZ/uu9JB0m+Lo4ebaNlca45qQ==",
       "cpu": [
         "x86",
         "ia32"
@@ -7491,9 +7490,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.30.4.tgz",
-      "integrity": "sha512-wzvMpj+AVEaLKKLkN1vZxuEwQJa5s8qiasYMBJTXFtD7+LqrONerHCRqk79W+60IBXX7MQSRFF3IsjVJzJGEjA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.30.0.tgz",
+      "integrity": "sha512-CiXuxnpJI0zho0XE5PVqIS9CwjDEYoMnHQRIr4Jj9OzlGTJ2iSSU6Zp3Ykd7lgo2iK4P6MfxIBm30gFQPnSvVA==",
       "cpu": [
         "x64"
       ],
@@ -7506,38 +7505,38 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.113.0.tgz",
-      "integrity": "sha512-pg75y3C5PG2+ur27A0Re37YTCEnX0liiEU7EOxWDGutH17x3ySwlYqLQmZsFZTSnvzv7t3MGsNZ8nT5O0746YA==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
       "dependencies": {
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.113.0.tgz",
-      "integrity": "sha512-aoerhlAw3vnY9a27eKAoK862oMXFbyMFWbaZuCeR5gfg7sHsOkVQkCl3yiYfF5hfw9MbwbbY6GqWbCrA89Ci/A==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.100.1.tgz",
+      "integrity": "sha512-zdt7f1k+5JE5FAunzBZUEFbvK5YP/LekLMeogTonaRObB07J6fJ9FD4mtNk7pV0utrTDwR+n942qmp+LbWauWA==",
       "dependencies": {
-        "@sentry/core": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.113.0.tgz",
-      "integrity": "sha512-w0sspGBQ+6+V/9bgCkpuM3CGwTYoQEVeTW6iNebFKbtN7MrM3XsGAM9I2cW1jVxFZROqCBPFtd2cs5n0j14aAg==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.100.1.tgz",
+      "integrity": "sha512-RUyZHcsN3Plc8G4hJN3BCMdbwS8ljUY3E3iLjzucA4HroBsGk5AMc6n7Pp/QqFIRgxrPjKEgA52Wgy5Nq6dSvw==",
       "dependencies": {
-        "@sentry/core": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -7545,14 +7544,14 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.113.0.tgz",
-      "integrity": "sha512-+zVPz+h5Wydq4ntekw3/dXq5jeHIpZoQ2iqhB96PA9Y94JIq178i/xIP204S1h6rN7cmWAqtR93vnPKdxnlUbQ==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.100.1.tgz",
+      "integrity": "sha512-EdrBtrXVLK2LSx4Rvz/nQP7HZUZQmr+t3GHV8436RAhF6vs5mntACVMBoQJRWiUvtZ1iRo3rIsIdah7DLiFPgQ==",
       "dependencies": {
-        "@sentry/browser": "7.113.0",
-        "@sentry/core": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0",
+        "@sentry/browser": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -7563,18 +7562,18 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "5.22.2",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.22.2.tgz",
-      "integrity": "sha512-q/Yg+oE2+jHIH2gRXI2NGYr4+vMGTAU2um4WGrMgEWWYc3QpG78SW7CVFHbdId7VETN3cLKB//twexWRuvvfZg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.20.0.tgz",
+      "integrity": "sha512-1jWqQFRvQeFgYrEXfvr0TTG/kXIGV2KgtkNqlInTTuXFXo6qInFhuu4Ak4zNuitFlfr6Soh2ASlJrpkBKf2pAg==",
       "dependencies": {
-        "@sentry/browser": "7.113.0",
-        "@sentry/cli": "2.30.4",
-        "@sentry/core": "7.113.0",
-        "@sentry/hub": "7.113.0",
-        "@sentry/integrations": "7.113.0",
-        "@sentry/react": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry/browser": "7.100.1",
+        "@sentry/cli": "2.30.0",
+        "@sentry/core": "7.100.1",
+        "@sentry/hub": "7.100.1",
+        "@sentry/integrations": "7.100.1",
+        "@sentry/react": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "bin": {
         "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
@@ -7591,33 +7590,33 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.113.0.tgz",
-      "integrity": "sha512-UD2IaphOWKFdeGR+ZiaNAQ+wFsnwbJK6PNwcW6cHmWKv9COlKufpFt06lviaqFZ8jmNrM4H+r+R8YVTrqCuxgg==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
+      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.113.0",
-        "@sentry/core": "7.113.0",
-        "@sentry/types": "7.113.0",
-        "@sentry/utils": "7.113.0"
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.113.0.tgz",
-      "integrity": "sha512-PJbTbvkcPu/LuRwwXB1He8m+GjDDLKBtu3lWg5xOZaF5IRdXQU2xwtdXXsjge4PZR00tF7MO7X8ZynTgWbYaew==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.113.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.113.0.tgz",
-      "integrity": "sha512-nzKsErwmze1mmEsbW2AwL2oB+I5v6cDEJY4sdfLekA4qZbYZ8pV5iWza6IRl4XfzGTE1qpkZmEjPU9eyo0yvYw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
       "dependencies": {
-        "@sentry/types": "7.113.0"
+        "@sentry/types": "7.100.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.13",
     "@rnmapbox/maps": "^10.1.19",
-    "@sentry/react-native": "^5.22.2",
+    "@sentry/react-native": "~5.20.0",
     "@tanstack/react-query": "^5.12.2",
     "@types/luxon": "^3.4.2",
     "assert": "^2.0.0",


### PR DESCRIPTION
Running `npx expo-doctor` showed that we had the incorrect sentry version installed.