### PR TITLE
chore: update crc-native to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12130,9 +12130,10 @@
       }
     },
     "node_modules/crc-native": {
-      "version": "1.0.7",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/crc-native/-/crc-native-1.0.11.tgz",
+      "integrity": "sha512-F3eeKJSA2Bx/jgy9f/sVdNVo4FnY+u+XiXHmFutw4RwM+r0SErbu4d/X6UbSlENLLm26T3tp6ycbs61xAEA1ag==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "napi-macros": "^2.0.0",

--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -10,7 +10,7 @@ const TARGETS = ['android-arm', 'android-arm64'];
 // TODO: Figure out how to know if module uses N-API at runtime
 const NATIVE_MODULES = [
   {name: 'better-sqlite3', version: '8.7.0', usesNapi: false},
-  {name: 'crc-native', version: '1.0.7', usesNapi: true},
+  {name: 'crc-native', version: '1.0.11', usesNapi: true},
   {name: 'fs-native-extensions', version: '1.2.3', usesNapi: true},
   {name: 'quickbit-native', version: '2.2.0', usesNapi: true},
   {name: 'simdle-native', version: '1.2.0', usesNapi: true},

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -1924,9 +1924,9 @@
       }
     },
     "node_modules/crc-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/crc-native/-/crc-native-1.0.7.tgz",
-      "integrity": "sha512-BfjqzkyOHUp3g4xvfE8J1Sek4bg6zxGKq69lpiLvDkWz4UazNSAI8F9Tmr9sZmNASapxTwjQ6y1t8CLLTuM1pg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/crc-native/-/crc-native-1.0.11.tgz",
+      "integrity": "sha512-F3eeKJSA2Bx/jgy9f/sVdNVo4FnY+u+XiXHmFutw4RwM+r0SErbu4d/X6UbSlENLLm26T3tp6ycbs61xAEA1ag==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -7171,9 +7171,9 @@
       }
     },
     "crc-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/crc-native/-/crc-native-1.0.7.tgz",
-      "integrity": "sha512-BfjqzkyOHUp3g4xvfE8J1Sek4bg6zxGKq69lpiLvDkWz4UazNSAI8F9Tmr9sZmNASapxTwjQ6y1t8CLLTuM1pg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/crc-native/-/crc-native-1.0.11.tgz",
+      "integrity": "sha512-F3eeKJSA2Bx/jgy9f/sVdNVo4FnY+u+XiXHmFutw4RwM+r0SErbu4d/X6UbSlENLLm26T3tp6ycbs61xAEA1ag==",
       "optional": true,
       "requires": {
         "napi-macros": "^2.0.0",


### PR DESCRIPTION
chore: update crc-native to latest version

This updates our [crc-native prebuild][0] to the latest version of crc-native, 1.0.11[^1]. This will hopefully fix [#534].

[^1]: Technically, 1.0.12 [was committed][1] but not deployed to npm.

[0]: https://github.com/digidem/crc-native-nodejs-mobile
[1]: https://github.com/holepunchto/crc-native/commit/d68f29366adc4afc08388a7ba09ed5c23789a810
[#534]: https://github.com/digidem/comapeo-mobile/issues/534