### PR TITLE
fix: fix extension name allowed for project config file when importing

### DIFF
--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -130,7 +130,7 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
     if (!asset) return;
 
     // Only allow importing files with the desired extension
-    if (asset.name.endsWith('.mapeoconfig')) {
+    if (asset.name.endsWith('.mapeosettings')) {
       setConfigFileResult({type: 'success', file: asset});
     } else {
       setConfigFileResult({


### PR DESCRIPTION
Fixes #518 

Forgot that we're updating the extension name of the config file when I initially implemented this 😅

Testing instructions:

1. Download config file mentioned in the notion issue onto the device.
2. Initiate project creation flow in app
3. Toggle advanced project settings and press import config button
4. Select config file from file picker
5. Press create project
6. Create observation. Notice categories are aligned with the imported config

---

Preview:

https://github.com/user-attachments/assets/e18907c9-541a-460e-91e7-45fce996f554