### PR TITLE
fix: Introduces CleartextTraffic permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,7 +50,12 @@
           "fonts": ["./public/Rubik-Regular.ttf", "./public/Rubik-Medium.ttf"]
         }
       ],
-      ["./expo-config-plugins/removeExpoInputStyles.js"]
+      ["./expo-config-plugins/removeExpoInputStyles.js"],
+      ["expo-build-properties",{
+        "android":{
+          "usesCleartextTraffic":true
+        }
+      }]
     ],
     "android": {
       "versionCode": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eventemitter3": "^5.0.1",
         "expo": "~50.0.8",
         "expo-av": "~13.10.6",
+        "expo-build-properties": "~0.11.1",
         "expo-camera": "~14.1.3",
         "expo-crypto": "~12.8.1",
         "expo-dev-client": "~3.3.11",
@@ -14023,6 +14024,38 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.11.1.tgz",
+      "integrity": "sha512-m4j4aEjFaDuBE6KWYMxDhWgLzzSmpE7uHKAwtvXyNmRK+6JKF0gjiXi0sXgI5ngNppDQpsyPFMvqG7uQpRuCuw==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.5.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/expo-camera": {
       "version": "14.1.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eventemitter3": "^5.0.1",
     "expo": "~50.0.8",
     "expo-av": "~13.10.6",
+    "expo-build-properties": "~0.11.1",
     "expo-camera": "~14.1.3",
     "expo-crypto": "~12.8.1",
     "expo-dev-client": "~3.3.11",
@@ -104,8 +105,7 @@
     "uint8array-extras": "^0.5.0",
     "utm": "^1.1.1",
     "validate-color": "^2.2.4",
-    "zustand": "^4.4.6",
-    "expo-build-properties": "~0.11.1"
+    "zustand": "^4.4.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "uint8array-extras": "^0.5.0",
     "utm": "^1.1.1",
     "validate-color": "^2.2.4",
-    "zustand": "^4.4.6"
+    "zustand": "^4.4.6",
+    "expo-build-properties": "~0.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
On production builds the map was not rendering and showing a black screen. The error was identified as [useClearTextTraffic](https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic) needed to be enabled.

This PR uses expo [BuildProperties](https://docs.expo.dev/versions/latest/sdk/build-properties/) to enable it/