### PR TITLE
feat: add setting to generate fake observations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@sentry/react-native": "~5.20.0",
         "@tanstack/react-query": "^5.12.2",
         "@turf/helpers": "^7.0.0",
+        "@turf/random": "^7.0.0",
         "@types/luxon": "^3.4.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
@@ -9473,6 +9474,19 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
       "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.0.0.tgz",
+      "integrity": "sha512-l3+FW0pk6MUQx2lyMvzps2YQS7ovP6YoV0tVvuNaQq0UICB1P4EHJIKLMTe5pXk73Z3p0wTgnEPk0Z2lqWaeGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
       "funding": {
         "url": "https://opencollective.com/turf"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@sentry/react-native": "~5.20.0",
     "@tanstack/react-query": "^5.12.2",
     "@turf/helpers": "^7.0.0",
+    "@turf/random": "^7.0.0",
     "@types/luxon": "^3.4.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",

--- a/src/frontend/Navigation/Drawer.tsx
+++ b/src/frontend/Navigation/Drawer.tsx
@@ -194,6 +194,17 @@ const DrawerContent = ({navigation}: DrawerContentComponentProps) => {
           <DrawerListItemIcon iconName="info-outline" />
           <ListItemText primary={<FormattedMessage {...m.aboutCoMapeo} />} />
         </ListItem>
+        {(process.env.APP_VARIANT === 'development' ||
+          process.env.APP_VARIANT === 'test') && (
+          <ListItem
+            onPress={() => {
+              navigate('CreateTestData');
+            }}
+            testID="settingsCreateTestDataButton">
+            <DrawerListItemIcon iconName="auto-fix-high" />
+            <ListItemText primary="Create Test Data" />
+          </ListItem>
+        )}
       </List>
     </DrawerContentScrollView>
   );

--- a/src/frontend/Navigation/Drawer.tsx
+++ b/src/frontend/Navigation/Drawer.tsx
@@ -194,8 +194,7 @@ const DrawerContent = ({navigation}: DrawerContentComponentProps) => {
           <DrawerListItemIcon iconName="info-outline" />
           <ListItemText primary={<FormattedMessage {...m.aboutCoMapeo} />} />
         </ListItem>
-        {(process.env.APP_VARIANT === 'development' ||
-          process.env.APP_VARIANT === 'test') && (
+        {process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI && (
           <ListItem
             onPress={() => {
               navigate('CreateTestData');

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -65,6 +65,7 @@ import {
   createNavigationOptions as createObservationCreateNavigationOptions,
 } from '../../screens/ObservationCreate';
 import {AboutSettings} from '../../screens/Settings/About';
+import {CreateTestDataScreen} from '../../screens/Settings/CreateTestData';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -272,5 +273,14 @@ export const createDefaultScreenGroup = ({
       component={AboutSettings}
       options={{headerTitle: intl(AboutSettings.navTitle)}}
     />
+
+    {(process.env.APP_VARIANT === 'development' ||
+      process.env.APP_VARIANT === 'test') && (
+      <RootStack.Screen
+        name="CreateTestData"
+        component={CreateTestDataScreen}
+        options={{headerTitle: 'Create Test Data'}}
+      />
+    )}
   </RootStack.Group>
 );

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -274,8 +274,7 @@ export const createDefaultScreenGroup = ({
       options={{headerTitle: intl(AboutSettings.navTitle)}}
     />
 
-    {(process.env.APP_VARIANT === 'development' ||
-      process.env.APP_VARIANT === 'test') && (
+    {process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI && (
       <RootStack.Screen
         name="CreateTestData"
         component={CreateTestDataScreen}

--- a/src/frontend/screens/Settings/CreateTestData.tsx
+++ b/src/frontend/screens/Settings/CreateTestData.tsx
@@ -242,7 +242,7 @@ function useCreateFakeObservationsMutation() {
         projectApi.preset.getMany(),
       ]);
 
-      const deviceName = deviceInfo.name;
+      const notes = deviceInfo.name ? `Created by ${deviceInfo.name}` : null;
 
       const distanceBufferDegrees = lengthToDegrees(distance, 'kilometers');
 
@@ -254,8 +254,6 @@ function useCreateFakeObservationsMutation() {
         longitude + distanceBufferDegrees,
         latitude + distanceBufferDegrees,
       ] satisfies BBox;
-
-      const notes = deviceName ? `Created by ${deviceName}` : null;
 
       const promises = [];
 

--- a/src/frontend/screens/Settings/CreateTestData.tsx
+++ b/src/frontend/screens/Settings/CreateTestData.tsx
@@ -1,0 +1,305 @@
+import {Preset} from '@mapeo/schema';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {lengthToDegrees} from '@turf/helpers';
+import {randomPosition} from '@turf/random';
+import {LocationObject} from 'expo-location';
+import {type BBox} from 'geojson';
+import React, {forwardRef} from 'react';
+import {Controller, useForm} from 'react-hook-form';
+import {StyleSheet, TextInput, ToastAndroid, View} from 'react-native';
+import {UIActivityIndicator} from 'react-native-indicators';
+
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useDeviceInfo} from '../../hooks/server/deviceInfo';
+import {OBSERVATION_KEY} from '../../hooks/server/observations';
+import {usePresetsQuery} from '../../hooks/server/presets';
+import {useLocation} from '../../hooks/useLocation';
+import {LIGHT_GREY, RED, WHITE} from '../../lib/styles';
+import {Button} from '../../sharedComponents/Button';
+import {LocationView} from '../../sharedComponents/Editor/LocationView';
+import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
+import {Text} from '../../sharedComponents/Text';
+
+const DISTANCE_BUFFER_KM = 50;
+
+const BASE_NUMBER_INPUT_RULES = {
+  min: 1,
+};
+
+export function CreateTestDataScreen() {
+  const presetsQuery = usePresetsQuery();
+  const locationState = useLocation({maxDistanceInterval: 0});
+  const deviceInfoQuery = useDeviceInfo();
+  const createFakeObservations = useCreateFakeObservationsMutation();
+
+  const {
+    control,
+    handleSubmit,
+    formState: {errors},
+  } = useForm<{count?: number; distance?: number}>({
+    mode: 'onBlur',
+    shouldFocusError: false,
+  });
+
+  return (
+    <ScreenContentWithDock
+      contentContainerStyle={styles.contentContainer}
+      dockContent={
+        deviceInfoQuery.data && presetsQuery.data ? (
+          <Button
+            fullWidth
+            disabled={createFakeObservations.status === 'pending'}
+            onPress={handleSubmit(data => {
+              if (data.count === undefined) return;
+              if (!locationState.location) {
+                ToastAndroid.show('Waiting for location', ToastAndroid.SHORT);
+                return;
+              }
+
+              createFakeObservations.mutate(
+                {
+                  count: data.count,
+                  location: locationState.location,
+                  deviceName: deviceInfoQuery.data.name,
+                  presets: presetsQuery.data,
+                  distance:
+                    data.distance === undefined
+                      ? DISTANCE_BUFFER_KM
+                      : data.distance,
+                },
+                {
+                  onSuccess: () => {
+                    ToastAndroid.show(
+                      'Observations created',
+                      ToastAndroid.SHORT,
+                    );
+                  },
+                  onError: () => {
+                    ToastAndroid.show(
+                      'Failed to create observations',
+                      ToastAndroid.SHORT,
+                    );
+                  },
+                },
+              );
+            })}>
+            {createFakeObservations.status === 'pending' ? (
+              <UIActivityIndicator
+                size={30}
+                color={WHITE}
+                style={{paddingVertical: 12}}
+              />
+            ) : (
+              'Create'
+            )}
+          </Button>
+        ) : (
+          <View style={{paddingVertical: 20}}>
+            <UIActivityIndicator size={30} />
+          </View>
+        )
+      }>
+      <View style={styles.field}>
+        <Text style={styles.labelText}>Number of observations (required):</Text>
+        <Controller
+          name="count"
+          control={control}
+          rules={{
+            ...BASE_NUMBER_INPUT_RULES,
+            required: true,
+          }}
+          render={({
+            field: {onBlur, onChange, ref, value},
+            fieldState: {error},
+          }) => {
+            return (
+              <NumberInput
+                error={!!error}
+                ref={ref}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+              />
+            );
+          }}
+        />
+        <View>
+          {errors.count?.type === 'required' && (
+            <Text style={styles.errorText}>Required</Text>
+          )}
+          {errors.count?.type === 'min' && (
+            <Text style={styles.errorText}>Must be greater than 0</Text>
+          )}
+        </View>
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.labelText}>
+          Maximum bounded distance in kilometers (optional, default is{' '}
+          {DISTANCE_BUFFER_KM}):
+        </Text>
+        <View>
+          <Text>Current location: </Text>
+          {locationState.location ? (
+            <LocationView
+              lat={locationState.location.coords.latitude}
+              lon={locationState.location.coords.longitude}
+              accuracy={locationState.location.coords.accuracy || undefined}
+            />
+          ) : (
+            <UIActivityIndicator size={20} />
+          )}
+        </View>
+        <Controller
+          name="distance"
+          control={control}
+          rules={BASE_NUMBER_INPUT_RULES}
+          render={({
+            field: {onBlur, onChange, ref, value},
+            fieldState: {error},
+          }) => {
+            return (
+              <NumberInput
+                error={!!error}
+                ref={ref}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+              />
+            );
+          }}
+        />
+        <View>
+          {errors.distance?.type === 'min' && (
+            <Text style={styles.errorText}>Must be greater than 0</Text>
+          )}
+        </View>
+      </View>
+    </ScreenContentWithDock>
+  );
+}
+
+const NumberInput = forwardRef<
+  TextInput,
+  {
+    error?: boolean;
+    numberOfLines?: number;
+    onBlur?: () => void;
+    onChange?: (value: number | undefined) => void;
+    value?: number;
+  }
+>(({error, numberOfLines = 1, onChange, onBlur, value}, ref) => {
+  return (
+    <TextInput
+      ref={ref}
+      keyboardType="number-pad"
+      numberOfLines={numberOfLines}
+      onChangeText={
+        onChange
+          ? text => {
+              const result = parseInt(text, 10);
+              onChange(isNaN(result) ? undefined : result);
+            }
+          : undefined
+      }
+      onBlur={onBlur}
+      style={[styles.input, error ? {borderColor: RED} : undefined]}
+      value={value === undefined ? '' : value.toString(10)}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    gap: 20,
+  },
+  field: {
+    gap: 12,
+  },
+  labelText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  submitButtonText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: WHITE,
+  },
+  input: {
+    flex: 1,
+    borderColor: LIGHT_GREY,
+    borderWidth: 1,
+    padding: 10,
+    fontSize: 20,
+  },
+  errorText: {
+    color: RED,
+  },
+});
+
+function useCreateFakeObservationsMutation() {
+  const queryClient = useQueryClient();
+  const {projectApi, projectId} = useActiveProject();
+
+  return useMutation({
+    mutationFn: ({
+      count,
+      deviceName,
+      location,
+      presets,
+      distance,
+    }: {
+      count: number;
+      deviceName?: string;
+      location: LocationObject;
+      presets: Array<Preset>;
+      distance: number;
+    }) => {
+      const distanceBufferDegrees = lengthToDegrees(distance, 'kilometers');
+
+      const {latitude, longitude} = location.coords;
+
+      const bbox = [
+        longitude - distanceBufferDegrees,
+        latitude - distanceBufferDegrees,
+        longitude + distanceBufferDegrees,
+        latitude + distanceBufferDegrees,
+      ] satisfies BBox;
+
+      const notes = deviceName ? `Created by ${deviceName}` : null;
+
+      const promises = [];
+
+      for (let i = 0; i < count; i++) {
+        const fakeCoordinates = randomPosition({
+          bbox,
+        });
+
+        const randomPreset = presets.at(
+          Math.floor(Math.random() * presets.length),
+        );
+
+        const value = {
+          attachments: [],
+          lon: fakeCoordinates[0],
+          lat: fakeCoordinates[1],
+          metadata: {
+            position: {
+              mocked: !!location.mocked,
+            },
+          },
+          refs: [],
+          schemaName: 'observation' as const,
+          tags: {...randomPreset!.tags, notes},
+        };
+
+        promises.push(projectApi.observation.create(value));
+      }
+
+      return Promise.all(promises);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: [OBSERVATION_KEY, projectId]});
+    },
+  });
+}

--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -110,8 +110,7 @@ export const Settings: NativeNavigationComponent<'Settings'> = () => {
             secondary={<FormattedMessage {...m.aboutMapeoDesc} />}
           />
         </ListItem>
-        {(process.env.APP_VARIANT === 'development' ||
-          process.env.APP_VARIANT === 'test') && (
+        {process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI && (
           <ListItem
             onPress={() => {
               navigate('CreateTestData');

--- a/src/frontend/screens/Settings/index.tsx
+++ b/src/frontend/screens/Settings/index.tsx
@@ -110,6 +110,17 @@ export const Settings: NativeNavigationComponent<'Settings'> = () => {
             secondary={<FormattedMessage {...m.aboutMapeoDesc} />}
           />
         </ListItem>
+        {(process.env.APP_VARIANT === 'development' ||
+          process.env.APP_VARIANT === 'test') && (
+          <ListItem
+            onPress={() => {
+              navigate('CreateTestData');
+            }}
+            testID="settingsCreateTestDataButton">
+            <ListItemIcon iconName="auto-fix-high" />
+            <ListItemText primary="Create Test Data" />
+          </ListItem>
+        )}
       </List>
     </ScrollView>
   );

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -95,6 +95,7 @@ export type RootStackParamsList = {
   DeviceNameEdit: undefined;
   SaveTrack: undefined;
   Sync: undefined;
+  CreateTestData: undefined;
 };
 
 export type DeviceNamingParamsList = {


### PR DESCRIPTION
Closes #579

- Adds screen in settings that provides interface for generating fake observations.
  - **~note that this is only accessible for test and development builds of the app.~ You need to have an env variable named `EXPO_PUBLIC_FEATURE_TEST_DATA_UI` specified to enable**. 
- Input parameters are:
  - count (required)
  - bounding distance in kilometers (optional, default is 50 km)
- randomized categories based on active config's presets
- adds note for each observation detailing which device created it
- at the moment, none of the displayed copy is marked as translatable. Wasn't sure if this is something that would be used by people outside the org, so didn't want these strings to end up in crowdin if external users will never see these. open to changing if we think otherwise.
- getting "proper" number inputs in React Native are a little tedious, hence the somewhat odd code 😄 
- DOES NOT implement attachments as described in the issue for now. plan is for that to be a follow-up

TODOs:

- [ ] Not sure what to include in the observation metadata. right now I only have the `mocked` field specified. might make sense to include the other information about the position, but wanted to get feedback before doing so

---

https://github.com/user-attachments/assets/fd29dfe6-c008-43b7-bfe1-12352eacdcef
