### PR TITLE
core: add browserstack note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,7 @@ The next version of Mapeo Mobile
         ```sh
         npm run android-no-backend-rebuild
         ```
+
+## E2E Testing
+
+This project is tested with BrowserStack.


### PR DESCRIPTION
This is a requirement for the browserstack open source plan that offer free real device testing for open source projects.