### PR TITLE
fix: use onDismiss() prop in BottomSheetModal component

### DIFF
--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -78,7 +78,7 @@ interface Props extends React.PropsWithChildren<{}> {
 }
 
 export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
-  ({children, isOpen, onBack, fullHeight}, ref) => {
+  ({children, isOpen, onBack, fullHeight, onDismiss}, ref) => {
     useBackHandler(isOpen, onBack);
 
     return (
@@ -90,6 +90,7 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
             : {borderColor: DARK_GREY, borderWidth: 1},
         ]}
         backdropComponent={DefaultBackdrop}
+        onDismiss={onDismiss}
         enableContentPanningGesture={false}
         enableHandlePanningGesture={false}
         snapPoints={!fullHeight ? undefined : ['100%']}


### PR DESCRIPTION
the prop was defined but never used in the component when it should be passed to the library's BottomSheetModal `onDismiss` prop, like it's done in [Mapeo Mobile](https://github.com/digidem/mapeo-mobile/blob/0c0ebbb9ef2261e21cd1d1c8bd5ab2fe42017ea3/src/frontend/sharedComponents/BottomSheetModal/index.tsx#L121).

There are a few consumers of this component that specify the prop for things like cleanup, which would've led to some unexpected behavior without this fix.