### PR TITLE
chore: only target arm-based architectures (for now)

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,12 +50,16 @@
           "fonts": ["./public/Rubik-Regular.ttf", "./public/Rubik-Medium.ttf"]
         }
       ],
-      ["./expo-config-plugins/removeExpoInputStyles.js"],
-      ["expo-build-properties",{
-        "android":{
-          "usesCleartextTraffic":true
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
         }
-      }]
+      ],
+      ["./expo-config-plugins/removeExpoInputStyles.js"],
+      ["./expo-config-plugins/targetArmArchsOnly.js"]
     ],
     "android": {
       "versionCode": 1,

--- a/expo-config-plugins/targetArmArchsOnly.js
+++ b/expo-config-plugins/targetArmArchsOnly.js
@@ -1,0 +1,49 @@
+const {
+  withAppBuildGradle,
+  withGradleProperties,
+} = require('expo/config-plugins');
+const {
+  mergeContents,
+} = require('@expo/config-plugins/build/utils/generateCode');
+
+/**
+ * @type {import('expo/config-plugins').ConfigPlugin}
+ */
+module.exports = function targetArmArchsOnly(config) {
+  // Update reactNativeArchitectures property in android/gradle.properties
+  const conf = withGradleProperties(config, configWithGradleProperties => {
+    const reactNativeArchitecturesProperty =
+      configWithGradleProperties.modResults.find(
+        p => p.type === 'property' && p.key === 'reactNativeArchitectures',
+      );
+
+    if (!reactNativeArchitecturesProperty) {
+      throw new Error(
+        "Could not find existing 'reactNativeArchitectures' property in android/gradle.properties",
+      );
+    }
+
+    reactNativeArchitecturesProperty.value = 'armeabi-v7a,arm64-v8a';
+
+    return configWithGradleProperties;
+  });
+
+  // Update android.defaultConfig in android/app/build.gradle
+  return withAppBuildGradle(conf, configWithAppBuildGradle => {
+    const abiFilters = `\t\tndk {\n\t\t\tabiFilters "armeabi-v7a", "arm64-v8a"\n\t\t}`;
+
+    configWithAppBuildGradle.modResults.contents = mergeContents({
+      tag: 'comapeo:add-ndk-abi-filters',
+      src: configWithAppBuildGradle.modResults.contents,
+      newSrc: abiFilters,
+      anchor: /defaultConfig {/gm,
+      offset: 1,
+      comment: '//',
+    }).contents;
+
+    return configWithAppBuildGradle;
+  });
+};
+
+/**
+ */

--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -4,7 +4,8 @@ import {$} from 'execa';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const TARGETS = ['android-arm', 'android-arm64', 'android-x64'];
+// NOTE: we currently don't support building for intel arch (android-x64)
+const TARGETS = ['android-arm', 'android-arm64'];
 
 // TODO: Figure out how to know if module uses N-API at runtime
 const NATIVE_MODULES = [


### PR DESCRIPTION
Closes #447 

Reduces the debug apk's size by almost half(!)

![image](https://github.com/digidem/comapeo-mobile/assets/18542095/db49a557-fb38-43ef-a0b3-02e75510f141)

apk internals comparison (white left is before, white right is after, right green is differences):

<img width="890" alt="image" src="https://github.com/digidem/comapeo-mobile/assets/18542095/e91bbcde-74b0-4f84-990a-1b1e070110fb">
