### PR TITLE
fix: update map scale bar when zoom changes

### DIFF
--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -79,6 +79,9 @@ export const MapScreen = () => {
         compassEnabled={false}
         scaleBarEnabled={false}
         styleURL={styleUrlQuery.data}
+        onMapIdle={event => {
+          setZoom(event.properties.zoom);
+        }}
         onDidFinishLoadingStyle={handleDidFinishLoadingStyle}
         onMoveShouldSetResponder={() => {
           if (following) setFollowing(false);


### PR DESCRIPTION
Fixes #487 

Test instructions:

1. Open app to main map screen
2. Zoom in/out using pinch gestures
3. Observe scale bar change to account for zoom change when map is idle.

---

Preview:

https://github.com/user-attachments/assets/1b2700e5-e347-4848-9786-f69527a61f6b
