### PR TITLE
feat: expose app passcode setting

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -739,15 +739,6 @@
     "description": "Category title for new track screen",
     "message": "Track"
   },
-  "screens.Security.obscurePassDescriptonPassNotSet": {
-    "message": "To use, enable App Passcode"
-  },
-  "screens.Security.obscurePassDescriptonPassSet": {
-    "message": "Protect your device against seizure"
-  },
-  "screens.Security.obscurePasscodeHeader": {
-    "message": "Obscure Passcode"
-  },
   "screens.Security.passDesriptionPassNotSet": {
     "message": "Passcode not set"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -199,13 +199,16 @@
   },
   "screens.AppPasscode.ConfirmPasscodeSheet.passcode": {
     "description": "used to indicate to the user what the new passcode will be.",
-    "message": "Passcode"
+    "message": "Passcode: {passcode}"
   },
   "screens.AppPasscode.ConfirmPasscodeSheet.saveAppPasscode": {
     "message": "Save App Passcode"
   },
+  "screens.AppPasscode.ConfirmPasscodeSheet.suggestion": {
+    "message": "Make sure to note your passcode in a secure location before saving."
+  },
   "screens.AppPasscode.ConfirmPasscodeSheet.title": {
-    "message": "App Passcodes can never be recovered if lost or forgotten! Make sure to note your passcode in a secure location before saving."
+    "message": "App Passcodes can never be recovered if lost or forgotten!"
   },
   "screens.AppPasscode.EnterPassToTurnOff.subTitleEnter": {
     "message": "Please Enter Passcode"

--- a/messages/en.json
+++ b/messages/en.json
@@ -92,6 +92,9 @@
     "description": "list of avaialable project settings",
     "message": "Categories, Config, Team"
   },
+  "Navigation.Drawer.security": {
+    "message": "Security"
+  },
   "Navigation.Drawer.title": {
     "description": "Title of settings screen",
     "message": "Settings"

--- a/src/frontend/Navigation/Drawer.tsx
+++ b/src/frontend/Navigation/Drawer.tsx
@@ -20,6 +20,7 @@ import {useProjectSettings} from '../hooks/server/projects';
 import {AppStackParamsList} from '../sharedTypes/navigation';
 import {RootStackNavigator} from './Stack';
 import {DrawerMenuIcon} from '../sharedComponents/icons/DrawerMenuIcon';
+import {useSecurityContext} from '../contexts/SecurityContext';
 
 const m = defineMessages({
   settingsTitle: {
@@ -71,6 +72,10 @@ const m = defineMessages({
     id: 'Navigation.Drawer.createOrJoinToSync',
     defaultMessage: 'Create or Join a Project to sync with other devices',
   },
+  security: {
+    id: 'Navigation.Drawer.security',
+    defaultMessage: 'Security',
+  },
 });
 
 export type DrawerScreens = {
@@ -98,6 +103,8 @@ const DrawerContent = ({navigation}: DrawerContentComponentProps) => {
   const {navigate} = navigation;
   const {formatMessage} = useIntl();
   const {data} = useProjectSettings();
+  const {authState} = useSecurityContext();
+
   return (
     <DrawerContentScrollView
       contentContainerStyle={{flexGrow: 1}}
@@ -159,6 +166,15 @@ const DrawerContent = ({navigation}: DrawerContentComponentProps) => {
           <DrawerListItemIcon iconName="settings-suggest" />
           <ListItemText primary={<FormattedMessage {...m.appSettings} />} />
         </ListItem>
+        {authState !== 'obscured' && (
+          <ListItem
+            onPress={() => {
+              navigate('Security');
+            }}>
+            <DrawerListItemIcon iconName="security" />
+            <ListItemText primary={<FormattedMessage {...m.security} />} />
+          </ListItem>
+        )}
         <ListItem
           onPress={() => {
             navigate('AboutSettings');

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -91,9 +91,7 @@ export const createDefaultScreenGroup = ({
       component={AuthScreen}
       options={{
         headerShown: false,
-        // TODO: These don't seem to work
-        presentation: 'fullScreenModal',
-        animation: 'slide_from_bottom',
+        animation: 'fade',
       }}
     />
     <RootStack.Screen

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -89,7 +89,12 @@ export const createDefaultScreenGroup = ({
     <RootStack.Screen
       name="AuthScreen"
       component={AuthScreen}
-      options={{headerShown: false}}
+      options={{
+        headerShown: false,
+        // TODO: These don't seem to work
+        presentation: 'fullScreenModal',
+        animation: 'slide_from_bottom',
+      }}
     />
     <RootStack.Screen
       name="ObservationEdit"

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -48,14 +48,6 @@ export function useDrawerNavigation() {
 export function RootStackNavigator({
   navigation,
 }: DrawerScreenProps<DrawerScreens, 'DrawerHome'>) {
-  const security = useSecurityContext();
-
-  React.useEffect(() => {
-    if (security.authState === 'unauthenticated') {
-      navigation.navigate('DrawerHome', {screen: 'AuthScreen'});
-    }
-  }, [security.authState, navigation]);
-
   return (
     <DrawerNavigationContext.Provider value={navigation}>
       <React.Suspense fallback={<Loading />}>
@@ -82,25 +74,21 @@ function RootStackNavigatorChild() {
 
   const security = useSecurityContext();
 
-  // const navigation = useNavigationFromRoot();
+  const {navigate} = useNavigationFromRoot();
 
-  // React.useEffect(() => {
-  //   if (security.authState === 'unauthenticated') {
-  //     navigation.navigate('AuthScreen');
-  //   }
-  // }, [security.authState, navigation]);
+  React.useEffect(() => {
+    if (security.authState === 'unauthenticated') {
+      navigate('AuthScreen');
+    }
+  }, [security.authState, navigate]);
 
   return (
     <RootStack.Navigator
-      initialRouteName={
-        security.authState === 'unauthenticated'
-          ? 'AuthScreen'
-          : getInitialRouteName({
-              hasDeviceName: !!deviceInfo.data.name,
-              existingObservation,
-              presets,
-            })
-      }
+      initialRouteName={getInitialRouteName({
+        hasDeviceName: !!deviceInfo.data.name,
+        existingObservation,
+        presets,
+      })}
       screenOptions={NavigatorScreenOptions}>
       {deviceInfo.data?.name
         ? createDefaultScreenGroup({

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -19,6 +19,8 @@ import {createDeviceNamingScreens} from './DeviceNamingScreens';
 import {useSuspenseQuery} from '@tanstack/react-query';
 import {useApi} from '../../contexts/ApiContext';
 import {Loading} from '../../sharedComponents/Loading';
+import {useSecurityContext} from '../../contexts/SecurityContext';
+import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 
 export const RootStack = createNativeStackNavigator<AppStackParamsList>();
 
@@ -46,6 +48,14 @@ export function useDrawerNavigation() {
 export function RootStackNavigator({
   navigation,
 }: DrawerScreenProps<DrawerScreens, 'DrawerHome'>) {
+  const security = useSecurityContext();
+
+  React.useEffect(() => {
+    if (security.authState === 'unauthenticated') {
+      navigation.navigate('DrawerHome', {screen: 'AuthScreen'});
+    }
+  }, [security.authState, navigation]);
+
   return (
     <DrawerNavigationContext.Provider value={navigation}>
       <React.Suspense fallback={<Loading />}>
@@ -70,13 +80,27 @@ function RootStackNavigatorChild() {
     },
   });
 
+  const security = useSecurityContext();
+
+  // const navigation = useNavigationFromRoot();
+
+  // React.useEffect(() => {
+  //   if (security.authState === 'unauthenticated') {
+  //     navigation.navigate('AuthScreen');
+  //   }
+  // }, [security.authState, navigation]);
+
   return (
     <RootStack.Navigator
-      initialRouteName={getInitialRouteName({
-        hasDeviceName: !!deviceInfo.data.name,
-        existingObservation,
-        presets,
-      })}
+      initialRouteName={
+        security.authState === 'unauthenticated'
+          ? 'AuthScreen'
+          : getInitialRouteName({
+              hasDeviceName: !!deviceInfo.data.name,
+              existingObservation,
+              presets,
+            })
+      }
       screenOptions={NavigatorScreenOptions}>
       {deviceInfo.data?.name
         ? createDefaultScreenGroup({

--- a/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
+++ b/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
@@ -15,7 +15,12 @@ const m = defineMessages({
   title: {
     id: 'screens.AppPasscode.ConfirmPasscodeSheet.title',
     defaultMessage:
-      'App Passcodes can never be recovered if lost or forgotten! Make sure to note your passcode in a secure location before saving.',
+      'App Passcodes can never be recovered if lost or forgotten!',
+  },
+  suggestion: {
+    id: 'screens.AppPasscode.ConfirmPasscodeSheet.suggestion',
+    defaultMessage:
+      'Make sure to note your passcode in a secure location before saving.',
   },
   cancel: {
     id: 'screens.AppPasscode.ConfirmPasscodeSheet.cancel',
@@ -27,7 +32,7 @@ const m = defineMessages({
   },
   passcode: {
     id: 'screens.AppPasscode.ConfirmPasscodeSheet.passcode',
-    defaultMessage: 'Passcode',
+    defaultMessage: 'Passcode: {passcode}',
     description: 'used to indicate to the user what the new passcode will be.',
   },
 });
@@ -54,7 +59,9 @@ export const ConfirmPasscodeSheet = React.forwardRef<
     <BottomSheetModal isOpen={isOpen} ref={sheetRef} onDismiss={() => {}}>
       <BottomSheetModalContent
         title={t(m.title)}
-        description={`${t(m.passcode)}: ${inputtedPasscode}`}
+        description={
+          t(m.suggestion) + '\n\n' + t(m.passcode, {passcode: inputtedPasscode})
+        }
         buttonConfigs={[
           {
             text: t(m.cancel),

--- a/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
+++ b/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
+import {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 import {defineMessages, useIntl} from 'react-intl';
-import {StyleSheet} from 'react-native';
-import {RED} from '../../lib/styles';
-import {
-  BottomSheetModalContent,
-  BottomSheetModal,
-} from '../../sharedComponents/BottomSheetModal';
-import {ErrorIcon} from '../../sharedComponents/icons';
+
 import {usePersistedPasscode} from '../../hooks/persistedState/usePersistedPasscode';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
-import {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
+import ErrorIcon from '../../images/Error.svg';
+import {RED} from '../../lib/styles';
+import {
+  BottomSheetModal,
+  BottomSheetModalContent,
+} from '../../sharedComponents/BottomSheetModal';
 
 const m = defineMessages({
   title: {
@@ -53,8 +53,6 @@ export const ConfirmPasscodeSheet = React.forwardRef<
   return (
     <BottomSheetModal isOpen={isOpen} ref={sheetRef} onDismiss={() => {}}>
       <BottomSheetModalContent
-        titleStyle={styles.text}
-        descriptionStyle={styles.text}
         title={t(m.title)}
         description={`${t(m.passcode)}: ${inputtedPasscode}`}
         buttonConfigs={[
@@ -71,14 +69,8 @@ export const ConfirmPasscodeSheet = React.forwardRef<
             onPress: setPasscodeAndNavigateBack,
           },
         ]}
-        icon={<ErrorIcon size={90} color={RED} />}
+        icon={<ErrorIcon width={60} height={60} color={RED} />}
       />
     </BottomSheetModal>
   );
-});
-
-const styles = StyleSheet.create({
-  text: {
-    fontSize: 16,
-  },
 });

--- a/src/frontend/screens/AppPasscode/InputPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/InputPasscode.tsx
@@ -108,10 +108,8 @@ export const InputPasscode = ({
               <Button
                 fullWidth
                 onPress={() => {
-                  {
-                    if (validate(inputValue)) {
-                      openSheet();
-                    }
+                  if (validate(inputValue)) {
+                    openSheet();
                   }
                 }}>
                 <Text style={[styles.buttonText, {color: WHITE}]}>

--- a/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import {BackHandler, StyleSheet, View} from 'react-native';
 import {defineMessages, FormattedMessage, useIntl} from 'react-intl';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
-import BottomSheet, {BottomSheetBackdrop} from '@gorhom/bottom-sheet';
-import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 
 import {
@@ -13,8 +11,7 @@ import {
   ListItemText,
 } from '../../sharedComponents/List';
 import {MEDIUM_GREY, RED, WHITE} from '../../lib/styles';
-import {ErrorIcon} from '../../sharedComponents/icons';
-import {Button} from '../../sharedComponents/Button';
+import ErrorIcon from '../../images/Error.svg';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {useFocusEffect, StackActions} from '@react-navigation/native';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
@@ -22,6 +19,11 @@ import {HeaderButtonProps} from '@react-navigation/native-stack/lib/typescript/s
 import {usePersistedPasscode} from '../../hooks/persistedState/usePersistedPasscode';
 import {useSecurityContext} from '../../contexts/SecurityContext';
 import {Text} from '../../sharedComponents/Text';
+import {
+  BottomSheetModal,
+  BottomSheetModalContent,
+  useBottomSheetModal,
+} from '../../sharedComponents/BottomSheetModal';
 
 const m = defineMessages({
   usePasscode: {
@@ -66,7 +68,9 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
   const {authValuesSet} = useSecurityContext();
   const setPasscode = usePersistedPasscode(state => state.setPasscode);
 
-  const sheetRef = React.useRef<BottomSheetMethods>(null);
+  const {sheetRef, openSheet, closeSheet, isOpen} = useBottomSheetModal({
+    openOnMount: false,
+  });
 
   const {navigate} = navigation;
 
@@ -107,10 +111,6 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
     navigate('Security');
   }
 
-  function openBottomSheet() {
-    sheetRef.current?.snapToIndex(1);
-  }
-
   return (
     <View style={styles.pageContainer}>
       <Text style={styles.description}>{t(m.description)}</Text>
@@ -118,12 +118,12 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
         {t(m.currentlyUsing)}
       </Text>
       <List>
-        <ListItem style={styles.checkBoxContainer} onPress={openBottomSheet}>
+        <ListItem style={styles.checkBoxContainer} onPress={openSheet}>
           <ListItemText
             style={styles.text}
             primary={<FormattedMessage {...m.usePasscode} />}
           />
-          <TouchableOpacity shouldActivateOnStart onPress={openBottomSheet}>
+          <TouchableOpacity shouldActivateOnStart onPress={openSheet}>
             <MaterialIcon
               name={
                 authValuesSet.passcodeSet
@@ -151,67 +151,28 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
           </ListItem>
         )}
       </List>
-      <ConfirmTurnOffPasswordModal
-        turnOffPasscode={unsetAppPasscode}
-        ref={sheetRef}
-        closeSheet={() => {
-          sheetRef.current?.close();
-        }}
-      />
+      <BottomSheetModal ref={sheetRef} isOpen={isOpen}>
+        <BottomSheetModalContent
+          title={t(m.turnOffConfirmation)}
+          icon={<ErrorIcon width={60} height={60} color={RED} />}
+          buttonConfigs={[
+            {
+              dangerous: true,
+              onPress: unsetAppPasscode,
+              text: t(m.turnOff),
+              variation: 'filled',
+            },
+            {
+              onPress: closeSheet,
+              text: t(m.cancel),
+              variation: 'outlined',
+            },
+          ]}
+        />
+      </BottomSheetModal>
     </View>
   );
 };
-
-interface ConfirmTurnOffPasswordModalProps {
-  turnOffPasscode: () => void;
-  closeSheet: () => void;
-}
-
-const ConfirmTurnOffPasswordModal = React.forwardRef<
-  BottomSheetMethods,
-  ConfirmTurnOffPasswordModalProps
->(({turnOffPasscode, closeSheet}, sheetRef) => {
-  const [snapPoints, setSnapPoints] = React.useState<(number | string)[]>([
-    1,
-    '40%',
-  ]);
-
-  const {formatMessage: t} = useIntl();
-
-  return (
-    <BottomSheet
-      ref={sheetRef}
-      snapPoints={snapPoints}
-      backdropComponent={BottomSheetBackdrop}
-      enableContentPanningGesture={false}
-      enableHandlePanningGesture={false}
-      handleHeight={0}
-      handleComponent={() => null}
-      index={-1}>
-      <View
-        onLayout={e => {
-          const {height} = e.nativeEvent.layout;
-          setSnapPoints([1, height]);
-        }}
-        style={styles.btmSheetContainer}>
-        <ErrorIcon style={{position: 'relative'}} size={90} color={RED} />
-        <Text style={{fontSize: 24, textAlign: 'center', margin: 10}}>
-          {t(m.turnOffConfirmation)}
-        </Text>
-        <Button
-          onPress={turnOffPasscode}
-          fullWidth
-          color="dark"
-          style={{backgroundColor: RED, marginTop: 30, marginBottom: 20}}>
-          {t(m.turnOff)}
-        </Button>
-        <Button onPress={closeSheet} fullWidth variant="outlined">
-          {t(m.cancel)}
-        </Button>
-      </View>
-    </BottomSheet>
-  );
-});
 
 TurnOffPasscode.navTitle = m.title;
 
@@ -223,13 +184,6 @@ const styles = StyleSheet.create({
   checkBoxContainer: {
     display: 'flex',
     alignItems: 'center',
-  },
-  btmSheetContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
   },
   description: {
     marginTop: 40,

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -46,7 +46,6 @@ export const AuthScreen = ({
   React.useEffect(() => {
     if (authState === 'unauthenticated') return;
 
-    console.log(JSON.stringify(navigation.getState(), null, 4));
     if (navigation.canGoBack()) {
       navigation.goBack();
     } else {

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -45,7 +45,8 @@ export const AuthScreen = ({
 
   React.useEffect(() => {
     if (authState === 'unauthenticated') return;
-    // TODO: Not working as expected
+
+    console.log(JSON.stringify(navigation.getState(), null, 4));
     if (navigation.canGoBack()) {
       navigation.goBack();
     } else {

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {defineMessages, useIntl} from 'react-intl';
-import {Image, ScrollView, StyleSheet, Text} from 'react-native';
+import {ScrollView, StyleSheet, Text} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {useSecurityContext} from '../contexts/SecurityContext';
-import {COMAPEO_DARK_BLUE, RED} from '../lib/styles';
+import CoMapeoLogoSvg from '../images/CoMapeoLogo.svg';
+import {RED} from '../lib/styles';
 import {PasscodeInput} from '../sharedComponents/PasscodeInput';
 import {ScreenContentWithDock} from '../sharedComponents/ScreenContentWithDock';
 import {AppStackParamsList} from '../sharedTypes/navigation';
+import {useWindowDimensions} from 'react-native';
 
 const m = defineMessages({
   enterPass: {
@@ -77,15 +79,18 @@ export const AuthScreen = ({
   }
 
   const {top} = useSafeAreaInsets();
+  const window = useWindowDimensions();
 
   return (
     <ScreenContentWithDock
-      contentContainerStyle={[styles.contentContainer, {paddingTop: top}]}
+      contentContainerStyle={[
+        styles.contentContainer,
+        {paddingTop: top + 20, paddingBottom: 20},
+      ]}
       dockContent={
         error && <Text style={styles.wrongPass}>{t(m.wrongPass)}</Text>
       }>
-      <Image source={require('../images/icon_mapeo_pin.png')} />
-      <Text style={styles.title}>CoMapeo</Text>
+      <CoMapeoLogoSvg height={window.height / 3} />
       <Text style={styles.description}>{t(m.enterPass)}</Text>
       <PasscodeInput
         error={error}
@@ -100,11 +105,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     gap: 20,
     alignItems: 'center',
-  },
-  title: {
-    fontSize: 52.5,
-    color: COMAPEO_DARK_BLUE,
-    fontWeight: '500',
   },
   description: {
     fontSize: 16,

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -1,17 +1,13 @@
 import * as React from 'react';
-import {defineMessages, FormattedMessage} from 'react-intl';
-import {
-  Image,
-  Text,
-  StyleSheet,
-  ScrollView,
-  KeyboardAvoidingView,
-} from 'react-native';
-
-import {DARK_BLUE, RED, WHITE} from '../lib/styles';
-import {PasscodeInput} from '../sharedComponents/PasscodeInput';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {defineMessages, useIntl} from 'react-intl';
+import {Image, ScrollView, StyleSheet, Text} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+
 import {useSecurityContext} from '../contexts/SecurityContext';
+import {COMAPEO_DARK_BLUE, RED} from '../lib/styles';
+import {PasscodeInput} from '../sharedComponents/PasscodeInput';
+import {ScreenContentWithDock} from '../sharedComponents/ScreenContentWithDock';
 import {AppStackParamsList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
@@ -28,6 +24,7 @@ const m = defineMessages({
 export const AuthScreen = ({
   navigation,
 }: NativeStackScreenProps<AppStackParamsList, 'AuthScreen'>) => {
+  const {formatMessage: t} = useIntl();
   const [error, setError] = React.useState(false);
   const {authenticate, authState} = useSecurityContext();
   const [inputtedPass, setInputtedPass] = React.useState('');
@@ -48,7 +45,12 @@ export const AuthScreen = ({
 
   React.useEffect(() => {
     if (authState === 'unauthenticated') return;
-    navigation.goBack();
+    // TODO: Not working as expected
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate('Home', {screen: 'Map'});
+    }
   }, [authState, navigation]);
 
   if (error) {
@@ -74,53 +76,42 @@ export const AuthScreen = ({
     }
   }
 
+  const {top} = useSafeAreaInsets();
+
   return (
-    <ScrollView
-      ref={scrollViewRef}
-      style={{height: '100%', backgroundColor: WHITE}}>
-      <KeyboardAvoidingView behavior="padding" style={styles.container}>
-        <Image source={require('../images/icon_mapeo_pin.png')} />
-        <Text style={[styles.title]}>Mapeo</Text>
-
-        <Text style={[{marginBottom: 20, fontSize: 16}]}>
-          <FormattedMessage {...m.enterPass} />
-        </Text>
-
-        <PasscodeInput
-          error={error}
-          inputValue={inputtedPass}
-          onChangeTextWithValidation={setInputWithValidation}
-        />
-
-        {error && (
-          <Text style={[styles.wrongPass]}>
-            <FormattedMessage {...m.wrongPass} />
-          </Text>
-        )}
-      </KeyboardAvoidingView>
-    </ScrollView>
+    <ScreenContentWithDock
+      contentContainerStyle={[styles.contentContainer, {paddingTop: top}]}
+      dockContent={
+        error && <Text style={styles.wrongPass}>{t(m.wrongPass)}</Text>
+      }>
+      <Image source={require('../images/icon_mapeo_pin.png')} />
+      <Text style={styles.title}>CoMapeo</Text>
+      <Text style={styles.description}>{t(m.enterPass)}</Text>
+      <PasscodeInput
+        error={error}
+        inputValue={inputtedPass}
+        onChangeTextWithValidation={setInputWithValidation}
+      />
+    </ScreenContentWithDock>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingHorizontal: 20,
+  contentContainer: {
+    gap: 20,
     alignItems: 'center',
-    paddingTop: 40,
-    backgroundColor: WHITE,
   },
   title: {
     fontSize: 52.5,
-    color: DARK_BLUE,
+    color: COMAPEO_DARK_BLUE,
     fontWeight: '500',
-    marginBottom: 40,
+  },
+  description: {
+    fontSize: 16,
   },
   wrongPass: {
-    marginTop: 20,
-    paddingBottom: 20,
     fontSize: 16,
     color: RED,
+    textAlign: 'center',
   },
 });

--- a/src/frontend/screens/Security/index.tsx
+++ b/src/frontend/screens/Security/index.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
-
+import {defineMessages, useIntl} from 'react-intl';
 import {ScrollView} from 'react-native-gesture-handler';
-import {FormattedMessage, defineMessages} from 'react-intl';
 
+import {useSecurityContext} from '../../contexts/SecurityContext';
 import {List, ListItem, ListItemText} from '../../sharedComponents/List';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
-import {MEDIUM_GREY, RED} from '../../lib/styles';
-import {Text} from 'react-native';
-import {useSecurityContext} from '../../contexts/SecurityContext';
 
 const m = defineMessages({
   title: {
@@ -30,46 +27,19 @@ const m = defineMessages({
     id: 'screens.Security.passDesriptionPassSet',
     defaultMessage: 'Passcode is set',
   },
-  obscurePasscodeHeader: {
-    id: 'screens.Security.obscurePasscodeHeader',
-    defaultMessage: 'Obscure Passcode',
-  },
-  obscurePassDescriptonPassNotSet: {
-    id: 'screens.Security.obscurePassDescriptonPassNotSet',
-    defaultMessage: 'To use, enable App Passcode',
-  },
-  obscurePassDescriptonPassSet: {
-    id: 'screens.Security.obscurePassDescriptonPassSet',
-    defaultMessage: 'Protect your device against seizure',
-  },
 });
 
 export const Security: NativeNavigationComponent<'Security'> = ({
   navigation,
 }) => {
+  const {formatMessage: t} = useIntl();
   const {authState, authValuesSet} = useSecurityContext();
-  const [highlight, setHighlight] = React.useState(false);
 
   React.useEffect(() => {
     if (authState === 'obscured') {
       navigation.navigate('Settings');
     }
   }, [navigation, authState]);
-
-  const [passCodeDes, obscurePassCodeDes] = React.useMemo(
-    () =>
-      authValuesSet.passcodeSet
-        ? [m.passDesriptionPassSet, m.obscurePassDescriptonPassSet]
-        : [m.passDesriptionPassNotSet, m.obscurePassDescriptonPassNotSet],
-    [authValuesSet.passcodeSet],
-  );
-
-  function highlightError() {
-    setHighlight(true);
-    setTimeout(() => {
-      setHighlight(false);
-    }, 2000);
-  }
 
   return (
     <ScrollView>
@@ -78,30 +48,16 @@ export const Security: NativeNavigationComponent<'Security'> = ({
           button={true}
           onPress={() =>
             navigation.navigate(
-              !authValuesSet.passcodeSet ? 'AppPasscode' : 'EnterPassToTurnOff',
+              authValuesSet.passcodeSet ? 'EnterPassToTurnOff' : 'AppPasscode',
             )
           }>
           <ListItemText
-            primary={<FormattedMessage {...m.passcodeHeader} />}
-            secondary={<FormattedMessage {...passCodeDes} />}
-          />
-        </ListItem>
-
-        <ListItem
-          onPress={() => {
-            if (!authValuesSet.passcodeSet) {
-              highlightError();
-              return;
-            }
-            navigation.navigate('ObscurePasscode');
-          }}>
-          <ListItemText
-            primary={<FormattedMessage {...m.obscurePasscodeHeader} />}
-            secondary={
-              <Text style={{color: highlight ? RED : MEDIUM_GREY}}>
-                <FormattedMessage {...obscurePassCodeDes} />
-              </Text>
-            }
+            primary={t(m.passcodeHeader)}
+            secondary={t(
+              authValuesSet.passcodeSet
+                ? m.passDesriptionPassSet
+                : m.passDesriptionPassNotSet,
+            )}
           />
         </ListItem>
       </List>


### PR DESCRIPTION
Fixes #490

Seems that getting the security context set up was already done prior to this.

Also adds UI fixes for:

- bottom sheet modal that appears when confirming the app passcode to set
- bottom sheet modal that appears when confirming to turn off app passcode

Testing instructions:

1. Open side drawer
2. Press `Security` list item
3. Press `App Passcode` list item
4. Press `Continue` button
5. Use input to create app passcode. Press `Next` button
6. Repeat (5)
7. Press `Save App Passcode` in bottom sheet modal
8. Unfocus - but do not close - the app (e.g. go to a different app, do gesture/press button to go to phone home screen, etc). Re-focus the app. The auth screen should appear and require inputting passcode. After entering passcode successfully, authscreen should disappear and you should land on the same screen that you were on when unfocusing the app
9. Close the app and then re-open. The auth screen should appear and require input. After succeeding, you should be taken to the expected initial screen (which is usually the map screen, or if you had a draft observation, the appropriate observation flow screen).
10. To turn off app passcode, repeat (1), (2), and (3).
11. Enter passcode
12. Press `Use App Passcode`. A bottom sheet modal confirming your choice should appear. Press `Turn Off` button to confirm.

Open question:

- Should we hide the obscure passcode setting for now? None of the app code is actually using that setting, so unless we plan to follow up on it immediately, it seems misleading to have it available via this PR. My suggestion would be to hide it for now, and then reintroduce it when we make the appropriate changes throughout the app to actually use it.

---

Preview:

(note that the obscure passcode setting has been removed, was just too lazy to recreate the video for now 😅 )

https://github.com/user-attachments/assets/5ad47185-cd2b-4230-ab73-bf4a2736356b
