### PR TITLE
chore: enable Sentry tracing

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -17,6 +17,7 @@ import {DeviceDiagnosticMetrics} from './metrics/DeviceDiagnosticMetrics';
 
 Sentry.init({
   dsn: 'https://e0e02907e05dc72a6da64c3483ed88a6@o4507148235702272.ingest.us.sentry.io/4507170965618688',
+  tracesSampleRate: 1.0,
   debug:
     process.env.APP_VARIANT === 'development' ||
     process.env.APP_VARIANT === 'test', // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production


### PR DESCRIPTION
I would like to experimentally [enable tracing for Sentry](https://docs.sentry.io/platforms/react-native/tracing/) in order to analyze what data is collected. 

I believe with our current setup this information will be collected:

- [App Start](https://docs.sentry.io/product/insights/mobile-vitals/#app-start): how long the app takes to start (both cold starts and warm starts)
- [Slow and Frozen Frames](https://docs.sentry.io/product/insights/mobile-vitals/#slow-and-frozen-frames): Whenever the frame rate in the app drops below 60fps, or if a frame is frozen for >700ms
- [Stall Tracking](https://docs.sentry.io/platforms/react-native/tracing/instrumentation/automatic-instrumentation/#stall-tracking): When the JavaScript event loop takes longer than expected to complete
- [Fetch/XML Request Instrumentation](https://docs.sentry.io/platforms/react-native/troubleshooting/#fetchxml-request-instrumentation): Measures any HTTP requests (e.g. blob server and map server)

I think those are all ok to collect within the context of "app diagnostics", but we should maybe look at scrubbing data from URLs to avoid sending any IDs (we can check this once we start collecting data).

What we don't want to collect by default are:

- [User Interaction](https://docs.sentry.io/platforms/react-native/tracing/instrumentation/user-interaction-instrumentation/): This records touch events, and is not captured by Sentry unless we set `enableUserInteractionTracing: true`
- [Routing Instrumentation](https://docs.sentry.io/platforms/react-native/troubleshooting/#enable-routing-instrumentation): Records route transition performance and errors.
- [Time to Display](https://docs.sentry.io/platforms/react-native/tracing/instrumentation/time-to-display/): This requires routing instrumentation.

I believe these last three collect detailed information (even though it's anonymized) that a user might consider a privacy issue, and we should only turn them on if the user opts-in to share that data.

I think we can capture time to display without routing instrumentation by using the [Sentry time to display components](https://docs.sentry.io/platforms/react-native/tracing/instrumentation/time-to-display/#time-to-initial-display-overwrite). We can add that in a follow-up issue.

Merging this PR will allow us to validate what information is collected before we release MVP, so that we can adjust the config or update our privacy policy accordingly.

