### PR TITLE
fix: MediaScrollView shows saved photos

### DIFF
--- a/src/frontend/contexts/PhotoPromiseContext/types.ts
+++ b/src/frontend/contexts/PhotoPromiseContext/types.ts
@@ -1,17 +1,15 @@
 import {LocationObject} from 'expo-location';
+import {Attachment} from '../../sharedTypes';
 
 export const THUMBNAIL_SIZE = 400;
 export const THUMBNAIL_QUALITY = 30;
 export const PREVIEW_SIZE = 1200;
 export const PREVIEW_QUALITY = 30;
 
-export interface SavedPhoto {
-  // id of the photo in the Mapeo database
-  id: string;
-  type?: 'photo';
-  // If an image is to be deleted
+export type SavedPhoto = Omit<Attachment, 'type'> & {
+  type: 'photo';
   deleted?: boolean;
-}
+};
 
 export type UnprocessedDraftPhoto = {
   type: 'unprocessed';

--- a/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
+++ b/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
@@ -1,11 +1,11 @@
 import {StateCreator} from 'zustand';
 import {createPersistedState} from '../createPersistedState';
-import {DraftPhoto, Photo} from '../../../contexts/PhotoPromiseContext/types';
 import {
-  deletePhoto,
-  filterPhotosFromAttachments,
-  replaceDraftPhotos,
-} from './photosMethods';
+  DraftPhoto,
+  Photo,
+  SavedPhoto,
+} from '../../../contexts/PhotoPromiseContext/types';
+import {deletePhoto, replaceDraftPhotos} from './photosMethods';
 import {ClientGeneratedObservation, Position} from '../../../sharedTypes';
 import {Observation, Preset} from '@mapeo/schema';
 import {usePresetsQuery} from '../../server/presets';
@@ -96,10 +96,9 @@ const draftObservationSlice: StateCreator<DraftObservationSlice> = (
       set({
         value: draftProps.observation,
         observationId: draftProps.observation.docId,
-        photos:
-          draftProps.observation.attachments.length > 0
-            ? filterPhotosFromAttachments(draftProps.observation.attachments)
-            : [],
+        photos: draftProps.observation.attachments.filter(
+          (att): att is SavedPhoto => att.type === 'photo',
+        ),
       });
     },
     updateTags: (tagKey, tagValue) => {

--- a/src/frontend/hooks/persistedState/usePersistedDraftObservation/photosMethods.ts
+++ b/src/frontend/hooks/persistedState/usePersistedDraftObservation/photosMethods.ts
@@ -1,17 +1,9 @@
 import {StoreApi} from 'zustand';
 import {DraftPhoto} from '../../../contexts/PhotoPromiseContext/types';
 import {DraftObservationSlice} from '.';
-import {ObservationValue} from '@mapeo/schema';
 
 type Setter = StoreApi<DraftObservationSlice>['setState'];
 type Getter = StoreApi<DraftObservationSlice>['getState'];
-export interface SavedPhoto {
-  // id of the photo in the Mapeo database
-  id: string;
-  type?: 'photo';
-  // If an image is to be deleted
-  deleted?: boolean;
-}
 
 export function deletePhoto(set: Setter, get: Getter, uri: string) {
   const newPhotosArray = get().photos.filter(
@@ -33,26 +25,4 @@ export function replaceDraftPhotos(
     return p;
   });
   set({photos: updatedPhotosState});
-}
-
-// Filter photos from an array of observation attachments (we could have videos
-// and other media types)
-export function filterPhotosFromAttachments(
-  attachments: ObservationValue['attachments'] = [],
-): Array<SavedPhoto> {
-  if (!attachments || attachments.length < 1) return [];
-
-  return attachments.reduce<Array<SavedPhoto>>((acc, att) => {
-    if (
-      att.type === 'photo' ||
-      // This is needed for backwards compat, because early versions did not
-      // save a type
-      (att.type === undefined && /(\.jpg|\.jpeg)$/i.test(att.hash))
-    )
-      acc.push({
-        id: `${att.driveDiscoveryId}/${att.type}/${att.name}`,
-        type: att.type,
-      });
-    return acc;
-  }, []);
 }

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -2,15 +2,11 @@
 import {fromLatLon} from 'utm';
 import {Preset, Observation} from '@mapeo/schema';
 import {LocationObject, LocationProviderStatus} from 'expo-location';
-import {NavigationState} from '@react-navigation/native';
-import {EDITING_SCREEN_NAMES} from '../constants';
-import {Photo, DraftPhoto} from '../contexts/PhotoPromiseContext/types';
 
 // import type {
 //   ObservationValue,
 //   ObservationAttachment,
 // } from "../context/ObservationsContext";
-// import type { SavedPhoto } from "../context/DraftObservationContext";
 // import type {
 //   Preset,
 //   PresetsMap,
@@ -91,29 +87,6 @@ export function getLocationStatus({
 //     ...preset,
 //     fields: filterFalsy(fieldDefs),
 //   };
-// }
-
-// // Filter photos from an array of observation attachments (we could have videos
-// // and other media types)
-// export function filterPhotosFromAttachments(
-//   attachments?: Array<ObservationAttachment> = []
-// ): Array<SavedPhoto> {
-//   return attachments.reduce((acc, att) => {
-//     if (
-//       att.type === "image/jpeg" ||
-//       // This is needed for backwards compat, because early versions did not
-//       // save a type
-//       (att.type === undefined && /(\.jpg|\.jpeg)$/i.test(att.id))
-//     )
-//       acc.push({ id: att.id, type: att.type });
-//     return acc;
-//   }, []);
-// }
-
-// export function getLastPhotoAttachment(
-//   attachments?: Array<ObservationAttachment> = []
-// ): SavedPhoto | void {
-//   return filterPhotosFromAttachments(attachments).pop();
 // }
 
 // // Coordinates conversions

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -16,9 +16,9 @@ import {ButtonFields} from './Buttons';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {ObservationHeaderRight} from './ObservationHeaderRight';
 import {MediaScrollView} from '../../sharedComponents/MediaScrollView/index.tsx';
-import {useAttachmentUrlQueries} from '../../hooks/server/media.ts';
 import {useDeviceInfo} from '../../hooks/server/deviceInfo';
 import {useCreatedByToDeviceId} from '../../hooks/server/projects.ts';
+import {SavedPhoto} from '../../contexts/PhotoPromiseContext/types.ts';
 
 const m = defineMessages({
   deleteTitle: {
@@ -72,12 +72,8 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
 
   // Currently only show photo attachments
   const photoAttachments = observation.attachments.filter(
-    attachment => attachment.type === 'photo',
+    (attachment): attachment is SavedPhoto => attachment.type === 'photo',
   );
-  const attachmentUrls = useAttachmentUrlQueries(
-    photoAttachments,
-    'thumbnail',
-  ).map(query => query.data);
 
   return (
     <ScrollView
@@ -102,16 +98,9 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
               <Text style={styles.textNotes}>{observation.tags.notes}</Text>
             </View>
           ) : null}
-          {attachmentUrls.length > 0 && (
+          {photoAttachments.length > 0 && (
             <MediaScrollView
-              photos={attachmentUrls.map(attachmentData => {
-                return !attachmentData
-                  ? undefined
-                  : {
-                      thumbnailUri: attachmentData.url,
-                      id: attachmentData.driveDiscoveryId,
-                    };
-              })}
+              photos={photoAttachments}
               observationId={observationId}
             />
           )}

--- a/src/frontend/sharedComponents/Editor/index.tsx
+++ b/src/frontend/sharedComponents/Editor/index.tsx
@@ -15,7 +15,7 @@ type EditorProps = {
   PresetIcon: React.ReactNode;
   notes: string;
   updateNotes: (newNotes: string) => void;
-  photos: (Partial<Photo> | undefined)[];
+  photos: Photo[];
   location?: {
     lat: number | undefined;
     lon: number | undefined;

--- a/src/frontend/sharedComponents/MediaScrollView/PhotoThumbnail.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/PhotoThumbnail.tsx
@@ -102,7 +102,7 @@ const UnsavedPhotoThumbnail = ({photo}: {photo: DraftPhoto}) => {
 };
 
 type PhotoThumbnailContextProps = {
-  onPress: () => any;
+  onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   size?: number;
 };

--- a/src/frontend/sharedComponents/MediaScrollView/PhotoThumbnail.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/PhotoThumbnail.tsx
@@ -1,5 +1,4 @@
-import React, {FC} from 'react';
-import {Photo} from '../../contexts/PhotoPromiseContext/types';
+import React, {FC, createContext, useContext} from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -13,38 +12,62 @@ import {
 import {AlertIcon} from '../icons';
 import debug from 'debug';
 import {LIGHT_GREY} from '../../lib/styles';
+import {
+  DraftPhoto,
+  Photo,
+  SavedPhoto,
+} from '../../contexts/PhotoPromiseContext/types';
+import {useAttachmentUrlQuery} from '../../hooks/server/media';
 
 const log = debug('Thumbnail');
 
-type PhotoThumbnailProps = {
-  photo?: Partial<Photo>;
-  onPress: () => any;
-  style?: StyleProp<ViewStyle>;
-  size?: number;
+type PhotoThumbnailProps = PhotoThumbnailContextProps & {
+  photo: Photo;
 };
 
 export const PhotoThumbnail: FC<PhotoThumbnailProps> = props => {
   const {photo, style, size, onPress} = props;
-  const [error, setError] = React.useState(false);
 
-  const uri =
-    (photo && 'thumbnailUri' in photo && photo.thumbnailUri) || undefined;
-  const photoProcessingError = photo && 'error' in photo && !!photo.error;
-  const isCapturing = photo && photo.type === 'unprocessed';
+  return (
+    <PhotoThumbnailContext.Provider value={{style, size, onPress}}>
+      {photo.type === 'photo' ? (
+        <SavedPhotoThumbnail photo={photo} />
+      ) : (
+        <UnsavedPhotoThumbnail photo={photo} />
+      )}
+    </PhotoThumbnailContext.Provider>
+  );
+};
+
+type PhotoThumbnailImageProps = {
+  isLoading: boolean;
+  error?: Error | null;
+  uri?: string;
+};
+
+const PhotoThumbnailImage = ({
+  isLoading,
+  error,
+  uri,
+}: PhotoThumbnailImageProps) => {
+  const [nativeImageError, setNativeImageError] = React.useState(false);
+
+  const {size, style, onPress} = usePhotoThumbnailContext();
 
   function handleImageError(e: NativeSyntheticEvent<ImageErrorEventData>) {
     log('Error loading image:\n', e.nativeEvent && e.nativeEvent.error);
-    setError(true);
+    setNativeImageError(true);
   }
 
   return (
     <TouchableOpacity
       style={[styles.thumbnailContainer, {width: size, height: size}, style]}
+      disabled={isLoading || !!error}
       onPress={onPress}>
-      {error || photoProcessingError ? (
-        <AlertIcon />
-      ) : isCapturing ? (
+      {isLoading ? (
         <ActivityIndicator />
+      ) : error || nativeImageError || !uri ? (
+        <AlertIcon />
       ) : (
         <Image
           onError={handleImageError}
@@ -55,6 +78,46 @@ export const PhotoThumbnail: FC<PhotoThumbnailProps> = props => {
     </TouchableOpacity>
   );
 };
+
+const SavedPhotoThumbnail = ({photo}: {photo: SavedPhoto}) => {
+  const image = useAttachmentUrlQuery(photo, 'thumbnail');
+
+  return (
+    <PhotoThumbnailImage
+      isLoading={image.isPending}
+      error={image.error}
+      uri={image.data?.url}
+    />
+  );
+};
+
+const UnsavedPhotoThumbnail = ({photo}: {photo: DraftPhoto}) => {
+  return (
+    <PhotoThumbnailImage
+      isLoading={photo.type === 'unprocessed' && !('error' in photo)}
+      error={'error' in photo ? photo.error : undefined}
+      uri={'thumbnailUri' in photo ? photo.thumbnailUri : undefined}
+    />
+  );
+};
+
+type PhotoThumbnailContextProps = {
+  onPress: () => any;
+  style?: StyleProp<ViewStyle>;
+  size?: number;
+};
+
+const PhotoThumbnailContext = createContext<
+  PhotoThumbnailContextProps | undefined
+>(undefined);
+
+function usePhotoThumbnailContext() {
+  const context = useContext(PhotoThumbnailContext);
+
+  if (!context) throw new Error('PhotoThumbnailContext not initialized');
+
+  return context;
+}
 
 const styles = StyleSheet.create({
   thumbnailContainer: {

--- a/src/frontend/sharedComponents/MediaScrollView/PhotoThumbnail.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/PhotoThumbnail.tsx
@@ -62,7 +62,7 @@ const PhotoThumbnailImage = ({
   return (
     <TouchableOpacity
       style={[styles.thumbnailContainer, {width: size, height: size}, style]}
-      disabled={isLoading || !!error}
+      disabled={isLoading || !!error || !onPress}
       onPress={onPress}>
       {isLoading ? (
         <ActivityIndicator />

--- a/src/frontend/sharedComponents/MediaScrollView/index.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/index.tsx
@@ -9,7 +9,7 @@ const spacing = 10;
 const minSize = 150;
 
 interface MediaScrollView {
-  photos: (Partial<Photo> | undefined)[];
+  photos: Photo[];
   observationId?: string;
 }
 
@@ -65,7 +65,7 @@ export const MediaScrollView: FC<MediaScrollView> = ({
             photo={photo}
             style={styles.thumbnail}
             size={size}
-            onPress={() => photo && handlePhotoPress(photo)}
+            onPress={() => handlePhotoPress(photo)}
           />
         ))}
     </ScrollView>

--- a/src/frontend/sharedComponents/MediaScrollView/index.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/index.tsx
@@ -24,24 +24,6 @@ export const MediaScrollView: FC<MediaScrollView> = ({
     scrollViewRef.current && scrollViewRef.current.scrollToEnd();
   }, [photos?.length]);
 
-  function handlePhotoPress(photo: Partial<Photo>) {
-    if ('driveDiscoveryId' in photo) {
-      navigation.navigate('PhotoPreviewModal', {
-        attachmentId: photo.driveDiscoveryId,
-        observationId: observationId,
-        deletable: false,
-      });
-      return;
-    }
-    if ('originalUri' in photo) {
-      navigation.navigate('PhotoPreviewModal', {
-        deletable: true,
-        originalPhotoUri: photo.originalUri,
-      });
-      return;
-    }
-  }
-
   if (photos?.length === 0) return null;
   const windowWidth = Dimensions.get('window').width;
   // Get a thumbnail size so there is always 1/2 of a thumbnail off the right of
@@ -59,15 +41,34 @@ export const MediaScrollView: FC<MediaScrollView> = ({
       style={styles.photosContainer}>
       {photos
         ?.filter(photo => photo?.deleted == null)
-        ?.map((photo, index) => (
-          <PhotoThumbnail
-            key={index}
-            photo={photo}
-            style={styles.thumbnail}
-            size={size}
-            onPress={() => handlePhotoPress(photo)}
-          />
-        ))}
+        ?.map((photo, index) => {
+          const onPress =
+            photo.type === 'photo'
+              ? () => {
+                  navigation.navigate('PhotoPreviewModal', {
+                    attachmentId: photo.driveDiscoveryId,
+                    observationId: observationId,
+                    deletable: false,
+                  });
+                }
+              : photo.type === 'processed'
+                ? () => {
+                    navigation.navigate('PhotoPreviewModal', {
+                      deletable: true,
+                      originalPhotoUri: photo.originalUri,
+                    });
+                  }
+                : undefined;
+          return (
+            <PhotoThumbnail
+              key={index}
+              photo={photo}
+              style={styles.thumbnail}
+              size={size}
+              onPress={onPress}
+            />
+          );
+        })}
     </ScrollView>
   );
 };

--- a/src/frontend/sharedComponents/MediaScrollView/index.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/index.tsx
@@ -25,9 +25,9 @@ export const MediaScrollView: FC<MediaScrollView> = ({
   }, [photos?.length]);
 
   function handlePhotoPress(photo: Partial<Photo>) {
-    if ('id' in photo) {
+    if ('driveDiscoveryId' in photo) {
       navigation.navigate('PhotoPreviewModal', {
-        attachmentId: photo.id,
+        attachmentId: photo.driveDiscoveryId,
         observationId: observationId,
         deletable: false,
       });

--- a/src/frontend/sharedComponents/PhotoUnpreparedView.tsx
+++ b/src/frontend/sharedComponents/PhotoUnpreparedView.tsx
@@ -46,7 +46,7 @@ const PhotoUnpreparedComponent = ({
 
   return (
     <Pressable onPress={onPress} style={[styles.container, style]}>
-      {isLoading ? (
+      {isLoading || !attachmentUrl ? (
         <UIActivityIndicator color={WHITE} />
       ) : isError ? (
         <AlertIcon size={96} />


### PR DESCRIPTION
Closes #549 

Updated the architecture of the photos and the media scroll view.

Previously, Mapeo did not have access to the types used in the back end. So the front end created the `SavedPhoto` Type. We ported this type over, but using this outdated type added a lot of complexity as we had to convert `Obervation.attachments` to this `SavedPhoto` type. Now that we have access to the backend types, I updated SavedPhoto to be `Observation["Attachments"]`. Now we no longer have to convert the type back an forth, which was causing confusing errors ans spaghetti code.

But this means that we had to convert all the component which used `Photo` (`type Photo = SavedPhoto & DraftPhoto`) or `SavedPhoto`. This PR converts those component, mainly media scroll view.

Media Scroll View now simply takes a `Photo[]` and maps each of these "photos" in the `PhotoThumbnail` component. The `PhotoThumbnail` component simply checks whether the photos is `SavedPhoto` or `DraftPhoto`. If it is a `DraftPhoto` the uri is accessible in memory (as the photo has just been taken), and produces an image with that uri. If it is a saved photo, it fetches the URI using `useAttachmentUrlQuery`. This `PhotoThumbnail` handles the loading and error state.