### PR TITLE
chore: fix missing dependency in "on backgrounded/foregrounded" hook

### DIFF
--- a/src/frontend/hooks/useOnBackgroundedAndForegrounded.ts
+++ b/src/frontend/hooks/useOnBackgroundedAndForegrounded.ts
@@ -10,5 +10,5 @@ export const useOnBackgroundedAndForegrounded = (api: MapeoClientApi): void => {
     } else {
       api.onBackgrounded();
     }
-  }, [isAppActive]);
+  }, [api, isAppActive]);
 };


### PR DESCRIPTION
I forgot to add this dependency in bb201e0f80a4a3efab0e2f109278a48febbd4ffd.

We don't ever change this argument in practice, but this fixes a lint error. And if we ever *do* change it in the future, we'll be ready.