### PR TITLE
chore: rotate Sentry user ID every month

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -11,8 +11,10 @@ import * as SplashScreen from 'expo-splash-screen';
 import * as Sentry from '@sentry/react-native';
 import * as TaskManager from 'expo-task-manager';
 import {LOCATION_TASK_NAME, LocationCallbackInfo} from './sharedTypes/location';
+import {storage} from './hooks/persistedState/createPersistedState';
 import {tracksStore} from './hooks/persistedState/usePersistedTrack';
 import {useOnBackgroundedAndForegrounded} from './hooks/useOnBackgroundedAndForegrounded';
+import {getSentryUserId} from './metrics/getSentryUserId';
 import {DeviceDiagnosticMetrics} from './metrics/DeviceDiagnosticMetrics';
 
 Sentry.init({
@@ -20,6 +22,11 @@ Sentry.init({
   debug:
     process.env.APP_VARIANT === 'development' ||
     process.env.APP_VARIANT === 'test', // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+  initialScope: {
+    user: {
+      id: getSentryUserId({now: new Date(), storage}),
+    },
+  },
 });
 
 const messagePort = new MessagePortLike();

--- a/src/frontend/__mocks__/expo-crypto.ts
+++ b/src/frontend/__mocks__/expo-crypto.ts
@@ -1,4 +1,8 @@
-import {createHash, type BinaryToTextEncoding} from 'node:crypto';
+import {
+  createHash,
+  type BinaryToTextEncoding,
+  randomBytes as nodeRandomBytes,
+} from 'node:crypto';
 
 export enum CryptoDigestAlgorithm {
   SHA512 = 'sha512',
@@ -8,6 +12,12 @@ export enum CryptoEncoding {
   HEX = 'hex',
   BASE64 = 'base64',
 }
+
+export const getRandomBytes = (byteCount: number): Uint8Array =>
+  // Though Node `Buffer`s are `Uint8Array` subclasses, their behavior is
+  // [subtly different][0], so convert the result to be safe.
+  // [0]: https://nodejs.org/docs/latest-v22.x/api/buffer.html#buffers-and-typedarrays
+  new Uint8Array(nodeRandomBytes(byteCount));
 
 type CryptoDigestOptions = {
   encoding: CryptoEncoding;

--- a/src/frontend/metrics/getSentryUserId.test.ts
+++ b/src/frontend/metrics/getSentryUserId.test.ts
@@ -1,0 +1,60 @@
+import {parseISO} from 'date-fns';
+import {getSentryUserId} from './getSentryUserId';
+
+describe('getSentryUserId', () => {
+  it('returns a new user ID if storage is empty', () => {
+    const result = getSentryUserId({
+      now: new Date(),
+      storage: new FakeStorage(),
+    });
+    expect(result.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('keeps the same ID if the previous one is from the same month', () => {
+    const storage = new FakeStorage();
+
+    const result1 = getSentryUserId({
+      now: parseISO('2000-06-06T06:06:00Z'),
+      storage,
+    });
+    const result2 = getSentryUserId({
+      now: parseISO('2000-06-09T04:20:00Z'),
+      storage,
+    });
+
+    expect(result1).toEqual(result2);
+  });
+
+  it('generates a new ID if the previous ID is from a different month', () => {
+    const storage = new FakeStorage();
+
+    const result1 = getSentryUserId({
+      now: parseISO('2000-06-06T06:06:00Z'),
+      storage,
+    });
+    const result2 = getSentryUserId({
+      now: parseISO('2000-07-07T04:20:00Z'),
+      storage,
+    });
+    const result3 = getSentryUserId({
+      now: parseISO('2002-07-07T04:20:00Z'),
+      storage,
+    });
+
+    expect(result1).not.toEqual(result2);
+    expect(result2).not.toEqual(result3);
+    expect(result1).not.toEqual(result3);
+  });
+});
+
+class FakeStorage {
+  #data = new Map<string, unknown>();
+
+  getString(key: string): undefined | string {
+    return this.#data.has(key) ? String(this.#data.get(key)) : undefined;
+  }
+
+  set(key: string, value: unknown): void {
+    this.#data.set(key, value);
+  }
+}

--- a/src/frontend/metrics/getSentryUserId.ts
+++ b/src/frontend/metrics/getSentryUserId.ts
@@ -1,0 +1,29 @@
+import {getRandomBytes} from 'expo-crypto';
+import {uint8ArrayToHex} from 'uint8array-extras';
+
+type Storage = {
+  getString(key: string): undefined | string;
+  set(key: string, value: unknown): void;
+};
+
+export function getSentryUserId({
+  now,
+  storage,
+}: {
+  now: Date;
+  storage: Storage;
+}): string {
+  const sentryId = storage.getString('sentryUser.id');
+  const sentryIdMonth = storage.getString('sentryUser.idMonth');
+
+  const currentUtcMonth = now.getUTCFullYear() + '-' + now.getUTCMonth();
+
+  if (sentryId && sentryIdMonth === currentUtcMonth) {
+    return sentryId;
+  } else {
+    const result = uint8ArrayToHex(getRandomBytes(16));
+    storage.set('sentryUser.id', result);
+    storage.set('sentryUser.idMonth', currentUtcMonth);
+    return result;
+  }
+}


### PR DESCRIPTION
I verified this with (1) automated tests (2) the following in the running app:

```javascript
// This logged the user ID we set.
Sentry.withScope(scope => {
  console.log(JSON.stringify(scope.getUser()));
});
```

Closes #488.