### PR TITLE
chore: only send screen width & height in metrics report

### DIFF
--- a/src/frontend/metrics/generateMetricsReport.test.ts
+++ b/src/frontend/metrics/generateMetricsReport.test.ts
@@ -2,14 +2,16 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import generateMetricsReport from './generateMetricsReport';
 
+type MetricsReportOptions = Parameters<typeof generateMetricsReport>[0];
+
 describe('generateMetricsReport', () => {
   const packageJson = readPackageJson();
 
-  const defaultOptions: Parameters<typeof generateMetricsReport>[0] = {
+  const defaultOptions = {
     packageJson,
     os: 'android',
     osVersion: 123,
-    screen: {width: 12, height: 34},
+    screen: {width: 12, height: 34, ignoredValue: 56},
     observations: [
       // Middle of the Atlantic
       {lat: 10, lon: -33},
@@ -22,7 +24,7 @@ describe('generateMetricsReport', () => {
       {lat: 12},
       {lon: 34},
     ],
-  };
+  } as MetricsReportOptions;
 
   it('can be serialized and deserialized as JSON', () => {
     const report = generateMetricsReport(defaultOptions);

--- a/src/frontend/metrics/generateMetricsReport.ts
+++ b/src/frontend/metrics/generateMetricsReport.ts
@@ -28,7 +28,7 @@ export default function generateMetricsReport({
     appVersion: packageJson.version,
     os,
     osVersion,
-    screen,
+    screen: {width: screen.width, height: screen.height},
     ...(countries.size ? {countries: Array.from(countries)} : {}),
   };
 }


### PR DESCRIPTION
Metrics reports include screen dimensions (width & height). If the provided `screen` object has additional properties, we want to ignore them.

This will likely be the case for us, because we're probably going to use [`Dimensions.get`][0] which returns an object with extra properties.

This change filters those out and only keeps the provided `width` and `height`.

[0]: https://reactnative.dev/docs/dimensions#get