### PR TITLE
fix: force load intl polyfills

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import 'react-native-gesture-handler';
-import './src/frontend/polyfills';
+import './src/frontend/polyfills/intl';
 import {registerRootComponent} from 'expo';
 import App from './src/frontend/App';
 

--- a/scripts/build-intl-polyfills.mjs
+++ b/scripts/build-intl-polyfills.mjs
@@ -67,14 +67,16 @@ function writePolyfillFile(locales, outputPath) {
 
   // Write lines to load base polyfills
   writer.write(
-    createImportStatement('@formatjs/intl-getcanonicallocales/polyfill'),
+    createImportStatement('@formatjs/intl-getcanonicallocales/polyfill-force'),
   );
-  writer.write(createImportStatement('@formatjs/intl-locale/polyfill'));
+  writer.write(createImportStatement('@formatjs/intl-locale/polyfill-force'));
 
   writer.write('\n');
 
   // Write lines to load plural rules polyfill
-  writer.write(createImportStatement('@formatjs/intl-pluralrules/polyfill'));
+  writer.write(
+    createImportStatement('@formatjs/intl-pluralrules/polyfill-force'),
+  );
   for (const locale of locales) {
     writer.write(
       createImportStatement(`@formatjs/intl-pluralrules/locale-data/${locale}`),
@@ -85,7 +87,7 @@ function writePolyfillFile(locales, outputPath) {
 
   // Write lines to load relative time format polyfill
   writer.write(
-    createImportStatement('@formatjs/intl-relativetimeformat/polyfill'),
+    createImportStatement('@formatjs/intl-relativetimeformat/polyfill-force'),
   );
   for (const locale of locales) {
     writer.write(

--- a/src/frontend/polyfills/index.ts
+++ b/src/frontend/polyfills/index.ts
@@ -1,1 +1,0 @@
-import './intl';


### PR DESCRIPTION
The normal intl polyfills do a conditional check to see if there's a need to actually set up the polyfill. This check is unnecessary for us (since we know React Native needs them) and apparently can have severe performance downsides on lower-end Android devices (see https://github.com/formatjs/formatjs/issues/4463 for additional context).

This PR changes the imports to unconditionally load the relevant intl polyfills. I didn't notice any notable performance improvement on my devices (Pixel 6 and Pixel 2) after some light testing, but think it's worth introducing this change anyways.