### PR TITLE
chore: update translations compilation script and use AST output

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -6,6 +6,7 @@ const defaultBlockList = Array.isArray(config.resolver.blockList)
   ? config.resolver.blockList
   : [config.resolver.blockList];
 
+/** @type {import('expo/metro-config').MetroConfig} */
 module.exports = {
   ...config,
   transformer: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
         "@eslint/eslintrc": "3.3.0",
         "@eslint/js": "9.21.0",
         "@formatjs/cli": "6.6.1",
+        "@formatjs/cli-lib": "6.6.6",
         "@mapeo/mock-data": "2.1.5",
         "@react-native/metro-babel-transformer": "0.76.6",
         "@react-native/metro-config": "0.76.6",
@@ -4683,6 +4684,205 @@
         }
       }
     },
+    "node_modules/@formatjs/cli-lib": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli-lib/-/cli-lib-6.6.6.tgz",
+      "integrity": "sha512-yWcW2fJB7wLblOPED+1NfaUU0dHBt/UZSsw774lh/oxKrr+rOfFTHciqTMif1H533mRcxkPtIZf/WdPsgzqgXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "@formatjs/icu-skeleton-parser": "1.8.8",
+        "@formatjs/ts-transformer": "3.13.23",
+        "@types/estree": "^1.0.0",
+        "@types/fs-extra": "9 || 10 || 11",
+        "@types/json-stable-stringify": "1",
+        "@types/node": "14 || 16 || 17 || 18 || 20 || 22",
+        "chalk": "4",
+        "commander": "12",
+        "fast-glob": "3",
+        "fs-extra": "9 || 10 || 11",
+        "json-stable-stringify": "1",
+        "loud-rejection": "2",
+        "tslib": "2",
+        "typescript": "5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "@glimmer/env": "^0.1.7",
+        "@glimmer/reference": "^0.91.1 || ^0.92.0",
+        "@glimmer/syntax": "^0.92.0",
+        "@glimmer/validator": "^0.92.0",
+        "@vue/compiler-core": "^3.4.0",
+        "content-tag": "^2.0.1",
+        "ember-template-recast": "^6.1.4",
+        "vue": "^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@glimmer/env": {
+          "optional": true
+        },
+        "@glimmer/reference": {
+          "optional": true
+        },
+        "@glimmer/syntax": {
+          "optional": true
+        },
+        "@glimmer/validator": {
+          "optional": true
+        },
+        "@vue/compiler-core": {
+          "optional": true
+        },
+        "content-tag": {
+          "optional": true
+        },
+        "ember-template-recast": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
+      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/intl-localematcher": "0.5.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
+      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
+      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-skeleton-parser": "1.8.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
+      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
+      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@formatjs/cli-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
@@ -4807,6 +5007,118 @@
         "@formatjs/ecma402-abstract": "2.3.4",
         "@formatjs/intl-localematcher": "0.6.1",
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.13.23.tgz",
+      "integrity": "sha512-9ufpij2uHlc/yzb2WDOswaslTQQ7nOIE7aDLWErmc7Kpm5uPU6MihSuEa//DVoNoOD+fywYkbqsZnDjvXeLuAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "@types/json-stable-stringify": "1",
+        "@types/node": "14 || 16 || 17 || 18 || 20 || 22",
+        "chalk": "4",
+        "json-stable-stringify": "1",
+        "tslib": "2",
+        "typescript": "5"
+      },
+      "peerDependencies": {
+        "ts-jest": ">=27"
+      },
+      "peerDependenciesMeta": {
+        "ts-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
+      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/intl-localematcher": "0.5.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
+      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
+      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-skeleton-parser": "1.8.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
+      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
+      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@formatjs/ts-transformer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@gorhom/bottom-sheet": {
@@ -8472,6 +8784,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/gensync": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.4.tgz",
@@ -8569,6 +8892,23 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-stable-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.1.0.tgz",
+      "integrity": "sha512-ESTsHWB72QQq+pjUFIbEz9uSCZppD31YrVkbt2rnUciTYEvcwN6uZIhX5JZeBHqRlFJ41x/7MewCs7E2Qux6Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lint-staged": {
       "version": "13.3.0",
@@ -10841,6 +11181,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/array-union": {
@@ -13519,6 +13869,19 @@
       "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-find-index": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -22014,6 +22377,27 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loud-rejection": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
+      "integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/loud-rejection/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@eslint/eslintrc": "3.3.0",
     "@eslint/js": "9.21.0",
     "@formatjs/cli": "6.6.1",
+    "@formatjs/cli-lib": "6.6.6",
     "@mapeo/mock-data": "2.1.5",
     "@react-native/metro-babel-transformer": "0.76.6",
     "@react-native/metro-config": "0.76.6",

--- a/scripts/build-translations.mjs
+++ b/scripts/build-translations.mjs
@@ -1,92 +1,65 @@
 #!/usr/bin/env node
 
+// @ts-check
+
+/**
+ * Uses @formatjs/cli-lib and its built-in CrowdIn messages formatter to compile extracted messages for usage in react-intl.
+ * The primary difference between this and using @format/cli directly is that this consolidates messages from all languages
+ * and compiles them to a single JSON file, which we load into memory in its entirety when the application starts.
+ *
+ * By contrast, the CLI creates a JSON file per language, which is done under the assumption that the application loads these files
+ * lazily based on the active language, which is usually the preferred approach and something we should eventually switch to
+ * (see https://github.com/digidem/mapeo-mobile/discussions/828).
+ */
+
+import {mkdirSync, readdirSync, rmSync, writeFileSync} from 'node:fs';
 import path from 'node:path';
-import fs from 'node:fs';
-import {readFile, writeFile} from 'node:fs/promises';
+import {compile} from '@formatjs/cli-lib';
 
 import LANGUAGE_NAME_TRANSLATIONS from '../src/frontend/languages.json' with {type: 'json'};
 
 const PROJECT_ROOT_DIR_PATH = new URL('../', import.meta.url).pathname;
 const TRANSLATIONS_DIR_PATH = path.join(PROJECT_ROOT_DIR_PATH, 'translations');
-
 const TRANSLATIONS_OUTPUT_PATH = path.join(
   TRANSLATIONS_DIR_PATH,
   'messages.json',
 );
+const CROWDIN_FORMATTER_PATH = new URL(
+  import.meta.resolve('@formatjs/cli-lib/src/formatters/crowdin.js'),
+).pathname;
 
-await run();
+rmSync(TRANSLATIONS_DIR_PATH, {force: true, recursive: true});
+mkdirSync(TRANSLATIONS_DIR_PATH);
 
-async function run() {
-  fs.rmSync(TRANSLATIONS_DIR_PATH, {force: true, recursive: true});
-  fs.mkdirSync(TRANSLATIONS_DIR_PATH);
+const files = readdirSync(path.join(PROJECT_ROOT_DIR_PATH, 'messages'), {
+  withFileTypes: true,
+});
 
-  const messages = await loadMessages();
-  const translations = convertMessagesToTranslations(messages);
-
-  await writeFile(
-    TRANSLATIONS_OUTPUT_PATH,
-    JSON.stringify(translations, null, 2),
-  );
-
-  console.log(`Successfully built translations to ${TRANSLATIONS_OUTPUT_PATH}`);
-}
-
-////////////////////////////// Helpers //////////////////////////////
-
-/**
- * @returns {Promise<{ [lang: string]: unknown }>}
- */
-async function loadMessages() {
-  const files = fs.readdirSync(path.join(PROJECT_ROOT_DIR_PATH, 'messages'), {
-    withFileTypes: true,
-  });
-
-  /** @type {Array<[string, any]>} */
-  const loadedMessages = await Promise.all(
-    files.map(async file => {
-      const lang = path.parse(file.name).name;
-      const msgs = JSON.parse(await readFile(path.join(file.path, file.name)));
-      return [lang, msgs];
-    }),
-  );
-
-  const result = {};
-
-  for (const [lang, msgs] of loadedMessages) {
-    // If a language is added to Crowdin, but has no translated messages,
-    // Crowdin still creates an empty file, so we just ignore it
-    if (Object.keys(msgs).length === 0) continue;
-
-    if (!result[lang]) {
-      result[lang] = msgs;
-    } else {
-      result[lang] = {...result[lang], ...msgs};
-    }
-  }
-
-  return result;
-}
-
-/**
- * @param {{ [lang: string]: unknown }} messages
- */
-function convertMessagesToTranslations(messages) {
-  const result = {};
-
-  for (const lang in messages) {
-    if (!LANGUAGE_NAME_TRANSLATIONS[lang]) {
-      console.warn(`Locale '${lang}' has no language name defined in \`src/frontend/languages.json\`,
-so it will not appear as a language option in CoMapeo.
-Add the language name in English and the native language to \`languages.json\`
-in order to allow users to select '${lang}' in CoMapeo`);
-    }
-    result[lang] = {};
-    const msgs = messages[lang];
-    Object.keys(msgs).forEach(key => {
-      if (!msgs[key].message) return;
-      result[lang][key] = msgs[key].message;
+const compiled = await Promise.all(
+  files.map(async f => {
+    const lang = path.parse(f.name).name;
+    const compiledMessages = await compile([path.join(f.path, f.name)], {
+      ast: true,
+      format: CROWDIN_FORMATTER_PATH,
     });
+
+    return [lang, JSON.parse(compiledMessages)];
+  }),
+);
+
+const translations = {};
+
+for (const [lang, messages] of compiled) {
+  if (!LANGUAGE_NAME_TRANSLATIONS[lang]) {
+    console.warn(`Locale '${lang}' has no language name defined in \`src/frontend/languages.json\`,
+  so it will not appear as a language option in CoMapeo.
+  Add the language name in English and the native language to \`languages.json\`
+  in order to allow users to select '${lang}' in CoMapeo`);
   }
 
-  return result;
+  translations[lang] = messages;
 }
+
+writeFileSync(TRANSLATIONS_OUTPUT_PATH, JSON.stringify(translations));
+
+console.log(`Successfully built translations to ${TRANSLATIONS_OUTPUT_PATH}\n`);


### PR DESCRIPTION
Closes https://github.com/digidem/comapeo-mobile/issues/539

Updates the `build-translations` script in the following ways:

- rely more on `@formatjs/cli` and `@format/cli-lib` to turn extracted messages into app-ready translations
- output an AST instead of the normal message format. reasons for this are:
  
    1. it allows react-intl to skip work parsing the data at runtime, improving performance (https://formatjs.github.io/docs/guides/advanced-usage#pre-compiling-messages)
    
    2. ~it allows us to avoid including the relevant parser in the bundled app, which reduces bundle size (https://formatjs.io/docs/guides/advanced-usage#react-intl-without-parser-40-smaller)~ EDIT: had to punt on this because if you're missing message keys for a language, it will fail to parse the code-defined defaultMessage (which is not in AST form) verbatim and thus not actually interpolate placeholders values, which is not desired. Removed in a subsequent commit but would be nice to take advantage of this eventually.
    
   the downside of using the AST is that it's larger in size compared to regular string messages, although it can be efficiently compressed. This means that given the current approach of loading the translations into the app (i.e. all at once, not lazily), this will probably result in slightly more memory being used.
      
   I'm open to removing the change to using the AST, in which case the issue referenced would not be closed and this PR would solely be making our custom script rely more on `@formatjs` tooling.
  
- less boilerplate code to make it more linear in terms of reading (at the small cost of functional purity/modularity)
  