### PR TITLE
feat: Add Photo metadata

### DIFF
--- a/src/frontend/contexts/PhotoPromiseContext/index.tsx
+++ b/src/frontend/contexts/PhotoPromiseContext/index.tsx
@@ -66,24 +66,27 @@ export const PhotoPromiseProvider = ({
     setPhotoPromises([]);
   }, [photoPromises]);
 
-  const deletePhotoPromise = React.useCallback((uri: String) => {
-    const newPhotoPromiseArray = photoPromises.map(async photo => {
-      const resolvedPhoto = await photo;
-      if (resolvedPhoto.originalUri === uri) {
-        const deletedPhoto: Promise<DraftPhoto> = new Promise(res => {
-          resolvedPhoto.deleted = true;
-          res(resolvedPhoto);
-        });
-        const cancelPhoto = deletedPhoto as CancellablePhotoPromise;
-        cancelPhoto.signal = {didCancel: true};
-        return cancelPhoto;
-      }
+  const deletePhotoPromise = React.useCallback(
+    (uri: String) => {
+      const newPhotoPromiseArray = photoPromises.map(async photo => {
+        const resolvedPhoto = await photo;
+        if (resolvedPhoto.originalUri === uri) {
+          const deletedPhoto: Promise<DraftPhoto> = new Promise(res => {
+            resolvedPhoto.deleted = true;
+            res(resolvedPhoto);
+          });
+          const cancelPhoto = deletedPhoto as CancellablePhotoPromise;
+          cancelPhoto.signal = {didCancel: true};
+          return cancelPhoto;
+        }
 
-      return photo;
-    });
+        return photo;
+      });
 
-    setPhotoPromises(newPhotoPromiseArray);
-  }, []);
+      setPhotoPromises(newPhotoPromiseArray);
+    },
+    [photoPromises],
+  );
 
   const context: PhotoPromiseContextState = React.useMemo(
     () => ({

--- a/src/frontend/contexts/PhotoPromiseContext/types.ts
+++ b/src/frontend/contexts/PhotoPromiseContext/types.ts
@@ -30,6 +30,7 @@ export interface DraftPhoto {
   deleted?: boolean;
   // If there was any kind of error on image capture
   error?: boolean;
+  mediaMetadata: MediaMetadata;
 }
 
 /**
@@ -52,6 +53,11 @@ export interface Signal {
 export type CancellablePhotoPromise = Promise<DraftPhoto> & {signal?: Signal};
 
 export type MediaMetadata = {
-  location: LocationObject;
+  location?: LocationObject;
   timestamp: number;
+};
+
+export type PhotoPromiseWithMetadata = {
+  capturePromise: Promise<CapturedPictureMM>;
+  mediaMetadata: MediaMetadata;
 };

--- a/src/frontend/contexts/PhotoPromiseContext/types.ts
+++ b/src/frontend/contexts/PhotoPromiseContext/types.ts
@@ -1,3 +1,5 @@
+import {LocationObject} from 'expo-location';
+
 export const THUMBNAIL_SIZE = 400;
 export const THUMBNAIL_QUALITY = 30;
 export const PREVIEW_SIZE = 1200;
@@ -48,3 +50,8 @@ export interface Signal {
 }
 
 export type CancellablePhotoPromise = Promise<DraftPhoto> & {signal?: Signal};
+
+export type MediaMetadata = {
+  location: LocationObject;
+  timestamp: number;
+};

--- a/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
+++ b/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
@@ -22,7 +22,7 @@ const emptyObservation: ClientGeneratedObservation = {
 };
 
 export type DraftObservationSlice = {
-  photos: Photo[];
+  photos: (Photo | {draftPhotoId: string})[];
   audioRecordings: [];
   value: Observation | null | ClientGeneratedObservation;
   observationId?: string;
@@ -53,7 +53,7 @@ const draftObservationSlice: StateCreator<DraftObservationSlice> = (
   actions: {
     deletePhoto: uri => deletePhoto(set, get, uri),
     addPhotoPlaceholder: draftPhotoId =>
-      set({photos: [...get().photos, {draftPhotoId, capturing: true}]}),
+      set({photos: [...get().photos, {draftPhotoId}]}),
     replacePhotoPlaceholderWithPhoto: draftPhoto =>
       replaceDraftPhotos(set, get, draftPhoto),
     clearDraft: () => {

--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -5,14 +5,17 @@ import {SetRequired} from 'type-fest';
 import {URL} from 'react-native-url-polyfill';
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
-import {DraftPhoto} from '../../contexts/PhotoPromiseContext/types';
+import {
+  DraftPhoto,
+  MediaMetadata,
+} from '../../contexts/PhotoPromiseContext/types';
 import {MapeoProjectApi} from '@mapeo/ipc';
 import {ClientApi} from 'rpc-reflector';
 
 type SavablePhoto = SetRequired<
   Pick<DraftPhoto, 'originalUri' | 'previewUri' | 'thumbnailUri'>,
   'originalUri'
->;
+> & {mediaMetadata: MediaMetadata};
 
 export function useCreateBlobMutation(opts: {retry?: number} = {}) {
   const project = useActiveProject();
@@ -21,6 +24,7 @@ export function useCreateBlobMutation(opts: {retry?: number} = {}) {
     retry: opts.retry,
     mutationFn: async (photo: SavablePhoto) => {
       const {originalUri, previewUri, thumbnailUri} = photo;
+      console.log({photo});
 
       return project.$blobs.create(
         {
@@ -30,7 +34,13 @@ export function useCreateBlobMutation(opts: {retry?: number} = {}) {
         },
         // TODO: DraftPhoto type should probably carry MIME type info that feeds this
         // although backend currently only uses first part of path
-        {mimeType: 'image/jpeg'},
+
+        {
+          mimeType: 'image/jpeg',
+          // @ts-expect-error
+          location: photo.mediaMetadata.location,
+          timestamp: photo.mediaMetadata.timestamp,
+        },
       );
     },
   });

--- a/src/frontend/hooks/useDraftObservation.ts
+++ b/src/frontend/hooks/useDraftObservation.ts
@@ -84,10 +84,13 @@ export const useDraftObservation = () => {
     [newPersistedDraft, cancelPhotoProcessing],
   );
 
-  const deletePhoto = useCallback((uri: string) => {
-    deletePersistedPhoto(uri);
-    deletePhotoPromise(uri);
-  }, []);
+  const deletePhoto = useCallback(
+    (uri: string) => {
+      deletePersistedPhoto(uri);
+      deletePhotoPromise(uri);
+    },
+    [deletePersistedPhoto, deletePhotoPromise],
+  );
 
   return {
     addPhoto,

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -4,6 +4,7 @@ import {Preset, Observation} from '@mapeo/schema';
 import {LocationObject, LocationProviderStatus} from 'expo-location';
 import {NavigationState} from '@react-navigation/native';
 import {EDITING_SCREEN_NAMES} from '../constants';
+import {Photo, DraftPhoto} from '../contexts/PhotoPromiseContext/types';
 
 // import type {
 //   ObservationValue,
@@ -281,4 +282,20 @@ export function matchPreset(
   });
 
   return bestMatch;
+}
+
+export function isSavablePhoto(
+  photo: Photo | {draftPhotoId: string},
+): photo is DraftPhoto & {originalUri: string} {
+  if (!('draftPhotoId' in photo)) return false;
+
+  if ('deleted' in photo && photo.deleted) return false;
+
+  if ('error' in photo && photo.error) return false;
+
+  if ('originalUri' in photo) {
+    return !!photo.originalUri;
+  }
+
+  return false;
 }

--- a/src/frontend/screens/AddPhoto.tsx
+++ b/src/frontend/screens/AddPhoto.tsx
@@ -7,7 +7,7 @@ import {defineMessages, FormattedMessage} from 'react-intl';
 import {CameraView} from '../sharedComponents/CameraView';
 import {useDraftObservation} from '../hooks/useDraftObservation';
 import {NativeRootNavigationProps} from '../sharedTypes/navigation';
-import {CapturedPictureMM} from '../contexts/PhotoPromiseContext/types';
+import {PhotoPromiseWithMetadata} from '../contexts/PhotoPromiseContext/types';
 
 const m = defineMessages({
   cancel: {
@@ -23,7 +23,7 @@ export const AddPhotoScreen = ({
 }: NativeRootNavigationProps<'AddPhoto'>) => {
   const {addPhoto} = useDraftObservation();
 
-  const handleAddPress = (capture: Promise<CapturedPictureMM>) => {
+  const handleAddPress = (capture: PhotoPromiseWithMetadata) => {
     log('pressed add button');
     addPhoto(capture);
     navigation.pop();

--- a/src/frontend/screens/CameraScreen.tsx
+++ b/src/frontend/screens/CameraScreen.tsx
@@ -3,7 +3,7 @@ import {View, StyleSheet} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 
 import {CameraView} from '../sharedComponents/CameraView';
-import {CapturedPictureMM} from '../contexts/PhotoPromiseContext/types';
+import {PhotoPromiseWithMetadata} from '../contexts/PhotoPromiseContext/types';
 import {useDraftObservation} from '../hooks/useDraftObservation';
 import {NativeHomeTabsNavigationProps} from '../sharedTypes/navigation';
 
@@ -13,8 +13,8 @@ export const CameraScreen = ({
   const isFocused = useIsFocused();
   const {newDraft} = useDraftObservation();
 
-  function handleAddPress(photoPromise: Promise<CapturedPictureMM>) {
-    newDraft(photoPromise);
+  function handleAddPress(capture: PhotoPromiseWithMetadata) {
+    newDraft(capture);
     navigation.navigate('PresetChooser');
   }
 

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -7,7 +7,6 @@ import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersis
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {useCreateObservation} from '../../hooks/server/observations';
 import {CommonActions} from '@react-navigation/native';
-import {Photo, DraftPhoto} from '../../contexts/PhotoPromiseContext/types';
 import {useCreateBlobMutation} from '../../hooks/server/media';
 import {usePersistedTrack} from '../../hooks/persistedState/usePersistedTrack';
 import {SaveButton} from '../../sharedComponents/SaveButton';
@@ -16,6 +15,7 @@ import {ErrorBottomSheet} from '../../sharedComponents/ErrorBottomSheet';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import {HeaderLeft} from './HeaderLeft';
 import {ActionsRow} from '../../sharedComponents/ActionRow';
+import {isSavablePhoto} from '../../lib/utils';
 
 const m = defineMessages({
   observation: {
@@ -232,14 +232,4 @@ export function createNavigationOptions({
       headerLeft: props => <HeaderLeft headerBackButtonProps={props} />,
     };
   };
-}
-
-function isSavablePhoto(
-  photo: Photo,
-): photo is DraftPhoto & {originalUri: string} {
-  if (!('draftPhotoId' in photo && !!photo.draftPhotoId)) return false;
-
-  if (photo.deleted || photo.error) return false;
-
-  return !!photo.originalUri;
 }

--- a/src/frontend/screens/ObservationEdit/SaveButton.tsx
+++ b/src/frontend/screens/ObservationEdit/SaveButton.tsx
@@ -10,12 +10,12 @@ import {useCreateObservation} from '../../hooks/server/observations';
 import {useEditObservation} from '../../hooks/server/observations';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {useCreateBlobMutation} from '../../hooks/server/media';
-import {DraftPhoto, Photo} from '../../contexts/PhotoPromiseContext/types';
 import {useDraftObservation} from '../../hooks/useDraftObservation';
 import {usePersistedTrack} from '../../hooks/persistedState/usePersistedTrack';
 import SaveCheck from '../../images/CheckMark.svg';
 import {CommonActions} from '@react-navigation/native';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {isSavablePhoto} from '../../lib/utils';
 
 const m = defineMessages({
   noGpsTitle: {
@@ -247,14 +247,4 @@ export const SaveButton = ({
 
 function isGpsAccurate(accuracy?: number): boolean {
   return typeof accuracy === 'number' ? accuracy < MINIMUM_ACCURACY : true;
-}
-
-function isSavablePhoto(
-  photo: Photo,
-): photo is DraftPhoto & {originalUri: string} {
-  if (!('draftPhotoId' in photo && !!photo.draftPhotoId)) return false;
-
-  if (photo.deleted || photo.error) return false;
-
-  return !!photo.originalUri;
 }


### PR DESCRIPTION
Closes #378 and #467 

Adds location and timestamp as metadata for a photo. This data is currently not exposed to user.