### PR TITLE
fix: update default config to fix startup crash

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@mapeo/core": "9.0.0-alpha.11",
-        "@mapeo/default-config": "^4.0.0-alpha.2",
+        "@mapeo/default-config": "^4.0.0-alpha.5",
         "@mapeo/ipc": "0.6.0",
         "debug": "^4.3.4",
         "mapeo-offline-map": "^2.0.0"
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@mapeo/default-config": {
-      "version": "4.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@mapeo/default-config/-/default-config-4.0.0-alpha.2.tgz",
-      "integrity": "sha512-3CxFRO8EfhoAzzYmiSS44eEwt3oLqveNTUNBsOqPc/OWhoniYfTzVrSo676pV4ThIFDH884K9e5cwgT59hErAQ=="
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@mapeo/default-config/-/default-config-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-Z8VOWCtMobnzblnjBN1+RRk9F9S0hD11fCkH6fxFA0qFwsuYDmoo7xfElJcClAlkFxmzCiKSxM0XfWzdTCuZ2w=="
     },
     "node_modules/@mapeo/ipc": {
       "version": "0.6.0",
@@ -6304,9 +6304,9 @@
       }
     },
     "@mapeo/default-config": {
-      "version": "4.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@mapeo/default-config/-/default-config-4.0.0-alpha.2.tgz",
-      "integrity": "sha512-3CxFRO8EfhoAzzYmiSS44eEwt3oLqveNTUNBsOqPc/OWhoniYfTzVrSo676pV4ThIFDH884K9e5cwgT59hErAQ=="
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@mapeo/default-config/-/default-config-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-Z8VOWCtMobnzblnjBN1+RRk9F9S0hD11fCkH6fxFA0qFwsuYDmoo7xfElJcClAlkFxmzCiKSxM0XfWzdTCuZ2w=="
     },
     "@mapeo/ipc": {
       "version": "0.6.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@mapeo/core": "9.0.0-alpha.11",
-    "@mapeo/default-config": "^4.0.0-alpha.2",
+    "@mapeo/default-config": "^4.0.0-alpha.5",
     "@mapeo/ipc": "0.6.0",
     "debug": "^4.3.4",
     "mapeo-offline-map": "^2.0.0"


### PR DESCRIPTION
After the recent update to `@mapeo/core@9.0.0-alpha.11` (in 5a94b7faf509d027a3d7f20b568662af531a2b05), we need a new default config to avoid a crash.
