### PR TITLE
fix: Drawer only closes on touch of menu icon

### DIFF
--- a/src/frontend/Navigation/Drawer.tsx
+++ b/src/frontend/Navigation/Drawer.tsx
@@ -106,7 +106,10 @@ const DrawerContent = ({navigation}: DrawerContentComponentProps) => {
         style={{
           paddingBottom: 40,
         }}>
-        <DrawerMenuIcon onPress={navigation.closeDrawer} />
+        <DrawerMenuIcon
+          style={{alignSelf: 'flex-end', marginRight: 20}}
+          onPress={navigation.closeDrawer}
+        />
         <Text
           testID="MAIN.drawer-create-join-txt"
           style={{

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -28,7 +28,7 @@ export const HomeHeader: FC<
         <SyncIconCircle />
       </IconButton>
       <GPSPill navigation={navigation} />
-      <DrawerMenuIcon onPress={openDrawer} />
+      <DrawerMenuIcon style={{marginRight: 20}} onPress={openDrawer} />
     </View>
   );
 };

--- a/src/frontend/sharedComponents/icons/DrawerMenuIcon.tsx
+++ b/src/frontend/sharedComponents/icons/DrawerMenuIcon.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react';
 import IonIcon from 'react-native-vector-icons/Ionicons';
-import {IconButton} from '../IconButton';
+import {TouchableOpacity} from 'react-native';
+import {ViewStyleProp} from '../../sharedTypes';
 
-export const DrawerMenuIcon = ({onPress}: {onPress: () => void}) => (
-  <IconButton style={{alignSelf: 'flex-end'}} onPress={onPress}>
+export const DrawerMenuIcon = ({
+  onPress,
+  style,
+}: {
+  onPress: () => void;
+  style?: ViewStyleProp;
+}) => (
+  <TouchableOpacity
+    style={[{justifyContent: 'center'}, style]}
+    onPress={onPress}>
     <IonIcon name="menu" size={32} testID="MAIN.drawer-icon" />
-  </IconButton>
+  </TouchableOpacity>
 );


### PR DESCRIPTION
closes #486 

On the drawer menu, the hamburger icon's `onPress` was being activated when touching around the icon. I originally though it was the hitslop, but setting it to null did not did fix the problem. Converting the `TouchableNativeFeedback` to a `TouchableOpacity` seemed to solved the problem.

I also converted the styling so the consumer can control it. The two components have added styling to adjust for this.