### PR TITLE
chore: remove unused import

### DIFF
--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -1,11 +1,6 @@
 import {Observation} from '@mapeo/schema';
 import {BlobVariant} from '@mapeo/core/dist/types';
-import {
-  useMutation,
-  useQueries,
-  useQuery,
-  UseQueryOptions,
-} from '@tanstack/react-query';
+import {useMutation, useQueries, useQuery} from '@tanstack/react-query';
 import {SetRequired} from 'type-fest';
 import {URL} from 'react-native-url-polyfill';
 


### PR DESCRIPTION
`UseQueryOptions` type was imported but not used.