### PR TITLE
fix: prevent queries using project api from using stale instance

### DIFF
--- a/src/frontend/contexts/ActiveProjectContext.tsx
+++ b/src/frontend/contexts/ActiveProjectContext.tsx
@@ -6,9 +6,9 @@ import {useProject, useCreateProject} from '../hooks/server/projects';
 import {Loading} from '../sharedComponents/Loading';
 import {useApi} from './ApiContext';
 
-const ActiveProjectContext = React.createContext<MapeoProjectApi | undefined>(
-  undefined,
-);
+const ActiveProjectContext = React.createContext<
+  {projectId: string; projectApi: MapeoProjectApi} | undefined
+>(undefined);
 
 export const ActiveProjectProvider = ({
   children,

--- a/src/frontend/hooks/server/fields.ts
+++ b/src/frontend/hooks/server/fields.ts
@@ -2,13 +2,12 @@ import {useQuery} from '@tanstack/react-query';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
 export const useFieldsQuery = () => {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useQuery({
-    queryKey: ['fields'],
+    queryKey: ['fields', projectId],
     queryFn: async () => {
-      if (!project) throw new Error('Project instance does not exist');
-      return project.field.getMany();
+      return projectApi.field.getMany();
     },
   });
 };

--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -78,8 +78,8 @@ export function useClearAllPendingInvites() {
 
 export function useSendInvite() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
-  type InviteParams = Parameters<typeof project.$member.invite>;
+  const {projectApi} = useActiveProject();
+  type InviteParams = Parameters<typeof projectApi.$member.invite>;
   return useMutation({
     mutationFn: ({
       deviceId,
@@ -87,7 +87,7 @@ export function useSendInvite() {
     }: {
       deviceId: InviteParams[0];
       role: InviteParams[1];
-    }) => project.$member.invite(deviceId, role),
+    }) => projectApi.$member.invite(deviceId, role),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [INVITE_KEY]});
       queryClient.invalidateQueries({queryKey: [PROJECT_MEMBERS_KEY]});
@@ -97,10 +97,10 @@ export function useSendInvite() {
 
 export function useRequestCancelInvite() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
   return useMutation({
     mutationFn: (deviceId: string) =>
-      project.$member.requestCancelInvite(deviceId),
+      projectApi.$member.requestCancelInvite(deviceId),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [INVITE_KEY]});
     },

--- a/src/frontend/hooks/server/observations.ts
+++ b/src/frontend/hooks/server/observations.ts
@@ -10,38 +10,34 @@ import {ClientGeneratedObservation} from '../../sharedTypes';
 export const OBSERVATION_KEY = 'observations';
 
 export function useObservations() {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useSuspenseQuery({
-    queryKey: [OBSERVATION_KEY],
+    queryKey: [OBSERVATION_KEY, projectId],
     queryFn: async () => {
-      if (!project) throw new Error('Project instance does not exist');
-      return project.observation.getMany();
+      return projectApi.observation.getMany();
     },
   });
 }
 
 export function useObservation(observationId: string) {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useSuspenseQuery({
-    queryKey: [OBSERVATION_KEY, observationId],
+    queryKey: [OBSERVATION_KEY, projectId, observationId],
     queryFn: async () => {
-      if (!project) throw new Error('Project instance does not exist');
-      return project.observation.getByDocId(observationId);
+      return projectApi.observation.getByDocId(observationId);
     },
   });
 }
 
 export function useCreateObservation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({value}: {value: ClientGeneratedObservation}) => {
-      if (!project) throw new Error('Project instance does not exist');
-
-      return project.observation.create({
+      return projectApi.observation.create({
         ...value,
         schemaName: 'observation',
       });
@@ -54,7 +50,7 @@ export function useCreateObservation() {
 
 export function useEditObservation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({
@@ -64,7 +60,7 @@ export function useEditObservation() {
       versionId: string;
       value: ObservationValue;
     }) => {
-      return project.observation.update(versionId, value);
+      return projectApi.observation.update(versionId, value);
     },
     onSuccess: data => {
       queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY, data.docId]});
@@ -74,12 +70,11 @@ export function useEditObservation() {
 
 export function useDeleteObservation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({id}: {id: string}) => {
-      if (!project) throw new Error('Project instance does not exist');
-      return project.observation.delete(id);
+      return projectApi.observation.delete(id);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY]});

--- a/src/frontend/hooks/server/presets.ts
+++ b/src/frontend/hooks/server/presets.ts
@@ -12,25 +12,23 @@ import {useActiveProject} from '../../contexts/ActiveProjectContext';
 export const PRESETS_KEY = 'presets';
 
 export function usePresetsQuery() {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useSuspenseQuery({
-    queryKey: [PRESETS_KEY],
+    queryKey: [PRESETS_KEY, projectId],
     queryFn: async () => {
-      if (!project) throw new Error('Project instance does not exist');
-      return await project.preset.getMany();
+      return await projectApi.preset.getMany();
     },
   });
 }
 
 export function usePresetsMutation() {
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (preset: PresetValue) => {
-      if (!project) throw new Error('Project instance does not exist');
-      return await project.preset.create(preset);
+      return await projectApi.preset.create(preset);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [PRESETS_KEY]});
@@ -39,17 +37,17 @@ export function usePresetsMutation() {
 }
 
 export function useGetPresetIcon(size: IconSize, name?: string) {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useQuery({
-    queryKey: ['presetIcon', name],
+    queryKey: ['presetIcon', projectId, size, name],
     enabled: !!name,
     queryFn: async () => {
-      const currentPreset = await project.preset
+      const currentPreset = await projectApi.preset
         .getMany()
         .then(res => res.find(p => p.name === name));
 
-      return await project.$icons.getIconUrl(currentPreset?.iconId!, {
+      return await projectApi.$icons.getIconUrl(currentPreset?.iconId!, {
         mimeType: 'image/png',
         size: size,
         pixelDensity: 3,

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -17,7 +17,9 @@ export function useProject(projectId?: string) {
     queryKey: [PROJECT_KEY, projectId],
     queryFn: async () => {
       if (!projectId) throw new Error('Active project ID must exist');
-      return api.getProject(projectId);
+      const projectApi = await api.getProject(projectId);
+
+      return {projectId, projectApi};
     },
     enabled: !!projectId,
     placeholderData: previousData => previousData,
@@ -59,34 +61,34 @@ export function useCreateProject() {
 }
 
 export function useProjectMembers() {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useQuery({
-    queryKey: [PROJECT_MEMBERS_KEY],
+    queryKey: [PROJECT_MEMBERS_KEY, projectId],
     queryFn: () => {
-      return project.$member.getMany();
+      return projectApi.$member.getMany();
     },
   });
 }
 
 export function useProjectSettings() {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useQuery({
-    queryKey: [PROJECT_SETTINGS_KEY],
+    queryKey: [PROJECT_SETTINGS_KEY, projectId],
     queryFn: () => {
-      return project.$getProjectSettings();
+      return projectApi.$getProjectSettings();
     },
   });
 }
 
 export const useCreatedByToDeviceId = (createdBy: string) => {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useQuery({
-    queryKey: [CREATED_BY_TO_DEVICE_ID_KEY, createdBy],
+    queryKey: [CREATED_BY_TO_DEVICE_ID_KEY, projectId, createdBy],
     queryFn: async () => {
-      return await project.$createdByToDeviceId(createdBy);
+      return await projectApi.$createdByToDeviceId(createdBy);
     },
   });
 };

--- a/src/frontend/hooks/server/track.ts
+++ b/src/frontend/hooks/server/track.ts
@@ -11,11 +11,11 @@ export const TRACK_KEY = 'tracks';
 
 export function useCreateTrack() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
   return useMutation({
     mutationFn: async (params: TrackValue) => {
-      return project.track.create(params);
+      return projectApi.track.create(params);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [TRACK_KEY]});
@@ -24,35 +24,35 @@ export function useCreateTrack() {
 }
 
 export function useTracks() {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useSuspenseQuery({
-    queryKey: [TRACK_KEY],
+    queryKey: [TRACK_KEY, projectId],
     queryFn: async () => {
       return process.env.EXPO_PUBLIC_FEATURE_TRACKS
-        ? project.track.getMany()
+        ? projectApi.track.getMany()
         : [];
     },
   });
 }
 
 export function useTrackQuery(docId: string) {
-  const project = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
   return useSuspenseQuery({
-    queryKey: [TRACK_KEY, docId],
+    queryKey: [TRACK_KEY, projectId, docId],
     queryFn: async () => {
-      return project.track.getByDocId(docId);
+      return projectApi.track.getByDocId(docId);
     },
   });
 }
 
 export function useDeleteTrackMutation() {
   const queryClient = useQueryClient();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
   return useMutation({
     mutationFn: async (docId: string) => {
-      return project.track.delete(docId);
+      return projectApi.track.delete(docId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [TRACK_KEY]});

--- a/src/frontend/hooks/useSyncState.ts
+++ b/src/frontend/hooks/useSyncState.ts
@@ -10,13 +10,13 @@ export type SyncState = Awaited<
 const projectSyncStoreMap = new WeakMap<MapeoProjectApi, SyncStore>();
 
 function useSyncStore() {
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
-  let syncStore = projectSyncStoreMap.get(project);
+  let syncStore = projectSyncStoreMap.get(projectApi);
 
   if (!syncStore) {
-    syncStore = new SyncStore(project);
-    projectSyncStoreMap.set(project, syncStore);
+    syncStore = new SyncStore(projectApi);
+    projectSyncStoreMap.set(projectApi, syncStore);
   }
 
   return syncStore;

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -44,7 +44,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
   route,
 }) => {
   const {formatMessage} = useIntl();
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
 
   const value = usePersistedDraftObservation(store => store.value);
   const {updateTags, clearDraft, usePreset, existingObservationToDraft} =
@@ -68,7 +68,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
         navigation.goBack();
         return;
       }
-      project.observation
+      projectApi.observation
         .getByDocId(route.params.observationId)
         .then(observation => {
           existingObservationToDraft(observation);
@@ -78,7 +78,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
     value,
     existingObservationToDraft,
     route.params?.observationId,
-    project.observation,
+    projectApi.observation,
     navigation,
   ]);
 

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -83,7 +83,7 @@ export const ProjectSyncDisplay = ({
 }) => {
   const {formatMessage: t} = useIntl();
 
-  const project = useActiveProject();
+  const {projectApi} = useActiveProject();
   const queryClient = useQueryClient();
   const navigation = useNavigationFromRoot();
   const {connectedPeers, data, initial} = syncState;
@@ -92,12 +92,12 @@ export const ProjectSyncDisplay = ({
   // stops sync when user leaves sync screen. The api allows us to continue syncing even if the user is not on the sync screen, but for simplicity we are only allowing sync while on the sync screen. In the future we can easily enable background sync, there are just some UI questions that need to answered before we do that.
   React.useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', () => {
-      project.$sync.stop();
+      projectApi.$sync.stop();
       queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY]});
     });
 
     return unsubscribe;
-  }, [navigation, project, queryClient]);
+  }, [navigation, projectApi, queryClient]);
 
   const isDataSyncEnabled = data.isSyncEnabled;
 
@@ -121,7 +121,7 @@ export const ProjectSyncDisplay = ({
             fullWidth
             variant="outlined"
             onPress={() => {
-              project.$sync.stop();
+              projectApi.$sync.stop();
             }}>
             <View style={styles.buttonContentContainer}>
               <StopIcon size={20} color={BLACK} />
@@ -136,7 +136,7 @@ export const ProjectSyncDisplay = ({
             variant="contained"
             onPress={() => {
               if (isSyncDone) return;
-              project.$sync.start();
+              projectApi.$sync.start();
             }}>
             <View style={styles.buttonContentContainer}>
               {isSyncDone ? (


### PR DESCRIPTION
Fixes #545 

Before, all queries that were using the project api instance (provided by the `useProject()` hook and accessed via the `useActiveProject()` hook) were prone to:

- working with an outdated instance, which could lead to incorrect results when fetching updates. 
- not refetching after a new project instance is being used. This is due to many of the queries using a `queryKey` that provided no indication for react-query to trigger refetches after setting a new project instance (e.g. after creating a project). 

The main change that this PR introduces is updating the return type of `useProjects()` and `useActiveProjects()` hooks such that they provide the associated project id, which in turn is mostly used for specifying the `queryKey` option for various relevant queries. Refrained from any major adjustments to existing implementations, aside from some types-enabled changes.

Haven't done a thorough testing of the app, nor any additional work to see if anything else can take advantage of the updated return type (which is probably possible, but can be done as a follow-up). 

---

Preview:

https://github.com/user-attachments/assets/59a8b2d7-3006-465d-90fc-2dd6607fe347

