### PR TITLE
Feat leave project

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -373,6 +373,33 @@
     "description": "Title language settings screen",
     "message": "Language"
   },
+  "screens.LeaveProject.AlreadyOnProject.leaveProj": {
+    "message": "Leave Current Project"
+  },
+  "screens.LeaveProject.cancel": {
+    "message": "Cancel"
+  },
+  "screens.LeaveProject.checkToConfirm": {
+    "message": "Please check the box to confirm"
+  },
+  "screens.LeaveProject.deleteConsentWithName": {
+    "message": "I understand I will be deleting all data from Project {projectName} from my device."
+  },
+  "screens.LeaveProject.deleteConsentWithoutName": {
+    "message": "I understand I will be deleting all data from my device."
+  },
+  "screens.LeaveProject.leaveProj": {
+    "message": "Leave Project"
+  },
+  "screens.LeaveProject.leavingProject": {
+    "message": "Leaving Project {projectName}"
+  },
+  "screens.LeaveProject.removeFromProjWithName": {
+    "message": "This will remove all Project {projectName}'s data from your device."
+  },
+  "screens.LeaveProject.removeFromProjWithoutName": {
+    "message": "This will remove all of the data from your device."
+  },
   "screens.LocationInfoScreen.details": {
     "description": "Section title for details about current position",
     "message": "Details"
@@ -995,6 +1022,18 @@
   },
   "screens.Sync.ProjectSyncDisplay.upToDate": {
     "message": "Up to Date! No data to Sync"
+  },
+  "screens.goBackect.AlreadyOnProject.alreadyOnProject": {
+    "message": "You are already on a project"
+  },
+  "screens.goBackect.AlreadyOnProject.goBack": {
+    "message": "Go Back"
+  },
+  "screens.goBackect.AlreadyOnProject.leaveWarning": {
+    "message": "To join a new project you must leave your current one."
+  },
+  "screens.goBackect.AlreadyOnProject.onProject": {
+    "message": "You are on {projectName}"
   },
   "shareComponent.KeyboardAccessory.showOptions": {
     "description": "title for observation options",

--- a/messages/en.json
+++ b/messages/en.json
@@ -373,8 +373,20 @@
     "description": "Title language settings screen",
     "message": "Language"
   },
+  "screens.LeaveProject.AlreadyOnProject.alreadyOnProject": {
+    "message": "You are already on a project"
+  },
+  "screens.LeaveProject.AlreadyOnProject.goBack": {
+    "message": "Go Back"
+  },
   "screens.LeaveProject.AlreadyOnProject.leaveProj": {
     "message": "Leave Current Project"
+  },
+  "screens.LeaveProject.AlreadyOnProject.leaveWarning": {
+    "message": "To join a new project you must leave your current one."
+  },
+  "screens.LeaveProject.AlreadyOnProject.onProject": {
+    "message": "You are on {projectName}"
   },
   "screens.LeaveProject.cancel": {
     "message": "Cancel"
@@ -1022,18 +1034,6 @@
   },
   "screens.Sync.ProjectSyncDisplay.upToDate": {
     "message": "Up to Date! No data to Sync"
-  },
-  "screens.goBackect.AlreadyOnProject.alreadyOnProject": {
-    "message": "You are already on a project"
-  },
-  "screens.goBackect.AlreadyOnProject.goBack": {
-    "message": "Go Back"
-  },
-  "screens.goBackect.AlreadyOnProject.leaveWarning": {
-    "message": "To join a new project you must leave your current one."
-  },
-  "screens.goBackect.AlreadyOnProject.onProject": {
-    "message": "You are on {projectName}"
   },
   "shareComponent.KeyboardAccessory.showOptions": {
     "description": "title for observation options",

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -2,7 +2,6 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {useApi} from '../../contexts/ApiContext';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
-import {usePersistedProjectId} from '../persistedState/usePersistedProjectId';
 
 export const ALL_PROJECTS_KEY = 'all_projects';
 export const PROJECT_SETTINGS_KEY = 'project_settings';
@@ -82,12 +81,11 @@ export function useProjectSettings() {
 
 export function useLeaveProject() {
   const mapeoApi = useApi();
-  const projectId = usePersistedProjectId(store => store.projectId);
+
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => {
-      if (!projectId) throw new Error('project Id does not exist');
+    mutationFn: (projectId: string) => {
       return mapeoApi.leaveProject(projectId);
     },
     onSuccess: () => {

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -2,6 +2,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {useApi} from '../../contexts/ApiContext';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {usePersistedProjectId} from '../persistedState/usePersistedProjectId';
 
 export const ALL_PROJECTS_KEY = 'all_projects';
 export const PROJECT_SETTINGS_KEY = 'project_settings';
@@ -75,6 +76,24 @@ export function useProjectSettings() {
     queryKey: [PROJECT_SETTINGS_KEY],
     queryFn: () => {
       return project.$getProjectSettings();
+    },
+  });
+}
+
+export function useLeaveProject() {
+  const mapeoApi = useApi();
+  const projectId = usePersistedProjectId(store => store.projectId);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => {
+      if (!projectId) throw new Error('project Id does not exist');
+      return mapeoApi.leaveProject(projectId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ALL_PROJECTS_KEY],
+      });
     },
   });
 }

--- a/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
@@ -34,7 +34,7 @@ export type ActionButtonConfig =
   | SecondaryActionButtonConfig;
 
 export interface Props extends React.PropsWithChildren {
-  buttonConfigs: ActionButtonConfig[];
+  buttonConfigs?: ActionButtonConfig[];
   description?: React.ReactNode;
   descriptionStyle?: TextStyle;
   icon?: React.ReactNode;
@@ -79,63 +79,65 @@ export const Content = ({
           </ScrollView>
         ) : null}
       </View>
-      <View style={styles.buttonsContainer}>
-        {loading ? (
-          <View style={styles.loadingContainer}>
-            <UIActivityIndicator size={LOADING_INDICATOR_HEIGHT} />
-          </View>
-        ) : (
-          buttonConfigs.map((config, index) => {
-            return (
-              <Button
-                testID={config?.testID}
-                fullWidth
-                key={index}
-                TouchableComponent={props => (
-                  <TouchableHighlight
-                    {...props}
-                    underlayColor={
+      {buttonConfigs && (
+        <View style={styles.buttonsContainer}>
+          {loading ? (
+            <View style={styles.loadingContainer}>
+              <UIActivityIndicator size={LOADING_INDICATOR_HEIGHT} />
+            </View>
+          ) : (
+            buttonConfigs.map((config, index) => {
+              return (
+                <Button
+                  testID={config?.testID}
+                  fullWidth
+                  key={index}
+                  TouchableComponent={props => (
+                    <TouchableHighlight
+                      {...props}
+                      underlayColor={
+                        config.variation === 'outlined'
+                          ? WHITE
+                          : config.dangerous
+                            ? RED
+                            : LIGHT_BLUE
+                      }
+                    />
+                  )}
+                  onPress={config.onPress}
+                  style={{
+                    backgroundColor:
                       config.variation === 'outlined'
                         ? WHITE
                         : config.dangerous
-                          ? RED
-                          : LIGHT_BLUE
-                    }
-                  />
-                )}
-                onPress={config.onPress}
-                style={{
-                  backgroundColor:
-                    config.variation === 'outlined'
-                      ? WHITE
-                      : config.dangerous
-                        ? MAGENTA
-                        : COMAPEO_BLUE,
-                }}
-                variant={
-                  config.variation === 'outlined' ? 'outlined' : undefined
-                }>
-                <View style={styles.buttonTextContainer}>
-                  {config.icon ? <View>{config.icon}</View> : null}
-                  <Text
-                    style={[
-                      styles.buttonText,
-                      styles.bold,
-                      {
-                        color:
-                          config.variation === 'outlined'
-                            ? COMAPEO_BLUE
-                            : WHITE,
-                      },
-                    ]}>
-                    {config.text}
-                  </Text>
-                </View>
-              </Button>
-            );
-          })
-        )}
-      </View>
+                          ? MAGENTA
+                          : COMAPEO_BLUE,
+                  }}
+                  variant={
+                    config.variation === 'outlined' ? 'outlined' : undefined
+                  }>
+                  <View style={styles.buttonTextContainer}>
+                    {config.icon ? <View>{config.icon}</View> : null}
+                    <Text
+                      style={[
+                        styles.buttonText,
+                        styles.bold,
+                        {
+                          color:
+                            config.variation === 'outlined'
+                              ? COMAPEO_BLUE
+                              : WHITE,
+                        },
+                      ]}>
+                      {config.text}
+                    </Text>
+                  </View>
+                </Button>
+              );
+            })
+          )}
+        </View>
+      )}
     </View>
   );
 };

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/AlreadyOnProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/AlreadyOnProject.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import ErrorIcon from '../../images/Error.svg';
 import {defineMessages, useIntl} from 'react-intl';
-import {useProjectSettings} from '../../hooks/server/projects';
 import {BottomSheetModalContent} from '../BottomSheetModal';
 
 const m = defineMessages({
@@ -31,14 +30,15 @@ const m = defineMessages({
 type AlreadyOnProjectProps = {
   closeSheet: () => void;
   moveToLeaveProjectModalContent: () => void;
+  projectName?: string;
 };
 
 export const AlreadyOnProject = ({
   closeSheet,
   moveToLeaveProjectModalContent,
+  projectName,
 }: AlreadyOnProjectProps) => {
   const {formatMessage} = useIntl();
-  const {data} = useProjectSettings();
 
   return (
     <BottomSheetModalContent
@@ -58,8 +58,8 @@ export const AlreadyOnProject = ({
       icon={<ErrorIcon />}
       title={formatMessage(m.alreadyOnProject)}
       description={
-        data?.name
-          ? formatMessage(m.onProject, {projectName: data.name})
+        projectName
+          ? formatMessage(m.onProject, {projectName: projectName})
           : undefined
       }
     />

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/AlreadyOnProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/AlreadyOnProject.tsx
@@ -10,19 +10,19 @@ const m = defineMessages({
     defaultMessage: 'Leave Current Project',
   },
   goBack: {
-    id: 'screens.goBackect.AlreadyOnProject.goBack',
+    id: 'screens.LeaveProject.AlreadyOnProject.goBack',
     defaultMessage: 'Go Back',
   },
   alreadyOnProject: {
-    id: 'screens.goBackect.AlreadyOnProject.alreadyOnProject',
+    id: 'screens.LeaveProject.AlreadyOnProject.alreadyOnProject',
     defaultMessage: 'You are already on a project',
   },
   onProject: {
-    id: 'screens.goBackect.AlreadyOnProject.onProject',
+    id: 'screens.LeaveProject.AlreadyOnProject.onProject',
     defaultMessage: 'You are on {projectName}',
   },
   leaveWarning: {
-    id: 'screens.goBackect.AlreadyOnProject.leaveWarning',
+    id: 'screens.LeaveProject.AlreadyOnProject.leaveWarning',
     defaultMessage: 'To join a new project you must leave your current one.',
   },
 });

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/AlreadyOnProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/AlreadyOnProject.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import ErrorIcon from '../../images/Error.svg';
+import {defineMessages, useIntl} from 'react-intl';
+import {useProjectSettings} from '../../hooks/server/projects';
+import {BottomSheetModalContent} from '../BottomSheetModal';
+
+const m = defineMessages({
+  leaveProj: {
+    id: 'screens.LeaveProject.AlreadyOnProject.leaveProj',
+    defaultMessage: 'Leave Current Project',
+  },
+  goBack: {
+    id: 'screens.goBackect.AlreadyOnProject.goBack',
+    defaultMessage: 'Go Back',
+  },
+  alreadyOnProject: {
+    id: 'screens.goBackect.AlreadyOnProject.alreadyOnProject',
+    defaultMessage: 'You are already on a project',
+  },
+  onProject: {
+    id: 'screens.goBackect.AlreadyOnProject.onProject',
+    defaultMessage: 'You are on {projectName}',
+  },
+  leaveWarning: {
+    id: 'screens.goBackect.AlreadyOnProject.leaveWarning',
+    defaultMessage: 'To join a new project you must leave your current one.',
+  },
+});
+
+type AlreadyOnProjectProps = {
+  closeSheet: () => void;
+  moveToLeaveProjectModalContent: () => void;
+};
+
+export const AlreadyOnProject = ({
+  closeSheet,
+  moveToLeaveProjectModalContent,
+}: AlreadyOnProjectProps) => {
+  const {formatMessage} = useIntl();
+  const {data} = useProjectSettings();
+
+  return (
+    <BottomSheetModalContent
+      buttonConfigs={[
+        {
+          variation: 'filled',
+          dangerous: true,
+          text: formatMessage(m.leaveProj),
+          onPress: moveToLeaveProjectModalContent,
+        },
+        {
+          variation: 'outlined',
+          text: formatMessage(m.goBack),
+          onPress: closeSheet,
+        },
+      ]}
+      icon={<ErrorIcon />}
+      title={formatMessage(m.alreadyOnProject)}
+      description={
+        data?.name
+          ? formatMessage(m.onProject, {projectName: data.name})
+          : undefined
+      }
+    />
+  );
+};

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
@@ -81,17 +81,22 @@ export const LeaveProject = ({
       {inviteId},
       {
         onSuccess: () => {
-          leaveProject.mutate(undefined, {
-            onSuccess: () => {
-              closeSheet();
-              setCombinedLoading(false);
-            },
-            onError: err => {
-              console.log(err);
-              setCombinedLoading(false);
-            },
-          });
+          closeSheet();
+          setCombinedLoading(false);
         },
+        // This is commented out for now and issue created: https://github.com/digidem/comapeo-mobile/issues/525
+        // onSuccess: () => {
+        //   leaveProject.mutate(undefined, {
+        //     onSuccess: () => {
+        //       closeSheet();
+        //       setCombinedLoading(false);
+        //     },
+        //     onError: err => {
+        //       console.log(err);
+        //       setCombinedLoading(false);
+        //     },
+        //   });
+        // },
         onError: err => {
           console.log(err);
           setCombinedLoading(false);

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import {StyleSheet, View} from 'react-native';
+import ErrorIcon from '../../images/Error.svg';
+import {defineMessages, useIntl} from 'react-intl';
+import {Text} from '../../sharedComponents/Text';
+import {useLeaveProject, useProjectSettings} from '../../hooks/server/projects';
+import {RED} from '../../lib/styles';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import {TouchableOpacity} from '../../sharedComponents/Touchables';
+
+// import {UIActivityIndicator} from 'react-native-indicators';
+import {BottomSheetModalContent} from '../BottomSheetModal';
+import {useAcceptInvite} from '../../hooks/server/invites';
+import {ErrorBottomSheet} from '../ErrorBottomSheet';
+
+const m = defineMessages({
+  leaveProj: {
+    id: 'screens.LeaveProject.leaveProj',
+    defaultMessage: 'Leave Project',
+  },
+  deleteConsentWithName: {
+    id: 'screens.LeaveProject.deleteConsentWithName',
+    defaultMessage:
+      'I understand I will be deleting all data from Project {projectName} from my device.',
+  },
+  deleteConsentWithoutName: {
+    id: 'screens.LeaveProject.deleteConsentWithoutName',
+    defaultMessage: 'I understand I will be deleting all data from my device.',
+  },
+  removeFromProjWithName: {
+    id: 'screens.LeaveProject.removeFromProjWithName',
+    defaultMessage:
+      "This will remove all Project {projectName}'s data from your device.",
+  },
+  removeFromProjWithoutName: {
+    id: 'screens.LeaveProject.removeFromProjWithoutName',
+    defaultMessage: 'This will remove all of the data from your device.',
+  },
+  cancel: {
+    id: 'screens.LeaveProject.cancel',
+    defaultMessage: 'Cancel',
+  },
+  checkToConfirm: {
+    id: 'screens.LeaveProject.checkToConfirm',
+    defaultMessage: 'Please check the box to confirm',
+  },
+  leavingProject: {
+    id: 'screens.LeaveProject.leavingProject',
+    defaultMessage: 'Leaving Project {projectName}',
+  },
+});
+
+type LeaveProjectProps = {
+  inviteId: string;
+  accept: ReturnType<typeof useAcceptInvite>;
+  closeSheet: () => void;
+};
+
+export const LeaveProject = ({
+  inviteId,
+  accept,
+  closeSheet,
+}: LeaveProjectProps) => {
+  const {formatMessage} = useIntl();
+  const {data} = useProjectSettings();
+  const [error, setError] = React.useState(false);
+  const [isChecked, setIsChecked] = React.useState(false);
+  const leaveProject = useLeaveProject();
+  const [combinedLoading, setCombinedLoading] = React.useState(false);
+
+  function handleLeavePress() {
+    if (!isChecked) {
+      setError(true);
+      return;
+    }
+    setCombinedLoading(true);
+    leaveProject.mutate(undefined, {
+      onSuccess: () => {
+        accept.mutate(
+          {inviteId},
+          {
+            onSuccess: () => {
+              closeSheet();
+              setCombinedLoading(false);
+            },
+            onError: () => {
+              setCombinedLoading(false);
+            },
+          },
+        );
+      },
+      onError: () => {
+        setCombinedLoading(false);
+      },
+    });
+  }
+
+  return (
+    <>
+      <BottomSheetModalContent
+        icon={<ErrorIcon />}
+        loading={combinedLoading}
+        buttonConfigs={[
+          {
+            onPress: handleLeavePress,
+            text: formatMessage(m.leaveProj),
+            variation: 'filled',
+            dangerous: true,
+          },
+          {
+            onPress: closeSheet,
+            text: formatMessage(m.cancel),
+            variation: 'outlined',
+          },
+        ]}
+        title={formatMessage(m.leaveProj)}
+        description={
+          data?.name
+            ? formatMessage(m.removeFromProjWithName, {
+                projectName: data?.name,
+              })
+            : formatMessage(m.removeFromProjWithoutName)
+        }>
+        <View style={{padding: 20}}>
+          <TouchableOpacity
+            style={styles.check}
+            disabled={combinedLoading}
+            onPress={() => setIsChecked(val => !val)}>
+            <MaterialIcons
+              size={32}
+              color={!isChecked && error ? RED : undefined}
+              name={isChecked ? 'check-box' : 'check-box-outline-blank'}
+            />
+            <Text style={{marginLeft: 10, marginRight: 10}}>
+              {data?.name
+                ? formatMessage(m.deleteConsentWithName, {
+                    projectName: data?.name,
+                  })
+                : formatMessage(m.deleteConsentWithoutName)}
+            </Text>
+          </TouchableOpacity>
+          {error && !isChecked && (
+            <Text style={{color: RED, marginTop: 20}}>
+              {formatMessage(m.checkToConfirm)}
+            </Text>
+          )}
+        </View>
+      </BottomSheetModalContent>
+      <ErrorBottomSheet
+        error={leaveProject.error || accept.error}
+        clearError={() => {
+          leaveProject.reset();
+          accept.reset();
+        }}
+        tryAgain={handleLeavePress}
+      />
+    </>
+  );
+};
+
+// const LeavingProjectProgress = ({projectName}: {projectName?: string}) => {
+//   const {formatMessage} = useIntl();
+//   return (
+//     <View>
+//       <Text style={{fontSize: 32, textAlign: 'center'}}>
+//         {formatMessage(m.leavingProject, {projectName: projectName || ''})}
+//       </Text>
+
+//       <UIActivityIndicator style={{marginTop: 40}} />
+//     </View>
+//   );
+// };
+
+const styles = StyleSheet.create({
+  check: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+});

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
@@ -6,6 +6,8 @@ import {Text} from '../../sharedComponents/Text';
 import {useLeaveProject} from '../../hooks/server/projects';
 import {RED} from '../../lib/styles';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import * as Sentry from '@sentry/react-native';
+
 import {TouchableOpacity} from '../../sharedComponents/Touchables';
 
 import {UIActivityIndicator} from 'react-native-indicators';
@@ -92,13 +94,13 @@ export const LeaveProject = ({
         //       setCombinedLoading(false);
         //     },
         //     onError: err => {
-        //       console.log(err);
+        //       Sentry.captureException(err)
         //       setCombinedLoading(false);
         //     },
         //   });
         // },
         onError: err => {
-          console.log(err);
+          Sentry.captureException(err);
           setCombinedLoading(false);
         },
       },

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/index.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/index.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import {useAcceptInvite} from '../../hooks/server/invites';
+import {AlreadyOnProject} from './AlreadyOnProject';
+import {LeaveProject} from './LeaveProject';
+import {useProjectSettings} from '../../hooks/server/projects';
+
+type LeaveProjectModalContentProps = {
+  cancel: () => void;
+  inviteId: string;
+  accept: ReturnType<typeof useAcceptInvite>;
+};
+
+export const LeaveProjectModalContent = ({
+  cancel,
+  inviteId,
+  accept,
+}: LeaveProjectModalContentProps) => {
+  const [leaveModalState, setLeaveModalState] = React.useState<
+    'AlreadyOnProj' | 'LeaveProj'
+  >('AlreadyOnProj');
+  const {data} = useProjectSettings();
+
+  function closeAndResetLeaveModal() {
+    cancel();
+    setLeaveModalState('AlreadyOnProj');
+  }
+
+  return leaveModalState === 'AlreadyOnProj' ? (
+    <AlreadyOnProject
+      moveToLeaveProjectModalContent={() => {
+        setLeaveModalState('LeaveProj');
+      }}
+      closeSheet={closeAndResetLeaveModal}
+    />
+  ) : (
+    <LeaveProject
+      closeSheet={closeAndResetLeaveModal}
+      inviteId={inviteId}
+      accept={accept}
+      projectName={data?.name}
+    />
+  );
+};

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/index.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/index.tsx
@@ -26,6 +26,7 @@ export const LeaveProjectModalContent = ({
     <AlreadyOnProject
       moveToLeaveProjectModalContent={setToLeaveProject}
       closeSheet={closeSheet}
+      projectName={data?.name}
     />
   ) : (
     <LeaveProject

--- a/src/frontend/sharedComponents/LeaveProjectModalContent/index.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/index.tsx
@@ -3,38 +3,33 @@ import {useAcceptInvite} from '../../hooks/server/invites';
 import {AlreadyOnProject} from './AlreadyOnProject';
 import {LeaveProject} from './LeaveProject';
 import {useProjectSettings} from '../../hooks/server/projects';
+import {LeaveProjectModalState} from '../ProjectInviteBottomSheet';
 
 type LeaveProjectModalContentProps = {
-  cancel: () => void;
+  closeSheet: () => void;
   inviteId: string;
   accept: ReturnType<typeof useAcceptInvite>;
+  leaveModalState: LeaveProjectModalState;
+  setToLeaveProject: () => void;
 };
 
 export const LeaveProjectModalContent = ({
-  cancel,
+  closeSheet,
   inviteId,
   accept,
+  leaveModalState,
+  setToLeaveProject,
 }: LeaveProjectModalContentProps) => {
-  const [leaveModalState, setLeaveModalState] = React.useState<
-    'AlreadyOnProj' | 'LeaveProj'
-  >('AlreadyOnProj');
   const {data} = useProjectSettings();
-
-  function closeAndResetLeaveModal() {
-    cancel();
-    setLeaveModalState('AlreadyOnProj');
-  }
 
   return leaveModalState === 'AlreadyOnProj' ? (
     <AlreadyOnProject
-      moveToLeaveProjectModalContent={() => {
-        setLeaveModalState('LeaveProj');
-      }}
-      closeSheet={closeAndResetLeaveModal}
+      moveToLeaveProjectModalContent={setToLeaveProject}
+      closeSheet={closeSheet}
     />
   ) : (
     <LeaveProject
-      closeSheet={closeAndResetLeaveModal}
+      closeSheet={closeSheet}
       inviteId={inviteId}
       accept={accept}
       projectName={data?.name}

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -12,6 +12,8 @@ import {InviteCanceledBottomSheetContent} from './InviteCanceledBottomSheetConte
 import {useAllProjects} from '../../hooks/server/projects';
 import {LeaveProjectModalContent} from '../LeaveProjectModalContent';
 
+export type LeaveProjectModalState = 'AlreadyOnProj' | 'LeaveProj';
+
 export const ProjectInviteBottomSheet = ({
   enabledForCurrentScreen,
 }: {
@@ -39,6 +41,9 @@ export const ProjectInviteBottomSheet = ({
   );
 
   const projects = useAllProjects();
+
+  const [leaveModalState, setLeaveModalState] =
+    React.useState<LeaveProjectModalState>('AlreadyOnProj');
 
   const invite = invites[0];
 
@@ -119,9 +124,15 @@ export const ProjectInviteBottomSheet = ({
           />
         )}
       </BottomSheetModal>
-      <BottomSheetModal fullScreen ref={leaveRef} isOpen={leaveIsOpen}>
+      <BottomSheetModal
+        onDismiss={() => setLeaveModalState('AlreadyOnProj')}
+        fullScreen
+        ref={leaveRef}
+        isOpen={leaveIsOpen}>
         <LeaveProjectModalContent
-          cancel={closeLeaveSheet}
+          closeSheet={closeLeaveSheet}
+          leaveModalState={leaveModalState}
+          setToLeaveProject={() => setLeaveModalState('LeaveProj')}
           inviteId={invite?.inviteId || ''}
           accept={accept}
         />

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -73,6 +73,9 @@ export const ProjectInviteBottomSheet = ({
         },
       });
     }
+    if (invites.length <= 1) {
+      closeInviteSheet();
+    }
   }
 
   function handleCanceledInvite() {


### PR DESCRIPTION
Adds leave project screens.

Added as a separate modal since it needed to be full screen.

We couldn't add the leave project screens as a nav screen because the invite modal is declarative and opens when there is an active invite and closes when there are no more active invites. Due to the architecture of modal, they always show up on top of the navigator. This means that the modal would show up on top of the leave project screens if they were part of the nav.

https://github.com/user-attachments/assets/f55ab30d-3fce-4d21-bbc6-90d5cbfb88b0

closes #162 

