### PR TITLE
chore: handle sync fetching in UI

### DIFF
--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -16,6 +16,7 @@ import {Loading} from '../../sharedComponents/Loading';
 import {TrackListItem} from './TrackListItem';
 import {useObservations} from '../../hooks/server/observations';
 import {useTracks} from '../../hooks/server/track';
+import {UIActivityIndicator} from 'react-native-indicators';
 
 const m = defineMessages({
   loading: {
@@ -55,7 +56,7 @@ export const ObservationsList: React.FC<
 > & {
   navTitle: MessageDescriptor;
 } = ({navigation}) => {
-  const {data: observations} = useObservations();
+  const {data: observations, isFetching} = useObservations();
   const {data: tracks} = useTracks();
   const {data, isPending} = useAllProjects();
 
@@ -78,6 +79,8 @@ export const ObservationsList: React.FC<
       ) : data && data.length <= 1 ? (
         <NoProjectWarning style={{margin: 20}} />
       ) : null}
+      {/* re: https://github.com/digidem/comapeo-mobile/issues/586  */}
+      {isFetching && <UIActivityIndicator style={{padding: 20, flex: 0}} />}
       <FlatList
         initialNumToRender={rowsPerWindow}
         getItemLayout={getItemLayout}

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -83,7 +83,7 @@ export const ProjectSyncDisplay = ({
 }) => {
   const {formatMessage: t} = useIntl();
 
-  const {projectApi} = useActiveProject();
+  const {projectApi, projectId} = useActiveProject();
   const queryClient = useQueryClient();
   const navigation = useNavigationFromRoot();
   const {connectedPeers, data, initial} = syncState;
@@ -93,11 +93,11 @@ export const ProjectSyncDisplay = ({
   React.useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', () => {
       projectApi.$sync.stop();
-      queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY]});
+      queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY, projectId]});
     });
 
     return unsubscribe;
-  }, [navigation, projectApi, queryClient]);
+  }, [navigation, projectApi, queryClient, projectId]);
 
   const isDataSyncEnabled = data.isSyncEnabled;
 


### PR DESCRIPTION
closes #586 
touches on #585 

Properly invalidates observations cache when sync is complete (now uses `projectId` as part of the query key that is being invalidated)

Shows a loader at the top of the observations list when observations are being fetched

<img width="293" alt="image" src="https://github.com/user-attachments/assets/326bd944-a31a-447b-820a-55e699d5aac7">
