### PR TITLE
fix: hide "disconnected" for unknown device connection status

### DIFF
--- a/src/frontend/lib/ExhaustivenessError.test.ts
+++ b/src/frontend/lib/ExhaustivenessError.test.ts
@@ -1,17 +1,19 @@
 import {ExhaustivenessError} from './ExhaustivenessError';
 
 describe('ExhaustivenessError', () => {
-  const bools = [true, false];
+  it('handles exhaustiveness', () => {
+    const bools = [true, false];
 
-  expect(() => {
-    bools.forEach(bool => {
-      switch (bool) {
-        case true:
-        case false:
-          break;
-        default:
-          throw new ExhaustivenessError(bool);
-      }
-    });
-  }).not.toThrow();
+    expect(() => {
+      bools.forEach(bool => {
+        switch (bool) {
+          case true:
+          case false:
+            break;
+          default:
+            throw new ExhaustivenessError(bool);
+        }
+      });
+    }).not.toThrow();
+  });
 });

--- a/src/frontend/lib/ExhaustivenessError.test.ts
+++ b/src/frontend/lib/ExhaustivenessError.test.ts
@@ -1,0 +1,17 @@
+import {ExhaustivenessError} from './ExhaustivenessError';
+
+describe('ExhaustivenessError', () => {
+  const bools = [true, false];
+
+  expect(() => {
+    bools.forEach(bool => {
+      switch (bool) {
+        case true:
+        case false:
+          break;
+        default:
+          throw new ExhaustivenessError(bool);
+      }
+    });
+  }).not.toThrow();
+});

--- a/src/frontend/lib/ExhaustivenessError.ts
+++ b/src/frontend/lib/ExhaustivenessError.ts
@@ -1,0 +1,6 @@
+export class ExhaustivenessError extends Error {
+  constructor(value: never) {
+    super(`Exhaustiveness check failed. ${value} should be impossible`);
+    this.name = 'ExhaustivenessError';
+  }
+}

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -67,7 +67,7 @@ export const SelectDevice: NativeNavigationComponent<'SelectDevice'> = ({
             key={deviceId}
             style={{marginBottom: 10}}
             name={name || ''}
-            isConnected={device.status === 'connected'}
+            deviceConnectionStatus={device.status}
             deviceType={deviceType}
             deviceId={deviceId}
             onPress={() =>

--- a/src/frontend/sharedComponents/DeviceCard.tsx
+++ b/src/frontend/sharedComponents/DeviceCard.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import {StyleSheet} from 'react-native';
 import {LIGHT_GREY} from '../lib/styles';
-import {DeviceType, ViewStyleProp} from '../sharedTypes';
+import {ExhaustivenessError} from '../lib/ExhaustivenessError';
+import type {
+  DeviceConnectionStatus,
+  DeviceType,
+  ViewStyleProp,
+} from '../sharedTypes';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {DeviceNameWithIcon} from './DeviceNameWithIcon';
 
 type DeviceCardProps = {
   deviceType: DeviceType;
   name: string;
-  isConnected?: boolean;
+  deviceConnectionStatus?: DeviceConnectionStatus;
   thisDevice?: boolean;
   deviceId?: string;
   dateAdded?: Date;
@@ -24,16 +29,29 @@ export const DeviceCard = ({
   deviceId,
   dateAdded,
   onPress,
-  isConnected = true,
+  deviceConnectionStatus,
 }: DeviceCardProps) => {
+  let isDisconnected: boolean;
+  switch (deviceConnectionStatus) {
+    case undefined:
+    case 'connected':
+      isDisconnected = false;
+      break;
+    case 'disconnected':
+      isDisconnected = true;
+      break;
+    default:
+      throw new ExhaustivenessError(deviceConnectionStatus);
+  }
+
   return (
     <TouchableOpacity
-      disabled={!onPress || !isConnected}
+      disabled={!onPress || isDisconnected}
       onPress={() => (onPress ? onPress() : {})}
       style={[styles.container, style]}>
       <DeviceNameWithIcon
         name={name}
-        isConnected={isConnected}
+        deviceConnectionStatus={deviceConnectionStatus}
         thisDevice={thisDevice}
         deviceType={deviceType}
         deviceId={deviceId}

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -33,7 +33,7 @@ type DeviceNameWithIconProps = {
 export const DeviceNameWithIcon = ({
   deviceType,
   name,
-  isConnected,
+  isConnected = true,
   deviceId,
   thisDevice,
   iconSize,

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 import {View, StyleSheet} from 'react-native';
 import DeviceMobile from '../images/DeviceMobile.svg';
 import DeviceDesktop from '../images/DeviceDesktop.svg';
-import {ViewStyleProp} from '../sharedTypes';
+import type {
+  ViewStyleProp,
+  DeviceConnectionStatus,
+  DeviceType,
+} from '../sharedTypes';
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from './Text';
 import {MEDIUM_GREY} from '../lib/styles';
-import {DeviceType} from '../sharedTypes';
+import {ExhaustivenessError} from '../lib/ExhaustivenessError';
 import Caution from '../images/caution.svg';
 
 const m = defineMessages({
@@ -27,19 +31,33 @@ type DeviceNameWithIconProps = {
   thisDevice?: boolean;
   iconSize?: number;
   style?: ViewStyleProp;
-  isConnected?: boolean;
+  deviceConnectionStatus?: DeviceConnectionStatus;
 };
 
 export const DeviceNameWithIcon = ({
   deviceType,
   name,
-  isConnected = true,
+  deviceConnectionStatus,
   deviceId,
   thisDevice,
   iconSize,
   style,
 }: DeviceNameWithIconProps) => {
   const {formatMessage} = useIntl();
+
+  let isDisconnected: boolean;
+  switch (deviceConnectionStatus) {
+    case undefined:
+    case 'connected':
+      isDisconnected = false;
+      break;
+    case 'disconnected':
+      isDisconnected = true;
+      break;
+    default:
+      throw new ExhaustivenessError(deviceConnectionStatus);
+  }
+
   return (
     <View style={[styles.flexRow, style]}>
       {deviceType === 'mobile' ? (
@@ -59,7 +77,7 @@ export const DeviceNameWithIcon = ({
             {formatMessage(m.thisDevice)}
           </Text>
         )}
-        {!isConnected && (
+        {isDisconnected && (
           <View style={[styles.flexRow, {marginTop: 4.4}]}>
             <Caution />
             <Text style={styles.deviceStatusText}>

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -2,6 +2,8 @@ import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {Observation, ObservationValue} from '@mapeo/schema';
 import type {RoleId, RoleIdForNewInvite} from '@mapeo/core/dist/roles';
 
+export type DeviceConnectionStatus = 'connected' | 'disconnected';
+
 export type DeviceType = 'mobile' | 'desktop';
 
 export type DeviceRole = RoleId;


### PR DESCRIPTION
The `<DeviceNameWithIcon>` component takes an optional `isConnected` prop. If it's missing, we treat the device as disconnected, which is not necessarily right.

This change inverts that, hiding the "Disconnected" text in these cases.

Fixes #493.