### PR TITLE
fix: fix query cache invalidation after editing observation

### DIFF
--- a/src/frontend/hooks/server/observations.ts
+++ b/src/frontend/hooks/server/observations.ts
@@ -50,7 +50,7 @@ export function useCreateObservation() {
 
 export function useEditObservation() {
   const queryClient = useQueryClient();
-  const {projectApi} = useActiveProject();
+  const {projectId, projectApi} = useActiveProject();
 
   return useMutation({
     mutationFn: async ({
@@ -63,7 +63,9 @@ export function useEditObservation() {
       return projectApi.observation.update(versionId, value);
     },
     onSuccess: data => {
-      queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY, data.docId]});
+      queryClient.invalidateQueries({
+        queryKey: [OBSERVATION_KEY, projectId, data.docId],
+      });
     },
   });
 }


### PR DESCRIPTION
I introduced a bug via #576 where after editing an observation, the changes are not refetched afterwards. This is due to the query key of the query cache of interest being multiple levels deep, as opposed to the other invalidations being one level. Checked other calls of cache invalidation to make sure that this wouldn't be an issue in other cases.

More of an aside, but I wonder if the query keys should technically be ordered so that the project id is the first path component (similar to an HTTP API) e.g. `queryKey: [projectId, 'observations', observationId]`. Perhaps something to do as a follow-up (or handle this in `@comapeo/react`)