### PR TITLE
fix: prevent project invite sheet from showing during observation creation

### DIFF
--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -9,6 +9,7 @@ export const EDITING_SCREEN_NAMES:
   'AddPhoto',
   'PresetChooser',
   'ManualGpsScreen',
+  'ObservationCreate',
   'ObservationDetails',
   'ObservationEdit',
   'Camera',


### PR DESCRIPTION
Fixes #552 

The invite bottom sheet is not supposed to show up when the person being invited is in the process of creating/editing an observation. The check we had for making sure this doesn't happen excluded the case of creating an observation and being in the editor screen.

Testing steps:

1. Device A creates project
2. Device B starts creating observation. Stop at the editor screen
3. Device A invites Device B to project. Note that Device B does not see the invite sheet
4. Device B either leaves or finishes the observation creation. Upon returning to the map, the invite sheet should display.

---

Preview:

https://github.com/user-attachments/assets/f1031ec5-4501-494c-a467-faa0b3ebce22