### PR TITLE
chore: remove config item in project settings screen (temporary)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -111,9 +111,6 @@
   "Screens.Settings.AppSettings.title": {
     "message": "App Setttings"
   },
-  "Screens.Settings.ProjectSettings.configuration": {
-    "message": "Configuration"
-  },
   "Screens.Settings.ProjectSettings.deviceName": {
     "message": "Device Name"
   },

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -12,10 +12,6 @@ const m = defineMessages({
     id: 'Screens.Settings.ProjectSettings.deviceName',
     defaultMessage: 'Device Name',
   },
-  configuration: {
-    id: 'Screens.Settings.ProjectSettings.configuration',
-    defaultMessage: 'Configuration',
-  },
   yourTeam: {
     id: 'Screens.Settings.ProjectSettings.yourTeam',
     defaultMessage: 'Your Team',
@@ -34,9 +30,6 @@ export const ProjectSettings: NativeNavigationComponent<'ProjectSettings'> = ({
             navigation.navigate('DeviceNameDisplay');
           }}>
           <ListItemText primary={<FormattedMessage {...m.deviceName} />} />
-        </ListItem>
-        <ListItem onPress={() => {}}>
-          <ListItemText primary={<FormattedMessage {...m.configuration} />} />
         </ListItem>
         <ListItem
           testID="MAIN.team-list-item"


### PR DESCRIPTION
Closes #421 

Removes the list item because doesn't perform as of right now. This item will be introduced once there's a clearer idea of what the config screen should look like.

<img width="200" alt="image" src="https://github.com/digidem/comapeo-mobile/assets/18542095/d8f0c23a-03e6-4060-9d0b-1c779b370250">
