### PR TITLE
chore: run types check for frontend code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,7 @@ jobs:
         run: npm run build:translations
       - name: Build Intl polyfills
         run: npm run build:intl-polyfills
+      - name: Check types
+        run: npm run lint:types
       - name: Run unit tests
         run: npm test


### PR DESCRIPTION
Seems as good a time as ever to enable type checks in CI for frontend code, given that at the time of writing, running that check reports no errors!