### PR TITLE
fix: use UTC date, which could be different from local date

### DIFF
--- a/src/frontend/lib/date.ts
+++ b/src/frontend/lib/date.ts
@@ -11,7 +11,7 @@ export const formatIsoUtc = (date: Readonly<Date>): string =>
   [
     date.getUTCFullYear().toString().padStart(4, '0'),
     (date.getUTCMonth() + 1).toString().padStart(2, '0'),
-    date.getDate().toString().padStart(2, '0'),
+    date.getUTCDate().toString().padStart(2, '0'),
   ].join('-');
 
 export const isDateValid = (date: Readonly<Date>): boolean =>


### PR DESCRIPTION
`formatIsoUtc` formats a `Date` in UTC. It's possible that the day (such as the 12th of the month) is different in local time versus UTC time. This makes it use UTC, as expected.