### PR TITLE
chore: A few small explanations for the map screen.

### DIFF
--- a/docs/EndToEndTests/E2ENoGos.md
+++ b/docs/EndToEndTests/E2ENoGos.md
@@ -10,7 +10,7 @@ This document outlines the tests that will need to be run by hand for QA and can
 
 1. **Scale Bar**:
 
-- Scale bar appears and shows proper measurements based on the zoom of the map
+- Scale bar appears and shows proper measurements based on the zoom of the map. It is not possible to use automated tests to test the pinch gesture, so that aspect of the scale bar needs to be tested manually.
 
 1. **Navigation Centering Button**:
 

--- a/docs/EndToEndTests/Main.md
+++ b/docs/EndToEndTests/Main.md
@@ -48,7 +48,7 @@ This tests the GPS pill that is on the main map screen and the main camera scree
 
 ## Map
 
-This tests that some of the buttons appear on the map and that an observation can be created from the map.
+This tests that some of the buttons appear on the map, that the scale bar appears, and that an observation can be created from the map.
 
 ### Test Objectives
 

--- a/e2e/main/map.yaml
+++ b/e2e/main/map.yaml
@@ -14,6 +14,9 @@ env:
 - assertVisible:
     label: 'Sync button, drawer icon, and plus button all appear on the map'
     id: '${CAT}.add-observation-btn'
+- assertVisible:
+    label: 'Scale bar at outset with default scaling'
+    text: '2km'
 - tapOn:
     id: '${CAT}.add-observation-btn'
 - assertVisible:


### PR DESCRIPTION
closes #463 

Not sure why this was assigned again? The scale bar does now work with the pinch gesture on devices, perhaps that is why? But the pinch gesture cannot be done with maestro tests (though the [feature has been requested by someone in their Github](https://github.com/mobile-dev-inc/maestro/issues/1489) and by me on their Slack).

I added a single little check for the scale bar and then an explanation about it in the E2E no gos document.