### PR TITLE
fix: project settings called when project created

### DIFF
--- a/src/frontend/contexts/ActiveProjectContext.tsx
+++ b/src/frontend/contexts/ActiveProjectContext.tsx
@@ -6,9 +6,13 @@ import {useProject, useCreateProject} from '../hooks/server/projects';
 import {Loading} from '../sharedComponents/Loading';
 import {useApi} from './ApiContext';
 
-const ActiveProjectContext = React.createContext<MapeoProjectApi | undefined>(
-  undefined,
-);
+const ActiveProjectContext = React.createContext<
+  | {
+      project: MapeoProjectApi | undefined;
+      isPlaceholderData: boolean;
+    }
+  | undefined
+>(undefined);
 
 export const ActiveProjectProvider = ({
   children,
@@ -18,7 +22,7 @@ export const ActiveProjectProvider = ({
   const activeProjectId = usePersistedProjectId(store => store.projectId);
   const setActiveProjectId = usePersistedProjectId(store => store.setProjectId);
 
-  const activeProjectQuery = useProject(activeProjectId);
+  const {data: project, isPlaceholderData} = useProject(activeProjectId);
   const {mutate: createProject} = useCreateProject();
 
   // The persisted active project ID may be missing in the following scenarios:
@@ -59,12 +63,17 @@ export const ActiveProjectProvider = ({
       });
   }, [activeProjectId, setActiveProjectId, createProject, mapeoApi]);
 
-  if (!activeProjectQuery.data) {
+  if (!project) {
     return <Loading />;
   }
 
+  const contextValue = {
+    project,
+    isPlaceholderData,
+  };
+
   return (
-    <ActiveProjectContext.Provider value={activeProjectQuery.data}>
+    <ActiveProjectContext.Provider value={contextValue}>
       {children}
     </ActiveProjectContext.Provider>
   );

--- a/src/frontend/hooks/server/fields.ts
+++ b/src/frontend/hooks/server/fields.ts
@@ -2,7 +2,7 @@ import {useQuery} from '@tanstack/react-query';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
 export const useFieldsQuery = () => {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useQuery({
     queryKey: ['fields'],

--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -78,7 +78,11 @@ export function useClearAllPendingInvites() {
 
 export function useSendInvite() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
+
+  if (!project) {
+    throw new Error('Project is not defined');
+  }
   type InviteParams = Parameters<typeof project.$member.invite>;
   return useMutation({
     mutationFn: ({
@@ -97,10 +101,15 @@ export function useSendInvite() {
 
 export function useRequestCancelInvite() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
+
   return useMutation({
-    mutationFn: (deviceId: string) =>
-      project.$member.requestCancelInvite(deviceId),
+    mutationFn: (deviceId: string) => {
+      if (!project) {
+        throw new Error('Project is not defined');
+      }
+      return project.$member.requestCancelInvite(deviceId);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [INVITE_KEY]});
     },

--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -9,14 +9,14 @@ import {MapeoProjectApi} from '@mapeo/ipc';
 import {ClientApi} from 'rpc-reflector';
 
 export function useCreateBlobMutation(opts: {retry?: number} = {}) {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useMutation({
     retry: opts.retry,
     mutationFn: async (photo: ProcessedDraftPhoto) => {
       const {originalUri, previewUri, thumbnailUri} = photo;
 
-      return project.$blobs.create(
+      return project!.$blobs.create(
         {
           original: new URL(originalUri).pathname,
           preview: previewUri ? new URL(previewUri).pathname : undefined,
@@ -95,10 +95,10 @@ export function useAttachmentUrlQuery(
   >,
   enabledByDefault: boolean = true,
 ) {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
   return useQuery(
     resolveAttachmentUrlQueryOptions(
-      project,
+      project!,
       attachment,
       variant,
       enabledByDefault,
@@ -113,12 +113,12 @@ export function useAttachmentUrlQueries(
   >,
   enabledByDefault: boolean = true,
 ) {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useQueries({
     queries: attachments.map(attachment =>
       resolveAttachmentUrlQueryOptions(
-        project,
+        project!,
         attachment,
         variant,
         enabledByDefault,

--- a/src/frontend/hooks/server/observations.ts
+++ b/src/frontend/hooks/server/observations.ts
@@ -10,7 +10,7 @@ import {ClientGeneratedObservation} from '../../sharedTypes';
 export const OBSERVATION_KEY = 'observations';
 
 export function useObservations() {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useSuspenseQuery({
     queryKey: [OBSERVATION_KEY],
@@ -22,7 +22,7 @@ export function useObservations() {
 }
 
 export function useObservation(observationId: string) {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useSuspenseQuery({
     queryKey: [OBSERVATION_KEY, observationId],
@@ -35,7 +35,7 @@ export function useObservation(observationId: string) {
 
 export function useCreateObservation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({value}: {value: ClientGeneratedObservation}) => {
@@ -54,7 +54,7 @@ export function useCreateObservation() {
 
 export function useEditObservation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({
@@ -64,7 +64,7 @@ export function useEditObservation() {
       versionId: string;
       value: ObservationValue;
     }) => {
-      return project.observation.update(versionId, value);
+      return project!.observation.update(versionId, value);
     },
     onSuccess: data => {
       queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY, data.docId]});
@@ -74,7 +74,7 @@ export function useEditObservation() {
 
 export function useDeleteObservation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({id}: {id: string}) => {

--- a/src/frontend/hooks/server/presets.ts
+++ b/src/frontend/hooks/server/presets.ts
@@ -12,7 +12,7 @@ import {useActiveProject} from '../../contexts/ActiveProjectContext';
 export const PRESETS_KEY = 'presets';
 
 export function usePresetsQuery() {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useSuspenseQuery({
     queryKey: [PRESETS_KEY],
@@ -24,7 +24,7 @@ export function usePresetsQuery() {
 }
 
 export function usePresetsMutation() {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -39,17 +39,17 @@ export function usePresetsMutation() {
 }
 
 export function useGetPresetIcon(size: IconSize, name?: string) {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useQuery({
     queryKey: ['presetIcon', name],
     enabled: !!name,
     queryFn: async () => {
-      const currentPreset = await project.preset
+      const currentPreset = await project!.preset
         .getMany()
         .then(res => res.find(p => p.name === name));
 
-      return await project.$icons.getIconUrl(currentPreset?.iconId!, {
+      return await project!.$icons.getIconUrl(currentPreset?.iconId!, {
         mimeType: 'image/png',
         size: size,
         pixelDensity: 3,

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -59,35 +59,41 @@ export function useCreateProject() {
 }
 
 export function useProjectMembers() {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useQuery({
     queryKey: [PROJECT_MEMBERS_KEY],
     queryFn: () => {
-      return project.$member.getMany();
+      return project!.$member.getMany();
     },
+    enabled: !!project,
   });
 }
 
 export function useProjectSettings() {
-  const project = useActiveProject();
+  const {project, isPlaceholderData} = useActiveProject();
 
   return useQuery({
     queryKey: [PROJECT_SETTINGS_KEY],
-    queryFn: () => {
-      return project.$getProjectSettings();
+    queryFn: async () => {
+      if (!project) {
+        throw new Error('Project is not defined');
+      }
+      return await project.$getProjectSettings();
     },
+    enabled: !!project && !isPlaceholderData,
   });
 }
 
 export const useCreatedByToDeviceId = (createdBy: string) => {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useQuery({
     queryKey: [CREATED_BY_TO_DEVICE_ID_KEY, createdBy],
     queryFn: async () => {
-      return await project.$createdByToDeviceId(createdBy);
+      return await project!.$createdByToDeviceId(createdBy);
     },
+    enabled: !!project,
   });
 };
 

--- a/src/frontend/hooks/server/track.ts
+++ b/src/frontend/hooks/server/track.ts
@@ -11,11 +11,11 @@ export const TRACK_KEY = 'tracks';
 
 export function useCreateTrack() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useMutation({
     mutationFn: async (params: TrackValue) => {
-      return project.track.create(params);
+      return project!.track.create(params);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [TRACK_KEY]});
@@ -24,35 +24,35 @@ export function useCreateTrack() {
 }
 
 export function useTracks() {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useSuspenseQuery({
     queryKey: [TRACK_KEY],
     queryFn: async () => {
       return process.env.EXPO_PUBLIC_FEATURE_TRACKS
-        ? project.track.getMany()
+        ? project!.track.getMany()
         : [];
     },
   });
 }
 
 export function useTrackQuery(docId: string) {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
   return useSuspenseQuery({
     queryKey: [TRACK_KEY, docId],
     queryFn: async () => {
-      return project.track.getByDocId(docId);
+      return project!.track.getByDocId(docId);
     },
   });
 }
 
 export function useDeleteTrackMutation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   return useMutation({
     mutationFn: async (docId: string) => {
-      return project.track.delete(docId);
+      return project!.track.delete(docId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [TRACK_KEY]});

--- a/src/frontend/hooks/useSyncState.ts
+++ b/src/frontend/hooks/useSyncState.ts
@@ -10,13 +10,13 @@ export type SyncState = Awaited<
 const projectSyncStoreMap = new WeakMap<MapeoProjectApi, SyncStore>();
 
 function useSyncStore() {
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
-  let syncStore = projectSyncStoreMap.get(project);
+  let syncStore = projectSyncStoreMap.get(project!);
 
   if (!syncStore) {
-    syncStore = new SyncStore(project);
-    projectSyncStoreMap.set(project, syncStore);
+    syncStore = new SyncStore(project!);
+    projectSyncStoreMap.set(project!, syncStore);
   }
 
   return syncStore;

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -44,7 +44,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
   route,
 }) => {
   const {formatMessage} = useIntl();
-  const project = useActiveProject();
+  const {project} = useActiveProject();
 
   const value = usePersistedDraftObservation(store => store.value);
   const {updateTags, clearDraft, usePreset, existingObservationToDraft} =
@@ -68,7 +68,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
         navigation.goBack();
         return;
       }
-      project.observation
+      project!.observation
         .getByDocId(route.params.observationId)
         .then(observation => {
           existingObservationToDraft(observation);
@@ -78,7 +78,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
     value,
     existingObservationToDraft,
     route.params?.observationId,
-    project.observation,
+    project!.observation,
     navigation,
   ]);
 

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -83,7 +83,7 @@ export const ProjectSyncDisplay = ({
 }) => {
   const {formatMessage: t} = useIntl();
 
-  const project = useActiveProject();
+  const {project} = useActiveProject();
   const queryClient = useQueryClient();
   const navigation = useNavigationFromRoot();
   const {connectedPeers, data, initial} = syncState;
@@ -92,7 +92,7 @@ export const ProjectSyncDisplay = ({
   // stops sync when user leaves sync screen. The api allows us to continue syncing even if the user is not on the sync screen, but for simplicity we are only allowing sync while on the sync screen. In the future we can easily enable background sync, there are just some UI questions that need to answered before we do that.
   React.useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', () => {
-      project.$sync.stop();
+      project!.$sync.stop();
       queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY]});
     });
 
@@ -121,7 +121,7 @@ export const ProjectSyncDisplay = ({
             fullWidth
             variant="outlined"
             onPress={() => {
-              project.$sync.stop();
+              project!.$sync.stop();
             }}>
             <View style={styles.buttonContentContainer}>
               <StopIcon size={20} color={BLACK} />
@@ -136,7 +136,7 @@ export const ProjectSyncDisplay = ({
             variant="contained"
             onPress={() => {
               if (isSyncDone) return;
-              project.$sync.start();
+              project!.$sync.start();
             }}>
             <View style={styles.buttonContentContainer}>
               {isSyncDone ? (


### PR DESCRIPTION
closes #545 

### Description

- When a project was created, placeholder data was being used in the ActiveProjectContext file to prevent the app from unmounting, so the project settings were not being updated and the new project name was not available in the drawer
- A new flag, isPlaceholderData, is now introduced in the ActiveProjectContext to indicate whether the data in the context is still placeholder data or fully loaded. This helps to conditionally enable queries so that they run at the right times
- Now ActiveProjectContext holds an object containing both project and isPlaceholderData
- Had to adjust all the places that useActiveProject is used to account for it being an object and typescript errors related to project possibly being undefined (although it can't be, I think)