### PR TITLE
fix: Can go back from team screen after creation of project

### DIFF
--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
@@ -51,16 +51,15 @@ export const ProjectCreated = ({
 
   //This resets the navigation so the user cannot press back and return to this screen
   function handleGoToInviteScreen() {
-    navigation.dispatch(state => {
-      const index = state.routes.findIndex(r => r.name === 'Settings');
+    navigation.dispatch(() => {
       const routes = [
-        ...state.routes.slice(0, index + 1),
+        {name: 'Home'},
+        {name: 'ProjectSettings'},
         {name: 'YourTeam'},
         {name: 'SelectDevice'},
       ];
 
       return CommonActions.reset({
-        ...state,
         routes,
         index: routes.length - 1,
       });


### PR DESCRIPTION
fixes #546

The nav state was previously being reset based on assumption that the user was navigating for the setting page. With the introduction of the setting drawer, the settings page no longer exists. So the nav state was being reset incorectly, meaning the user was stuck at team page, with no way to go to navigate back. This PR manually resets the nav state based on the desired back actions.