### PR TITLE
fix: detail navigation

### DIFF
--- a/e2e/observations/add-details.yaml
+++ b/e2e/observations/add-details.yaml
@@ -9,8 +9,7 @@ env:
 - tapOn:
     id: '${SUBCAT}.add-observation-btn'
 - tapOn: '.*Gathering Site.*'
-- tapOn:
-    id: 'OBS.add-details-btn'
+- tapOn: '.*Details.*'
 - assertVisible:
     label: 'Add details button opens Details screen'
     id: 'OBS.add-details-scrn'
@@ -26,17 +25,18 @@ env:
 - assertVisible:
     label: 'Prompt displays name of detail field with placeholder/help text below'
     text: '.*firewood.*'
+- assertVisible:
+    label: 'Cursor is visible and on-screen keyboard is open by default'
+    id: '${CAT}.details-inp'
+    focused: true
 - tapOn:
     id: '${SUBCAT}.header-back-btn'
 - assertVisible:
     label: 'Back arrow when on question 1 of 1 returns to new observation screen'
     text: '.*New Observation.*'
+- tapOn: '.*Details.*'
 - tapOn:
-    id: 'OBS.add-details-btn'
-- assertVisible:
-    label: 'Cursor is visible and on-screen keyboard is open by default'
     id: '${CAT}.details-inp'
-    focused: true
 - inputText:
     label: 'Can input text into the text field'
     text: 'Some details'
@@ -50,4 +50,4 @@ env:
     label: 'Tapping done returns to new observation screen'
     text: '.*New Observation.*'
 - tapOn:
-    id: '${CAT}.edit-save-btn'
+    id: '${CAT}.save-btn'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@bam.tech/react-native-image-resizer": "^3.0.7",
+        "@dev-plugins/react-navigation": "^0.0.6",
         "@dr.pogodin/react-native-fs": "^2.24.1",
         "@formatjs/intl-getcanonicallocales": "^2.3.0",
         "@formatjs/intl-locale": "^3.3.2",
@@ -2525,6 +2526,36 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dev-plugins/react-navigation": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@dev-plugins/react-navigation/-/react-navigation-0.0.6.tgz",
+      "integrity": "sha512-DBuNhCyo0kqYPxZzirL4TZBemOGHBI1pxxF6LOU4WlsVaCK16PJvvtgoD2Tbd0xS64fdfaDyISrn16RbIncy5A==",
+      "dependencies": {
+        "@react-navigation/devtools": "^6.0.20",
+        "nanoid": "^3.1.23"
+      },
+      "peerDependencies": {
+        "@react-navigation/core": "*",
+        "expo": "*"
+      }
+    },
+    "node_modules/@dev-plugins/react-navigation/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/@digidem/types": {
       "version": "2.3.0",
@@ -8153,6 +8184,36 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/@react-navigation/devtools": {
+      "version": "6.0.27",
+      "resolved": "https://registry.npmjs.org/@react-navigation/devtools/-/devtools-6.0.27.tgz",
+      "integrity": "sha512-ppeAz1cDGs9aIsAk6sHJtLTqLgtij1+qS3jWRAjLFBvx3urFdiIS73Ujq2Zmh+jPXmo+QpdD/A37x9vI095iLQ==",
+      "dependencies": {
+        "deep-equal": "^2.0.5",
+        "nanoid": "^3.1.23",
+        "stacktrace-parser": "^0.1.10"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@react-navigation/devtools/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/@react-navigation/drawer": {
       "version": "6.6.15",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.7",
+    "@dev-plugins/react-navigation": "^0.0.6",
     "@dr.pogodin/react-native-fs": "^2.24.1",
     "@formatjs/intl-getcanonicallocales": "^2.3.0",
     "@formatjs/intl-locale": "^3.3.2",

--- a/src/frontend/AppNavigator.tsx
+++ b/src/frontend/AppNavigator.tsx
@@ -9,6 +9,7 @@ import {ProjectInviteBottomSheet} from './sharedComponents/ProjectInviteBottomSh
 import {Loading} from './sharedComponents/Loading';
 import {AppStackParamsList} from './sharedTypes/navigation';
 import {EDITING_SCREEN_NAMES} from './constants';
+import {useReactNavigationDevTools} from '@dev-plugins/react-navigation';
 
 export const rootNavigationRef =
   createNavigationContainerRef<AppStackParamsList>();
@@ -31,6 +32,8 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
       unsubscribe();
     };
   }, []);
+
+  useReactNavigationDevTools(rootNavigationRef);
 
   return (
     <NavigationContainer ref={rootNavigationRef}>

--- a/src/frontend/screens/ObservationEdit/ThumbnailAndActionTab.tsx
+++ b/src/frontend/screens/ObservationEdit/ThumbnailAndActionTab.tsx
@@ -67,11 +67,15 @@ export const ThumbnailAndActionTab: FC<ThumbnailAndActionTab> = ({
 
   const handleAudioPress = useCallback(() => {
     if (permissionResponse?.granted) {
-      navigation.navigate('Home', {screen: 'Map'});
+      // handle audio recording start
     } else {
       openAudioPermissionSheet();
     }
-  }, [navigation, openAudioPermissionSheet, permissionResponse?.granted]);
+  }, [openAudioPermissionSheet, permissionResponse?.granted]);
+
+  const handleAudioPermissionGranted = useCallback(() => {
+    // handle audio recording start after permission is granted
+  }, []);
 
   const bottomSheetItems = [
     {
@@ -108,6 +112,7 @@ export const ThumbnailAndActionTab: FC<ThumbnailAndActionTab> = ({
         closeSheet={closeAudioPermissionSheet}
         isOpen={isAudioPermissionSheetOpen}
         sheetRef={audioPermissionSheetRef}
+        onPermissionGranted={handleAudioPermissionGranted}
       />
     </>
   );

--- a/src/frontend/sharedComponents/PermissionAudio.tsx
+++ b/src/frontend/sharedComponents/PermissionAudio.tsx
@@ -20,18 +20,20 @@ interface PermissionAudio {
   sheetRef: React.RefObject<BottomSheetModalMethods>;
   closeSheet: () => void;
   isOpen: boolean;
+  onPermissionGranted?: () => void;
 }
 
 export const PermissionAudio: FC<PermissionAudio> = props => {
-  const {sheetRef, closeSheet, isOpen} = props;
+  const {sheetRef, closeSheet, isOpen, onPermissionGranted} = props;
   const {formatMessage: t} = useIntl();
-  const navigation = useNavigationFromRoot();
   const [permissionResponse] = Audio.usePermissions({request: false});
 
   const handlePermissionGranted = useCallback(() => {
     closeSheet();
-    navigation.navigate('Home', {screen: 'Map'});
-  }, [closeSheet, navigation]);
+    if (onPermissionGranted) {
+      onPermissionGranted();
+    }
+  }, [closeSheet, onPermissionGranted]);
 
   const isPermissionGranted = Boolean(permissionResponse?.granted);
 


### PR DESCRIPTION
closes #515 

### Description
- adds a [package](https://docs.expo.dev/debugging/devtools-plugins/#react-navigation) to enable navigation debugging, which can make navigation which is sometimes obtuse, much clearer.
- Turns out when I was testing I was granting *all* permissions, even audio. 
- Because of the way the audio permissions file was set up, which is called from the thumbnail and action tab, if audio permission was granted, as soon as I got to the edit screen, I was being navigated back to the home screen
- Because we don't yet have audio, and I am not sure what is supposed to be happening, I just put comments in the code so that when we actually have that functionality, we can call it as needed. 
- In the meantime, this fixes the problem I was having, and the problem anyone who had granted permission for audio would have
- Because I am now on the ObservationEdit screen in the ObservationDetails test, I had to adjust a few things within the test

