### PR TITLE
fix: update invites api usage to fix invite accept flow

### DIFF
--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -21,7 +21,7 @@ export function usePendingInvites() {
   });
 }
 
-export function useAcceptInvite(projectId?: string) {
+export function useAcceptInvite() {
   const mapeoApi = useApi();
   const queryClient = useQueryClient();
   const switchActiveProject = usePersistedProjectId(
@@ -30,25 +30,17 @@ export function useAcceptInvite(projectId?: string) {
 
   return useMutation({
     mutationFn: async ({inviteId}: {inviteId: string}) => {
-      if (!inviteId) return;
       return mapeoApi.invite.accept({inviteId});
     },
-    onSuccess: () => {
-      // This is a workaround. There is a race condition where the project in not available when the invite is accepted. This is temporary and is currently being worked on.
-      setTimeout(() => {
-        Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: [INVITE_KEY],
-          }),
-          queryClient.invalidateQueries({
-            queryKey: [ALL_PROJECTS_KEY],
-          }),
-        ]).then(() => {
-          if (projectId) {
-            switchActiveProject(projectId);
-          }
-        });
-      }, 5000);
+    onSuccess: projectPublicId => {
+      queryClient.invalidateQueries({
+        queryKey: [INVITE_KEY],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [ALL_PROJECTS_KEY],
+      });
+
+      switchActiveProject(projectPublicId);
     },
   });
 }

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -27,7 +27,7 @@ export const ProjectInviteBottomSheet = ({
       inviteId: invite?.inviteId,
       bottomSheetIsOpen: isOpen,
     });
-  const accept = useAcceptInvite(invite?.projectPublicId);
+  const accept = useAcceptInvite();
   const reject = useRejectInvite();
 
   if (invite && !isOpen && enabledForCurrentScreen) {


### PR DESCRIPTION
a recent upgrade to `@mapeo/core` changed a couple of things about how invites are handled, most notably replacing the `projectPublicId` field with the `projectInviteId` field. This wasn't accounted for when upgrading to the core version that introduced that change, causing some invite-related code to be broken.