### PR TITLE
fix: refetch project members after receiving invite response

### DIFF
--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -7,7 +7,7 @@ import {
 import {useApi} from '../../contexts/ApiContext';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {usePersistedProjectId} from '../persistedState/usePersistedProjectId';
-import {ALL_PROJECTS_KEY} from './projects';
+import {ALL_PROJECTS_KEY, PROJECT_MEMBERS_KEY} from './projects';
 
 export const INVITE_KEY = 'pending_invites';
 
@@ -90,6 +90,7 @@ export function useSendInvite() {
     }) => project.$member.invite(deviceId, role),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [INVITE_KEY]});
+      queryClient.invalidateQueries({queryKey: [PROJECT_MEMBERS_KEY]});
     },
   });
 }


### PR DESCRIPTION
Fixes #492

Exposes another small issue where initially returning to the "Your Team" screen will show the newly added member but without their name. I believe this is an issue related to the backend due to the following sequence:

1. Device A invites Device B
2. Device B accepts invite from Device A and responds to Device A. Device B also starts updating its own database to add itself to the project (**this takes some time to finish**).
3. Device A receives response from Device B, refetches project's members
4. Device B finishes updating its own database. Starts syncing initial information with Device A
5. Device A receives device info information about Device B

In the preview attached, what's displayed in the "Your Team" screen is what's shown after (3). Notice that if you navigate away from that screen and come back, the expected device info is finally displayed since (4) and (5) finish and Device A refetches the members.

In the backend, when the invitee accepts an invite, it will:

1. [Send the response](https://github.com/digidem/mapeo-core-next/blob/534c2853f569655ece3a790c3516e89dc98d7582/src/invite-api.js#L363), which causes the transition from steps (2) to (3)
2. [Add itself to the project](https://github.com/digidem/mapeo-core-next/blob/534c2853f569655ece3a790c3516e89dc98d7582/src/invite-api.js#L378). It's only after this step that Device A can "properly" obtain the device information of Device B via syncing (happens involuntarily in the background), which is then used to populate the information about project members

Not sure if solving the issue is as simple as switching the above two steps, as I can imagine it introducing some other issues and having different UX tradeoffs.

---

Preview:

https://github.com/user-attachments/assets/8e9abbf6-0af8-408a-ab64-3a94ddc08c90

