### PR TITLE
fix: fix submit button when editing device name

### DIFF
--- a/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
@@ -108,10 +108,8 @@ export const EditScreen = ({
     [t, navigation, getValues, nameHasChanges],
   );
 
-  const onPress = React.useCallback(() => {
-    if (isPending) return;
-
-    handleSubmit(async value => {
+  const onSubmit = React.useMemo(() => {
+    return handleSubmit(value => {
       if (!nameHasChanges) {
         navigation.navigate('DeviceNameDisplay');
         return;
@@ -121,21 +119,23 @@ export const EditScreen = ({
         onSuccess: () => navigation.navigate('DeviceNameDisplay'),
       });
     });
-  }, [handleSubmit, isPending, mutate, nameHasChanges, navigation]);
+  }, [handleSubmit, mutate, nameHasChanges, navigation]);
 
   React.useEffect(
     function updateNavigationOptions() {
       navigation.setOptions({
         headerRight: () => {
           return (
-            <IconButton testID="save-icon" onPress={onPress}>
+            <IconButton
+              testID="save-icon"
+              onPress={isPending ? undefined : onSubmit}>
               {isPending ? <UIActivityIndicator size={30} /> : <SaveIcon />}
             </IconButton>
           );
         },
       });
     },
-    [handleSubmit, navigation, isPending, mutate, nameHasChanges, onPress],
+    [navigation, isPending, onSubmit],
   );
 
   return (
@@ -157,7 +157,7 @@ export const EditScreen = ({
           />
         </FieldRow>
       </ScrollView>
-      <ErrorBottomSheet error={error} clearError={reset} tryAgain={onPress} />
+      <ErrorBottomSheet error={error} clearError={reset} tryAgain={onSubmit} />
     </>
   );
 };

--- a/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
@@ -125,11 +125,13 @@ export const EditScreen = ({
     function updateNavigationOptions() {
       navigation.setOptions({
         headerRight: () => {
-          return (
-            <IconButton
-              testID="save-icon"
-              onPress={isPending ? undefined : onSubmit}>
-              {isPending ? <UIActivityIndicator size={30} /> : <SaveIcon />}
+          return isPending ? (
+            <IconButton testID="save-icon">
+              <UIActivityIndicator size={30} />
+            </IconButton>
+          ) : (
+            <IconButton testID="save-icon" onPress={onSubmit}>
+              <SaveIcon />
             </IconButton>
           );
         },


### PR DESCRIPTION
Fixes #434 

Root issue was not properly creating a press handler via react hook form, which meant that pressing the button essentially did nothing.

unrelated, but `handleSubmit` is kind of an unfortunate naming from them - probably would've benefited from being called something like `createSubmitHandler`