### PR TITLE
fix: fix useRejectInvite mutation

### DIFF
--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -58,7 +58,7 @@ export function useRejectInvite() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({inviteId}: {inviteId: string}) => {
-      mapeoApi.invite.reject({inviteId});
+      return mapeoApi.invite.reject({inviteId});
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [INVITE_KEY]});


### PR DESCRIPTION
potentially avoids very subtle bugs caused by race conditions. prior to this change, the mutation is not waiting on the actual reject call to finish, which could lead to issues if the app code is - for example - rejecting an invitation and then refetching all of the invites with the expectation of the rejection being applied first