### PR TITLE
chore: add processor architecture to metrics report

### DIFF
--- a/src/frontend/hooks/useSendMetrics.ts
+++ b/src/frontend/hooks/useSendMetrics.ts
@@ -4,6 +4,7 @@ import {useAppState} from '@react-native-community/hooks';
 import * as Sentry from '@sentry/react-native';
 import {useEffect} from 'react';
 import {Dimensions, Platform} from 'react-native';
+import DeviceInfo from 'react-native-device-info';
 import packageJson from '../../../package.json';
 import {assert} from '../lib/assert';
 import {sleep} from '../lib/sleep';
@@ -80,11 +81,14 @@ export function useSendMetrics(api: MapeoClientApi): void {
 
       await sleepUntilWeCanSendMetrics(lastMetricsReportSentAt, {signal});
 
+      const supportedAbis = await DeviceInfo.supportedAbis();
+
       const metricsReport = generateMetricsReport({
         packageJson,
         os: Platform.OS,
         osVersion: Platform.Version,
         screen: Dimensions.get('screen'),
+        supportedAbis,
         observations: await getAllObservations(api),
       });
 

--- a/src/frontend/metrics/generateMetricsReport.test.ts
+++ b/src/frontend/metrics/generateMetricsReport.test.ts
@@ -35,6 +35,7 @@ describe('generateMetricsReport', () => {
     os: 'android',
     osVersion: 123,
     screen: {width: 12, height: 34, ignoredValue: 56},
+    supportedAbis: ['test64'],
     observations,
   } as MetricsReportOptions;
 
@@ -75,6 +76,17 @@ describe('generateMetricsReport', () => {
   it('includes screen dimensions', () => {
     const report = generateMetricsReport(defaultOptions);
     expect(report.screen).toEqual({width: 12, height: 34});
+  });
+
+  it('includes the architecture', () => {
+    const report = generateMetricsReport(defaultOptions);
+    expect(report.arch).toBe('test64');
+  });
+
+  it("doesn't include the architecture if there are no supported ABIs", () => {
+    const options = {...defaultOptions, supportedAbis: []};
+    const report = generateMetricsReport(options);
+    expect(report.arch).toBe(undefined);
   });
 
   it("doesn't include countries if no observations are provided", () => {

--- a/src/frontend/metrics/generateMetricsReport.ts
+++ b/src/frontend/metrics/generateMetricsReport.ts
@@ -10,14 +10,18 @@ export function generateMetricsReport({
   os,
   osVersion,
   screen,
+  supportedAbis,
   observations,
 }: ReadonlyDeep<{
   packageJson: {version: string};
   os: Platform['OS'] | NodeJS.Platform;
   osVersion: number | string;
   screen: {width: number; height: number};
+  supportedAbis: string[];
   observations: ReadonlyDeep<Array<Partial<Observation>>>;
 }>) {
+  const [arch] = supportedAbis;
+
   const countries = new Set<string>();
 
   for (const {lat, lon} of observations) {
@@ -31,6 +35,7 @@ export function generateMetricsReport({
     os,
     osVersion,
     screen: {width: screen.width, height: screen.height},
+    ...(arch ? {arch} : {}),
     ...(countries.size ? {countries: Array.from(countries)} : {}),
     percentageOfNetworkAvailability:
       getPercentageOfNetworkAvailability(observations),


### PR DESCRIPTION
This pulls the processor architecture from react-native-device-info's [`supportedAbis()` utility][0] and adds it to the metrics report.

On Android, the library pulls from [`Build.SUPPORTED_ABIS`][1] or [`Build.CPU_ABI`][2] on old Androids. On iOS, the library pulls from [`NXGetLocalArchInfo`][3]. This list is in preference order, so we just take the first one for our report.

[0]: https://github.com/react-native-device-info/react-native-device-info?tab=readme-ov-file#supportedAbis
[1]: https://developer.android.com/reference/android/os/Build#SUPPORTED_ABIS
[2]: https://developer.android.com/reference/android/os/Build#CPU_ABI
[3]: https://keith.github.io/xcode-man-pages/arch.3.html#NXGetLocalArchInfo