### PR TITLE
chore: remove useless escapes from regular expressions

### DIFF
--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -98,10 +98,10 @@ function getNodeJsMobileNodeVersions() {
 
   const content = fs.readFileSync(nodeVersionFilePath, 'utf-8');
 
-  const major = content.match(/\#define NODE_MAJOR_VERSION (.+)/)[1];
-  const minor = content.match(/\#define NODE_MINOR_VERSION (.+)/)[1];
-  const patch = content.match(/\#define NODE_PATCH_VERSION (.+)/)[1];
-  const abi = content.match(/\#define NODE_MODULE_VERSION (.+)/)[1];
+  const major = content.match(/#define NODE_MAJOR_VERSION (.+)/)[1];
+  const minor = content.match(/#define NODE_MINOR_VERSION (.+)/)[1];
+  const patch = content.match(/#define NODE_PATCH_VERSION (.+)/)[1];
+  const abi = content.match(/#define NODE_MODULE_VERSION (.+)/)[1];
 
   return {
     major,

--- a/src/frontend/screens/ManualGpsScreen/shared.ts
+++ b/src/frontend/screens/ManualGpsScreen/shared.ts
@@ -13,7 +13,7 @@ export type FormProps = {
 };
 
 // Adapted from https://stackoverflow.com/a/7708352
-export const POSITIVE_DECIMAL_REGEX = /^([\d]+(?:[\.][\d]*)?|\.[\d]+)$/;
+export const POSITIVE_DECIMAL_REGEX = /^([\d]+(?:\.[\d]*)?|\.[\d]+)$/;
 
 export const INTEGER_REGEX = /^[0-9]\d*$/;
 


### PR DESCRIPTION
*This is not urgent, and is just something I noticed while working.*

This change should have no impact on functionality, and only fixes lint warnings.