### PR TITLE
chore: address lint error caused by ts-expect-error

### DIFF
--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -26,7 +26,6 @@ export function useCreateBlobMutation(opts: {retry?: number} = {}) {
         // although backend currently only uses first part of path
         {
           mimeType: 'image/jpeg',
-          // @ts-expect-error
           location: photo.mediaMetadata.location,
           timestamp: photo.mediaMetadata.timestamp,
         },


### PR DESCRIPTION
Comment was originally introduced to silence an error that has now been addressed since merging https://github.com/digidem/comapeo-mobile/pull/566