### PR TITLE
chore: make UI for app passcode settings screens more consistent with other parts of app

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -259,7 +259,7 @@
     "message": "App Passcode allows you to add an additional layer of security by requiring that you enter a passcode in order to open the Mapeo app. You can define your own 5-digit passcode by turning on the feature below."
   },
   "screens.AppPasscode.PasscodeIntro.warning": {
-    "message": "**Please note that forgotten passcodes cannot be recovered!** Once this feature is enabled, if you forget or lose your passcode, you will not be able to open Mapeo and will lose access to any Mapeo data that has not been synced with other project participants."
+    "message": "<bold>Please note that forgotten passcodes cannot be recovered!</bold> Once this feature is enabled, if you forget or lose your passcode, you will not be able to open Mapeo and will lose access to any Mapeo data that has not been synced with other project participants."
   },
   "screens.AppPasscode.TurnOffPasscode.cancel": {
     "message": "Cancel"

--- a/src/frontend/contexts/IntlContext.tsx
+++ b/src/frontend/contexts/IntlContext.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import {IntlProvider as IntlProviderOrig, CustomFormats} from 'react-intl';
+import {IntlProvider as ReactIntlProvider, CustomFormats} from 'react-intl';
+import {StyleSheet} from 'react-native';
 
 import messages from '../../../translations/messages.json';
 import {usePersistedLocale} from '../hooks/persistedState/usePersistedLocale';
 import {TranslatedLocale} from '../lib/intl';
+import {Text} from '../sharedComponents/Text';
 
 export const formats: CustomFormats = {
   date: {
@@ -15,6 +17,12 @@ export const formats: CustomFormats = {
       minute: '2-digit',
     },
   },
+};
+
+const DEFAULT_RICH_TEXT_MAPPINGS: NonNullable<
+  React.ComponentProps<typeof ReactIntlProvider>['defaultRichTextElements']
+> = {
+  bold: chunk => <Text style={styles.bold}>{chunk}</Text>,
 };
 
 export const IntlProvider = ({children}: {children: React.ReactNode}) => {
@@ -29,17 +37,24 @@ export const IntlProvider = ({children}: {children: React.ReactNode}) => {
   };
 
   return (
-    <IntlProviderOrig
+    <ReactIntlProvider
       locale={appLocale}
       messages={localeMessages}
       formats={formats}
       onError={onError}
-      wrapRichTextChunksInFragment>
+      wrapRichTextChunksInFragment
+      defaultRichTextElements={DEFAULT_RICH_TEXT_MAPPINGS}>
       {children}
-    </IntlProviderOrig>
+    </ReactIntlProvider>
   );
 };
 
 function onError(e: Error) {
   console.log(e);
 }
+
+const styles = StyleSheet.create({
+  bold: {
+    fontWeight: 'bold',
+  },
+});

--- a/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
+++ b/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import {defineMessages} from 'react-intl';
+import {defineMessages, useIntl} from 'react-intl';
 
+import {useSecurityContext} from '../../contexts/SecurityContext';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {InputPasscode} from './InputPasscode';
-import {useSecurityContext} from '../../contexts/SecurityContext';
 
 const m = defineMessages({
   titleEnter: {
@@ -27,6 +27,7 @@ const m = defineMessages({
 export const EnterPassToTurnOff: NativeNavigationComponent<
   'EnterPassToTurnOff'
 > = ({navigation}) => {
+  const {formatMessage: t} = useIntl();
   const {authenticate, authValuesSet} = useSecurityContext();
   const [error, setError] = React.useState(false);
   const {navigate} = navigation;
@@ -48,11 +49,9 @@ export const EnterPassToTurnOff: NativeNavigationComponent<
 
   return (
     <InputPasscode
-      text={{
-        errorMessage: m.passwordError,
-        subtitle: m.subTitleEnter,
-        title: m.titleEnter,
-      }}
+      title={t(m.titleEnter)}
+      subtitle={t(m.subTitleEnter)}
+      errorMessage={t(m.passwordError)}
       error={error}
       validate={validate}
       showNext={false}

--- a/src/frontend/screens/AppPasscode/InputPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/InputPasscode.tsx
@@ -77,6 +77,7 @@ export const InputPasscode = ({
             <Button
               fullWidth
               variant="outlined"
+              color="ComapeoBlue"
               onPress={() => {
                 navigate('Security');
               }}>

--- a/src/frontend/screens/AppPasscode/InputPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/InputPasscode.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {defineMessages, MessageDescriptor, useIntl} from 'react-intl';
+import {defineMessages, useIntl} from 'react-intl';
 import {StyleSheet, View} from 'react-native';
 import {useBlurOnFulfill} from 'react-native-confirmation-code-field';
 
@@ -22,12 +22,11 @@ const m = defineMessages({
     defaultMessage: 'Cancel',
   },
 });
+
 interface InputPasscodeProps {
-  text: {
-    title: MessageDescriptor;
-    subtitle: MessageDescriptor;
-    errorMessage: MessageDescriptor;
-  };
+  title: string;
+  subtitle: string;
+  errorMessage: string;
   validate: (pass: string) => void | boolean;
   showPasscodeValues?: boolean;
   error: boolean;
@@ -37,7 +36,9 @@ interface InputPasscodeProps {
 
 export const InputPasscode = ({
   validate,
-  text,
+  title,
+  subtitle,
+  errorMessage,
   showPasscodeValues,
   error,
   hideError,
@@ -95,8 +96,8 @@ export const InputPasscode = ({
             )}
           </View>
         }>
-        <Text style={styles.header}>{t(text.title)}</Text>
-        <Text style={styles.subtext}>{t(text.subtitle)}</Text>
+        <Text style={styles.header}>{title}</Text>
+        <Text style={styles.subtext}>{subtitle}</Text>
 
         <PasscodeInput
           error={error}
@@ -106,7 +107,7 @@ export const InputPasscode = ({
           maskValues={!showPasscodeValues}
         />
 
-        {error && <Text style={styles.error}>{t(text.errorMessage)}</Text>}
+        {error && <Text style={styles.error}>{errorMessage}</Text>}
       </ScreenContentWithDock>
 
       <ConfirmPasscodeSheet

--- a/src/frontend/screens/AppPasscode/InputPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/InputPasscode.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
-import {defineMessages, FormattedMessage, MessageDescriptor} from 'react-intl';
-import {View, StyleSheet, ScrollView} from 'react-native';
+import {defineMessages, MessageDescriptor, useIntl} from 'react-intl';
+import {StyleSheet, View} from 'react-native';
 import {useBlurOnFulfill} from 'react-native-confirmation-code-field';
 
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
-import {WHITE, RED, COMAPEO_BLUE} from '../../lib/styles';
+import {RED} from '../../lib/styles';
+import {useBottomSheetModal} from '../../sharedComponents/BottomSheetModal';
 import {Button} from '../../sharedComponents/Button';
 import {CELL_COUNT, PasscodeInput} from '../../sharedComponents/PasscodeInput';
+import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
 import {Text} from '../../sharedComponents/Text';
 import {ConfirmPasscodeSheet} from './ConfirmPasscodeSheet';
-import {useBottomSheetModal} from '../../sharedComponents/BottomSheetModal';
 
 const m = defineMessages({
   button: {
@@ -42,6 +43,7 @@ export const InputPasscode = ({
   hideError,
   showNext = true,
 }: InputPasscodeProps) => {
+  const {formatMessage: t} = useIntl();
   const [inputValue, setInputValue] = React.useState('');
   const {sheetRef, isOpen, openSheet} = useBottomSheetModal({
     openOnMount: false,
@@ -64,44 +66,20 @@ export const InputPasscode = ({
   }
 
   const {navigate} = useNavigationFromRoot();
+
   return (
-    <React.Fragment>
-      <ScrollView>
-        <View style={styles.container}>
-          <View>
-            <Text style={[styles.header]}>
-              <FormattedMessage {...text.title} />
-            </Text>
-            <Text style={[styles.subtext]}>
-              <FormattedMessage {...text.subtitle} />
-            </Text>
-
-            <PasscodeInput
-              error={error}
-              ref={inputRef}
-              inputValue={inputValue}
-              onChangeTextWithValidation={updateInput}
-              maskValues={!showPasscodeValues}
-            />
-
-            {error && (
-              <Text style={styles.error}>
-                <FormattedMessage {...text.errorMessage} />
-              </Text>
-            )}
-          </View>
-
-          <View>
+    <>
+      <ScreenContentWithDock
+        contentContainerStyle={styles.contentContainer}
+        dockContent={
+          <View style={styles.buttonsContainer}>
             <Button
               fullWidth
               variant="outlined"
-              style={{marginBottom: 20, marginTop: 20}}
               onPress={() => {
                 navigate('Security');
               }}>
-              <Text style={[styles.buttonText, {color: COMAPEO_BLUE}]}>
-                <FormattedMessage {...m.cancel} />
-              </Text>
+              {t(m.cancel)}
             </Button>
 
             {showNext && (
@@ -112,55 +90,52 @@ export const InputPasscode = ({
                     openSheet();
                   }
                 }}>
-                <Text style={[styles.buttonText, {color: WHITE}]}>
-                  <FormattedMessage {...m.button} />
-                </Text>
+                {t(m.button)}
               </Button>
             )}
           </View>
-        </View>
-      </ScrollView>
+        }>
+        <Text style={styles.header}>{t(text.title)}</Text>
+        <Text style={styles.subtext}>{t(text.subtitle)}</Text>
+
+        <PasscodeInput
+          error={error}
+          ref={inputRef}
+          inputValue={inputValue}
+          onChangeTextWithValidation={updateInput}
+          maskValues={!showPasscodeValues}
+        />
+
+        {error && <Text style={styles.error}>{t(text.errorMessage)}</Text>}
+      </ScreenContentWithDock>
+
       <ConfirmPasscodeSheet
         inputtedPasscode={inputValue}
         ref={sheetRef}
         isOpen={isOpen}
       />
-    </React.Fragment>
+    </>
   );
 };
 
 const styles = StyleSheet.create({
-  buttonText: {
-    fontSize: 16,
-    textAlign: 'center',
-  },
-  button: {
-    width: '100%',
-    minWidth: 90,
-    maxWidth: 280,
+  contentContainer: {
+    gap: 20,
   },
   header: {
     fontSize: 32,
-    marginBottom: 20,
     textAlign: 'center',
+  },
+  buttonsContainer: {
+    gap: 20,
   },
   subtext: {
-    marginBottom: 20,
     textAlign: 'center',
     fontSize: 16,
-  },
-  container: {
-    padding: 20,
-    flexDirection: 'column',
-    height: '100%',
-    flex: 1,
-    justifyContent: 'space-between',
   },
   error: {
     textAlign: 'center',
     fontSize: 16,
-    marginBottom: 20,
-    marginTop: 20,
     color: RED,
   },
 });

--- a/src/frontend/screens/AppPasscode/PasscodeIntro.tsx
+++ b/src/frontend/screens/AppPasscode/PasscodeIntro.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
-import {StyleSheet, View, ScrollView} from 'react-native';
+import {StyleSheet} from 'react-native';
 
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {Button} from '../../sharedComponents/Button';
+import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
 import {Text} from '../../sharedComponents/Text';
 
 const m = defineMessages({
@@ -23,7 +24,7 @@ const m = defineMessages({
   warning: {
     id: 'screens.AppPasscode.PasscodeIntro.warning',
     defaultMessage:
-      '**Please note that forgotten passcodes cannot be recovered!** Once this feature is enabled, if you forget or lose your passcode, you will not be able to open Mapeo and will lose access to any Mapeo data that has not been synced with other project participants.',
+      '<bold>Please note that forgotten passcodes cannot be recovered!</bold> Once this feature is enabled, if you forget or lose your passcode, you will not be able to open Mapeo and will lose access to any Mapeo data that has not been synced with other project participants.',
   },
 });
 
@@ -32,48 +33,30 @@ export const PasscodeIntro = () => {
   const {navigate} = useNavigationFromRoot();
 
   return (
-    <ScrollView>
-      <View style={styles.container}>
-        <View>
-          <Text style={[styles.title]}>{t(m.title)}</Text>
-          <Text style={[styles.description]}>{t(m.description)}</Text>
-          <Text style={[styles.description, {marginTop: 20}]}>
-            {t(m.warning)}
-          </Text>
-        </View>
-        <View>
-          <Button
-            style={[styles.button]}
-            onPress={() => navigate('SetPasscode')}>
-            {t(m.continue)}
-          </Button>
-        </View>
-      </View>
-    </ScrollView>
+    <ScreenContentWithDock
+      contentContainerStyle={styles.contentContainer}
+      dockContent={
+        <Button fullWidth onPress={() => navigate('SetPasscode')}>
+          {t(m.continue)}
+        </Button>
+      }>
+      <Text style={styles.title}>{t(m.title)}</Text>
+      <Text style={styles.description}>{t(m.description)}</Text>
+      <Text style={styles.description}>{t(m.warning)}</Text>
+    </ScreenContentWithDock>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    display: 'flex',
-    flexBasis: '90%',
-    justifyContent: 'space-between',
-    paddingTop: 20,
+  contentContainer: {
+    gap: 20,
   },
   title: {
     fontSize: 32,
     textAlign: 'center',
-    paddingHorizontal: 30,
-    marginBottom: 20,
     fontWeight: 'bold',
   },
   description: {
     fontSize: 16,
-  },
-  button: {
-    marginTop: 20,
-    width: '100%',
-    minWidth: 90,
-    maxWidth: 280,
   },
 });

--- a/src/frontend/screens/AppPasscode/SetPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/SetPasscode.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import {InputPasscode} from './InputPasscode';
-import {defineMessages} from 'react-intl';
+import {defineMessages, useIntl} from 'react-intl';
+
 import {OBSCURE_PASSCODE} from '../../constants';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
+import {InputPasscode} from './InputPasscode';
 
 const m = defineMessages({
   titleSet: {
@@ -43,6 +44,7 @@ type SetPasswordError =
   | {error: false; isObscurePassword: false};
 
 export const SetPasscode: NativeNavigationComponent<'SetPasscode'> = () => {
+  const {formatMessage: t} = useIntl();
   const [error, setError] = React.useState<SetPasswordError>({
     error: false,
     isObscurePassword: false,
@@ -73,13 +75,11 @@ export const SetPasscode: NativeNavigationComponent<'SetPasscode'> = () => {
   if (!isConfirming) {
     return (
       <InputPasscode
-        text={{
-          title: m.titleSet,
-          errorMessage: error.isObscurePassword
-            ? m.obscurePasscodeError
-            : m.initialPassError,
-          subtitle: m.subTitleSet,
-        }}
+        title={t(m.titleSet)}
+        subtitle={t(m.subTitleSet)}
+        errorMessage={t(
+          error.isObscurePassword ? m.obscurePasscodeError : m.initialPassError,
+        )}
         validate={validate}
         error={error.error}
         showPasscodeValues={true}
@@ -94,6 +94,8 @@ export const SetPasscode: NativeNavigationComponent<'SetPasscode'> = () => {
 SetPasscode.navTitle = m.title;
 
 const SetPasswordConfirm = ({initialPass}: {initialPass: string}) => {
+  const {formatMessage: t} = useIntl();
+
   const [error, setError] = React.useState(false);
 
   function validate(inputVal: string) {
@@ -107,11 +109,9 @@ const SetPasswordConfirm = ({initialPass}: {initialPass: string}) => {
 
   return (
     <InputPasscode
-      text={{
-        title: m.titleConfirm,
-        errorMessage: m.passwordDoesNotMatch,
-        subtitle: m.subTitleSet,
-      }}
+      title={t(m.titleConfirm)}
+      subtitle={t(m.subTitleSet)}
+      errorMessage={t(m.passwordDoesNotMatch)}
       validate={validate}
       error={error}
       showPasscodeValues={true}

--- a/src/frontend/screens/AppPasscode/SetPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/SetPasscode.tsx
@@ -106,20 +106,18 @@ const SetPasswordConfirm = ({initialPass}: {initialPass: string}) => {
   }
 
   return (
-    <React.Fragment>
-      <InputPasscode
-        text={{
-          title: m.titleConfirm,
-          errorMessage: m.passwordDoesNotMatch,
-          subtitle: m.subTitleSet,
-        }}
-        validate={validate}
-        error={error}
-        showPasscodeValues={true}
-        hideError={() => {
-          setError(false);
-        }}
-      />
-    </React.Fragment>
+    <InputPasscode
+      text={{
+        title: m.titleConfirm,
+        errorMessage: m.passwordDoesNotMatch,
+        subtitle: m.subTitleSet,
+      }}
+      validate={validate}
+      error={error}
+      showPasscodeValues={true}
+      hideError={() => {
+        setError(false);
+      }}
+    />
   );
 };

--- a/src/frontend/screens/AppPasscode/index.tsx
+++ b/src/frontend/screens/AppPasscode/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import {defineMessages} from 'react-intl';
-import {StyleSheet, View} from 'react-native';
 
-import {WHITE} from '../../lib/styles';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {PasscodeIntro} from './PasscodeIntro';
 import {useSecurityContext} from '../../contexts/SecurityContext';
@@ -25,20 +23,7 @@ export const AppPasscode: NativeNavigationComponent<'AppPasscode'> = ({
     }
   }, [navigation, authState]);
 
-  return (
-    <View style={styles.pageContainer}>
-      <PasscodeIntro />
-    </View>
-  );
+  return <PasscodeIntro />;
 };
 
 AppPasscode.navTitle = m.title;
-
-const styles = StyleSheet.create({
-  pageContainer: {
-    paddingBottom: 20,
-    paddingHorizontal: 20,
-    flex: 1,
-    backgroundColor: WHITE,
-  },
-});


### PR DESCRIPTION
Stacked on #503 

Noticed that the UI in these screens was very different compared to other parts of the app with similar designs. Believe this is an artifact of porting over directly from Mapeo Mobile, which may have had slightly different design specifications, but I would like it to be more consistent with how other similar screens are implemented (namely action buttons docked to the bottom of the screen, consistent spacing, etc).

In terms of technical changes:

- uses the shared `ScreenContentWithDock` component for relevant screens to ensure uniformity and consistency
- fixes an issue with injecting rich formatting into specific parts of a translation string. this requires using the [defaultRichTextElements](https://formatjs.io/docs/react-intl/components#defaultrichtextelements) functionality built into react-intl. currently only defines a `<bold>` tag.

---

Preview:

### Before

<img width="200" alt="image" src="https://github.com/user-attachments/assets/00518d7e-9ce1-4251-aa38-ff535a351796">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/cc91bba8-86d0-4dee-bf11-b48d96cd3473">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/0f5bfa08-2e58-46f6-8e68-ebae97909d01">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/c5dec2af-7f19-4109-a515-4d82b76d22f8">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/08db2f7d-69a9-4547-b5b1-b56ce778f3be">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ba107581-508b-4e64-80f9-6fc12fad10bc">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/043e703e-15b8-4ea1-bcf3-1edf64a7c3d2">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/04defd60-3e94-4413-94d2-bd80c3e15a38">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/5d50f8af-e5c0-446a-b741-1dfa6e5e877b">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9af155cf-f456-465b-8cfc-8e8d1a52510c">


### After

<img width="200" alt="image" src="https://github.com/user-attachments/assets/58c1ac77-2fed-4a84-9fc5-5305b94f28c9">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/b3adb777-be60-4130-87ea-c44c59a5641e">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/6e6d5ee3-0e4c-4098-8772-0d8d958c88c7">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/d0af0ad7-182c-499e-9b1f-5200546cf46b">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/47374103-7c52-4116-bc62-a3562b9db279">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/7b99e8d2-3b8c-401c-a2f8-031514f99a4d">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/09a7e904-52cb-4b28-bcf3-4d1c73c2f317">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/6ed4559d-7868-4e62-ac92-575968dc2e33">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/6ec3510b-3465-4709-84e2-0435d7e1f0e5">

<img width="200" alt="image" src="https://github.com/user-attachments/assets/46812ebb-fe12-4f70-b6e3-f643b65f1739">
