### PR TITLE
chore: specify deviceType field when setting device info

### DIFF
--- a/src/frontend/hooks/server/deviceInfo.ts
+++ b/src/frontend/hooks/server/deviceInfo.ts
@@ -1,4 +1,6 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {isTablet} from 'react-native-device-info';
+
 import {useApi} from '../../contexts/ApiContext';
 
 export const DEVICE_INFO_KEY = 'deviceInfo';
@@ -21,7 +23,10 @@ export const useEditDeviceInfo = () => {
   return useMutation({
     mutationKey: ['device'],
     mutationFn: async (name: string) => {
-      return mapeoApi.setDeviceInfo({name});
+      return mapeoApi.setDeviceInfo({
+        name,
+        deviceType: isTablet() ? 'tablet' : 'mobile',
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [DEVICE_INFO_KEY]});

--- a/src/frontend/hooks/server/deviceInfo.ts
+++ b/src/frontend/hooks/server/deviceInfo.ts
@@ -1,4 +1,4 @@
-import {DeviceInfo} from '@mapeo/schema';
+import {type DeviceInfo} from '@mapeo/schema';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {deviceType, DeviceType} from 'expo-device';
 

--- a/src/frontend/hooks/server/deviceInfo.ts
+++ b/src/frontend/hooks/server/deviceInfo.ts
@@ -52,5 +52,8 @@ function expoToCoreDeviceType(d: DeviceType): DeviceInfo['deviceType'] {
     case DeviceType.UNKNOWN: {
       return 'UNRECOGNIZED';
     }
+    default: {
+      throw new Error(`Invalid device type ${d}`);
+    }
   }
 }

--- a/src/frontend/hooks/server/deviceInfo.ts
+++ b/src/frontend/hooks/server/deviceInfo.ts
@@ -1,5 +1,6 @@
+import {DeviceInfo} from '@mapeo/schema';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import {isTablet} from 'react-native-device-info';
+import {deviceType, DeviceType} from 'expo-device';
 
 import {useApi} from '../../contexts/ApiContext';
 
@@ -25,7 +26,7 @@ export const useEditDeviceInfo = () => {
     mutationFn: async (name: string) => {
       return mapeoApi.setDeviceInfo({
         name,
-        deviceType: isTablet() ? 'tablet' : 'mobile',
+        deviceType: deviceType ? expoToCoreDeviceType(deviceType) : undefined,
       });
     },
     onSuccess: () => {
@@ -33,3 +34,23 @@ export const useEditDeviceInfo = () => {
     },
   });
 };
+
+function expoToCoreDeviceType(d: DeviceType): DeviceInfo['deviceType'] {
+  switch (d) {
+    case DeviceType.PHONE: {
+      return 'mobile';
+    }
+    case DeviceType.TABLET: {
+      return 'tablet';
+    }
+    case DeviceType.TV: {
+      return undefined;
+    }
+    case DeviceType.DESKTOP: {
+      return 'desktop';
+    }
+    case DeviceType.UNKNOWN: {
+      return 'UNRECOGNIZED';
+    }
+  }
+}


### PR DESCRIPTION
the `deviceType` field was added as part of the `deviceInfo` that can be retrieved and saved.