### PR TITLE
fix: disable android:allowBackup manifest option

### DIFF
--- a/app.json
+++ b/app.json
@@ -53,6 +53,7 @@
     ],
     "android": {
       "versionCode": 1,
+      "allowBackup": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/icon.png",
         "backgroundColor": "#050F77"


### PR DESCRIPTION
Addresses the SecureStore error I keep seeing in #370 . This PR disables Android's [Auto Backup](https://developer.android.com/identity/data/autobackup) feature which is basically a mechanism that allows you to store your app data via a Google Drive account so that you can restore apps and their data later or on another device. Expo enables this by default: https://docs.expo.dev/versions/v50.0.0/config/app/#allowbackup

I don't have the feature enabled on my devices, but seems like disabling the manifest value fixes the issue I was seeing with SecureStore being unable to decrypt the vault everytime I loaded a new dev client, so maybe there's some underlying thing that's not playing well with the module. 

In general, I don't think it's desirable for us to have the app enabled for this feature. I've run into really confusing complications with Manyverse in the past because of it and in general, seems to not play well with apps that use local databases.