### PR TITLE
chore: properly detect and copy Intel-based native prebuilds when building apk

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -64,6 +64,10 @@ This step ensures that the development environment is using the same major Node 
 NodeJS Mobile React Native. The check is most relevant when building native modules, but since we use native prebuilds,
 skipping it does not seem to affect our ability to build the app and is thus (probably) not needed.
 
+### [Fix copying of Intel-based native prebuilds into native assets directory when building apk](./nodejs-mobile-react-native+18.17.7+006+fix-copying-x86-prebuilds.patch)
+
+When targeting Intel-based architectures (i.e. `x86_64`), the affected Gradle build steps were attempting to find native prebuilds using the extended target architecture name i.e. in each directory for relevant native Node modules, it was looking for `prebuilds/android-x86_64/` instead of `prebuilds/android-x64/`. This naming discrepancy is due to how our [prebuild template](https://github.com/digidem/nodejs-mobile-prebuilds-template) publishes the output from https://github.com/nodejs-mobile/prebuild-for-nodejs-mobile/, which uses an abbreviated name of the architecture (e.g. `x86_64` is referred to as `x64`).
+
 ## @react-native/eslint-config
 
 ### [Disable prettier plugin rules](./@react-native+eslint-config+0.73.2.patch)

--- a/patches/nodejs-mobile-react-native+18.17.7+006+fix-copying-x86-prebuilds.patch
+++ b/patches/nodejs-mobile-react-native+18.17.7+006+fix-copying-x86-prebuilds.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/nodejs-mobile-react-native/android/build.gradle b/node_modules/nodejs-mobile-react-native/android/build.gradle
+index 724c377..705e4c8 100644
+--- a/node_modules/nodejs-mobile-react-native/android/build.gradle
++++ b/node_modules/nodejs-mobile-react-native/android/build.gradle
+@@ -370,7 +370,15 @@ if ("1".equals(shouldRebuildNativeModules)) {
+ 
+             delete fileTree(dir: "${rootProject.buildDir}/nodejs-native-assets-temp-build/nodejs-native-assets-${abi_name}/nodejs-project/node_modules/").matching {
+                 include "**/*.node" // Look for all .node files
+-                exclude "**/prebuilds/android-${temp_arch}/*" // Don't touch the correct prebuilds
++                /*  
++                For Intel-based architectures, `temp_arch` represents the extended name e.g. `x86_64`,
++                but we need to reference the abbreviated name (`x64`) used by the [prebuilds template](https://github.com/digidem/nodejs-mobile-prebuilds-template), 
++                (which is transitively due to naming used by https://github.com/nodejs-mobile/prebuild-for-nodejs-mobile/).
++
++                Instead, we use `temp_dest_cpu`, which represents the corresponding abbreviated name.
++                */
++                // exclude "**/prebuilds/android-${temp_arch}/*" // Don't touch the correct prebuilds
++                exclude "**/prebuilds/android-${temp_dest_cpu}/*" // Don't touch the correct prebuilds
+                 exclude "**/build/Release/*" // Don't touch the prebuilds moved here from previous run of DetectCorrectPrebuilds step
+             }
+         }
+@@ -383,7 +391,15 @@ if ("1".equals(shouldRebuildNativeModules)) {
+ 
+             doLast {
+                 def correctDotNodes = fileTree(dir: "${rootProject.buildDir}/nodejs-native-assets-temp-build/nodejs-native-assets-${abi_name}/nodejs-project/node_modules/").matching {
+-                    include "**/prebuilds/android-${temp_arch}/*.node"
++                    /*  
++                    For Intel-based architectures, `temp_arch` represents the extended name e.g. `x86_64`,
++                    but we need to reference the abbreviated name (`x64`) used by the [prebuilds template](https://github.com/digidem/nodejs-mobile-prebuilds-template), 
++                    (which is transitively due to naming used by https://github.com/nodejs-mobile/prebuild-for-nodejs-mobile/).
++
++                    Instead, we use `temp_dest_cpu`, which represents the corresponding abbreviated name.
++                    */
++                    // include "**/prebuilds/android-${temp_arch}/*.node"
++                    include "**/prebuilds/android-${temp_dest_cpu}/*.node"
+                 }
+                 for (dotNode in correctDotNodes) {
+                     def moduleRoot = file("${dotNode.getAbsoluteFile()}/../../..")


### PR DESCRIPTION
See patch comments and readme entry for full explanation, but basically some nodejs-mobile-react-native gradle steps were trying to find native prebuild directories that didn't exist due to slight naming discrepancies. This adds a patch to the gradle file, which I think is an easier (and maybe more appropriate?) solution than updating the configuration for all of the prebuild repos that we manage.

The original context for this PR can be found in #446 , but basically this is a relatively non-urgent PR because we decided to only build for arm (will happen in a separate PR). however, i think this is still good to have because it's one of those things that very easy to forget in the future, in case we decide to revisit introducing intel builds