### PR TITLE
chore: fix type issues related to non-existent audioRecordings prop

### DIFF
--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -104,7 +104,6 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
                     };
               })}
               observationId={observationId}
-              audioRecordings={[]}
             />
           )}
         </View>

--- a/src/frontend/screens/ObservationEdit/ThumbnailAndActionTab.tsx
+++ b/src/frontend/screens/ObservationEdit/ThumbnailAndActionTab.tsx
@@ -46,9 +46,7 @@ export const ThumbnailAndActionTab: FC<ThumbnailAndActionTab> = ({
   const {formatMessage: t} = useIntl();
   const {usePreset} = useDraftObservation();
   const preset = usePreset();
-  const {photos, audioRecordings, observationId} = usePersistedDraftObservation(
-    store => store,
-  );
+  const {photos, observationId} = usePersistedDraftObservation(store => store);
   const {
     openSheet: openAudioPermissionSheet,
     sheetRef: audioPermissionSheetRef,
@@ -103,11 +101,7 @@ export const ThumbnailAndActionTab: FC<ThumbnailAndActionTab> = ({
   return (
     <>
       <View>
-        <MediaScrollView
-          photos={photos}
-          audioRecordings={audioRecordings}
-          observationId={observationId}
-        />
+        <MediaScrollView photos={photos} observationId={observationId} />
         <ActionTab items={bottomSheetItems} />
       </View>
       <PermissionAudio


### PR DESCRIPTION
Addresses a couple of type errors related to specifying a prop that doesn't exist for the `MediaScrollView` component.