### PR TITLE
fix: fix navigation error after responding to invite

### DIFF
--- a/src/frontend/AppNavigator.tsx
+++ b/src/frontend/AppNavigator.tsx
@@ -1,21 +1,57 @@
-import {NavigationContainer} from '@react-navigation/native';
+import {
+  NavigationContainer,
+  createNavigationContainerRef,
+} from '@react-navigation/native';
 import * as React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 import {DrawerNavigator} from './Navigation/Drawer';
 import {ProjectInviteBottomSheet} from './sharedComponents/ProjectInviteBottomSheet';
 import {Loading} from './sharedComponents/Loading';
+import {AppStackParamsList} from './sharedTypes/navigation';
+import {EDITING_SCREEN_NAMES} from './constants';
+
+export const rootNavigationRef =
+  createNavigationContainerRef<AppStackParamsList>();
 
 export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   if (permissionAsked) {
     SplashScreen.hideAsync();
   }
 
+  const [inviteSheetEnabled, setInviteSheetEnabled] = React.useState(() => {
+    return shouldEnableInviteSheet();
+  });
+
+  React.useEffect(() => {
+    const unsubscribe = rootNavigationRef.addListener('state', () => {
+      setInviteSheetEnabled(shouldEnableInviteSheet());
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
   return (
-    <NavigationContainer>
+    <NavigationContainer ref={rootNavigationRef}>
       <React.Suspense fallback={<Loading />}>
         <DrawerNavigator />
-        <ProjectInviteBottomSheet />
+        <ProjectInviteBottomSheet
+          enabledForCurrentScreen={inviteSheetEnabled}
+        />
       </React.Suspense>
     </NavigationContainer>
   );
 };
+
+function shouldEnableInviteSheet() {
+  const currentRoute = rootNavigationRef?.current?.getCurrentRoute();
+
+  if (!currentRoute) return true;
+
+  for (const name of EDITING_SCREEN_NAMES) {
+    if (name === currentRoute.name) return false;
+  }
+
+  return true;
+}

--- a/src/frontend/AppNavigator.tsx
+++ b/src/frontend/AppNavigator.tsx
@@ -10,8 +10,7 @@ import {Loading} from './sharedComponents/Loading';
 import {AppStackParamsList} from './sharedTypes/navigation';
 import {EDITING_SCREEN_NAMES} from './constants';
 
-export const rootNavigationRef =
-  createNavigationContainerRef<AppStackParamsList>();
+const rootNavigationRef = createNavigationContainerRef<AppStackParamsList>();
 
 export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   if (permissionAsked) {

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -305,18 +305,3 @@ export function matchPreset(
 
   return bestMatch;
 }
-
-export function isEditingScreen(
-  routes: NavigationState['routes'],
-  index: number | undefined,
-) {
-  const parentRoute = routes[index || 0];
-
-  const routeName = !parentRoute
-    ? undefined
-    : !parentRoute.state
-      ? parentRoute.name
-      : parentRoute.state.routes[parentRoute.state.index || 0]?.name;
-
-  return !!EDITING_SCREEN_NAMES.find(val => val === routeName);
-}

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import {BottomSheetModal, useBottomSheetModal} from '../BottomSheetModal';
-import {useNavigationState} from '@react-navigation/native';
-import {isEditingScreen} from '../../lib/utils';
 import {
   useAcceptInvite,
   usePendingInvites,
@@ -12,14 +10,14 @@ import {NewInviteBottomSheetContent} from './NewInviteBottomSheetContent';
 import {InviteSuccessBottomSheetContent} from './InviteSuccessBottomSheetContent';
 import {InviteCanceledBottomSheetContent} from './InviteCanceledBottomSheetContent';
 
-export const ProjectInviteBottomSheet = () => {
+export const ProjectInviteBottomSheet = ({
+  enabledForCurrentScreen,
+}: {
+  enabledForCurrentScreen: boolean;
+}) => {
   const {sheetRef, isOpen, closeSheet, openSheet} = useBottomSheetModal({
     openOnMount: false,
   });
-  const routes = useNavigationState(state => (!state ? [] : state.routes));
-  const index = useNavigationState(state => (!state ? undefined : state.index));
-
-  const isEditScreen = isEditingScreen(routes, index);
   const invites = usePendingInvites().data.sort(
     (a, b) => a.receivedAt - b.receivedAt,
   );
@@ -32,7 +30,7 @@ export const ProjectInviteBottomSheet = () => {
   const accept = useAcceptInvite(invite?.projectPublicId);
   const reject = useRejectInvite();
 
-  if (invite && !isOpen && !isEditScreen) {
+  if (invite && !isOpen && enabledForCurrentScreen) {
     openSheet();
   }
 


### PR DESCRIPTION
Fixes #391 

Also fixes an issue with determining the name of the current route. The `isEditingScreen()` util (now removed completely) did not properly extract the route name for screens within the tab container (e.g. going to camera or observations list). This would've caused unexpected behavior in some cases, such as the invite sheet showing up while in the camera screen (which is not desired).