### PR TITLE
fix: fix potential field access issue when editing observation

### DIFF
--- a/src/frontend/screens/ObservationEdit/SaveButton.tsx
+++ b/src/frontend/screens/ObservationEdit/SaveButton.tsx
@@ -14,8 +14,8 @@ import {DraftPhoto, Photo} from '../../contexts/PhotoPromiseContext/types';
 import {useDraftObservation} from '../../hooks/useDraftObservation';
 import {usePersistedTrack} from '../../hooks/persistedState/usePersistedTrack';
 import SaveCheck from '../../images/CheckMark.svg';
-import {useProject} from '../../hooks/server/projects';
 import {CommonActions} from '@react-navigation/native';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
 const m = defineMessages({
   noGpsTitle: {
@@ -83,7 +83,7 @@ export const SaveButton = ({
   const addNewTrackObservation = usePersistedTrack(
     state => state.addNewObservation,
   );
-  const project = useProject();
+  const project = useActiveProject();
 
   function createObservation() {
     if (!value) throw new Error('no observation saved in persisted state ');


### PR DESCRIPTION
The original implementation was doing `const project = useProject()` and was trying to access the returned value as a normal project api, which is incorrect because `project` is a react query object. This PR switches it to use `useActiveProject()` which can be used as the project api directly.

Editing an observation is not yet exposed in the UI, so this technically preemptively fixes an issue that could have been encountered otherwise.