### PR TITLE
fix: fix app variant env variable exposure

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,11 +1,11 @@
 const SUFFIX =
   {development: '.dev', production: '', test: '.test'}[
-    process.env.APP_VARIANT
+    process.env.EXPO_PUBLIC_APP_VARIANT
   ] ?? '';
 
 const NAME =
   {development: ' (DEV)', production: '', test: ' (TEST)'}[
-    process.env.APP_VARIANT
+    process.env.EXPO_PUBLIC_APP_VARIANT
   ] ?? '';
 
 /**

--- a/eas.json
+++ b/eas.json
@@ -15,14 +15,14 @@
         "buildType": "apk"
       },
       "env": {
-        "APP_VARIANT": "development"
+        "EXPO_PUBLIC_APP_VARIANT": "development"
       }
     },
     "test": {
       "distribution": "internal",
       "channel": "preview",
       "env": {
-        "APP_VARIANT": "test"
+        "EXPO_PUBLIC_APP_VARIANT": "test"
       },
       "android": {
         "image": "latest",
@@ -41,7 +41,7 @@
       },
       "channel": "production",
       "env": {
-        "APP_VARIANT": "production"
+        "EXPO_PUBLIC_APP_VARIANT": "production"
       }
     }
   },

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -21,8 +21,8 @@ Sentry.init({
   dsn: 'https://e0e02907e05dc72a6da64c3483ed88a6@o4507148235702272.ingest.us.sentry.io/4507170965618688',
   tracesSampleRate: 1.0,
   debug:
-    process.env.APP_VARIANT === 'development' ||
-    process.env.APP_VARIANT === 'test', // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+    process.env.EXPO_PUBLIC_APP_VARIANT === 'development' ||
+    process.env.EXPO_PUBLIC_APP_VARIANT === 'test', // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   initialScope: {
     user: {
       id: getSentryUserId({now: new Date(), storage}),

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -29,7 +29,7 @@ function deriveSupportedLanguages(
     if (!hasAtLeastOneTranslatedString) continue;
 
     if (!isSupportedLanguageLocale(locale)) {
-      if (process.env.APP_VARIANT === 'development') {
+      if (process.env.EXPO_PUBLIC_APP_VARIANT === 'development') {
         console.warn(
           `Locale "${locale}" is not available in CoMapeo (see \`src/frontend/languages.json\`)`,
         );


### PR DESCRIPTION
Based on Expo's documentation around env variables, I _think_ we're not exposing the `APP_VARIANT` env variable properly, despite things kind of just working anyways???

https://docs.expo.dev/build-reference/variables/
https://docs.expo.dev/guides/environment-variables/

Basically, if you want to read an env variable from `process.env` in your **app** (i.e. not at build time), you're supposed to prefix it with `EXPO_PUBLIC_` so that it gets inlined when bundling. We reference `process.env.APP_VARIANT` directly in a few places, which technically shouldn't be working based on their docs, but maybe I'm missing something?