### PR TITLE
feat: show config details and upload new config

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1056,6 +1056,18 @@
   "screens.Setting.ProjectSettings.YourTeam.title": {
     "message": "Your Team"
   },
+  "screens.Settings.Config.created": {
+    "message": "Created {date} at {time}"
+  },
+  "screens.Settings.Config.name": {
+    "message": "Config Name:"
+  },
+  "screens.Settings.Config.navTitle": {
+    "message": "Configuration"
+  },
+  "screens.Settings.Config.projectName": {
+    "message": "Project Name:"
+  },
   "screens.Settings.CreateOrJoinProject.CreateProject.title": {
     "message": "Create a Project"
   },
@@ -1145,6 +1157,10 @@
   "screens.Settings.appSettingsDesc": {
     "description": "list of avaialable app settings",
     "message": "Language, Security, Coordinates"
+  },
+  "screens.Settings.config": {
+    "description": "Primary text for project config settings",
+    "message": "Project Configuration"
   },
   "screens.Settings.createOrJoin": {
     "message": "Create or Join Project"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1059,6 +1059,9 @@
   "screens.Settings.Config.created": {
     "message": "Created {date} at {time}"
   },
+  "screens.Settings.Config.importConfig": {
+    "message": "Import Config"
+  },
   "screens.Settings.Config.name": {
     "message": "Config Name:"
   },

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -73,6 +73,7 @@ import {
 import {DataAndPrivacy} from '../../screens/Settings/DataAndPrivacy/DataAndPrivacy';
 import {SettingsPrivacyPolicy} from '../../screens/Settings/DataAndPrivacy/SettingsPrivacyPolicy';
 import {TrackEdit} from '../../screens/TrackEdit/index.tsx';
+import {Config} from '../../screens/Settings/Config';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -301,6 +302,13 @@ export const createDefaultScreenGroup = ({
       component={TrackEdit}
       options={{headerTitle: intl(TrackEdit.navTitle)}}
     />
+
+    <RootStack.Screen
+      name="Config"
+      component={Config}
+      options={{headerTitle: intl(Config.navTitle)}}
+    />
+
     {process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI && (
       <RootStack.Screen
         name="CreateTestData"

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -56,6 +56,9 @@ export function useCreateProject() {
       queryClient.invalidateQueries({
         queryKey: [ALL_PROJECTS_KEY],
       });
+      queryClient.invalidateQueries({
+        queryKey: [PROJECT_SETTINGS_KEY],
+      });
     },
   });
 }
@@ -106,6 +109,20 @@ export function useLeaveProject() {
       queryClient.invalidateQueries({
         queryKey: [ALL_PROJECTS_KEY],
       });
+    },
+  });
+}
+
+export function useImportProjectConfig() {
+  const queryClient = useQueryClient();
+  const {projectApi} = useActiveProject();
+
+  return useMutation({
+    mutationFn: (configPath: string) => {
+      return projectApi.importConfig({configPath});
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]});
     },
   });
 }

--- a/src/frontend/hooks/useSelectFileAndImportConfig.ts
+++ b/src/frontend/hooks/useSelectFileAndImportConfig.ts
@@ -1,0 +1,30 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {selectFile} from '../lib/selectFile';
+import * as FileSystem from 'expo-file-system';
+import {PROJECT_SETTINGS_KEY, useImportProjectConfig} from './server/projects';
+import {convertFileUriToPosixPath} from '../lib/file-system';
+
+export function useSelectFileAndImportConfig() {
+  const importProjectConfigMutation = useImportProjectConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const asset = await selectFile(['mapeoconfig']);
+      if (!asset) return;
+
+      try {
+        return await importProjectConfigMutation.mutateAsync(
+          convertFileUriToPosixPath(asset.uri),
+        );
+      } finally {
+        await FileSystem.deleteAsync(asset.uri).catch((err: unknown) => {
+          console.log(err);
+        });
+      }
+    },
+    onSuccess: () => {
+      return queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]});
+    },
+  });
+}

--- a/src/frontend/hooks/useSelectFileAndImportConfig.ts
+++ b/src/frontend/hooks/useSelectFileAndImportConfig.ts
@@ -10,7 +10,7 @@ export function useSelectFileAndImportConfig() {
 
   return useMutation({
     mutationFn: async () => {
-      const asset = await selectFile(['mapeoconfig', 'mapeosettings']);
+      const asset = await selectFile(['comapeocat']);
       if (!asset) return;
 
       try {

--- a/src/frontend/hooks/useSelectFileAndImportConfig.ts
+++ b/src/frontend/hooks/useSelectFileAndImportConfig.ts
@@ -10,7 +10,7 @@ export function useSelectFileAndImportConfig() {
 
   return useMutation({
     mutationFn: async () => {
-      const asset = await selectFile(['mapeoconfig']);
+      const asset = await selectFile(['mapeoconfig', 'mapeosettings']);
       if (!asset) return;
 
       try {

--- a/src/frontend/lib/selectFile.ts
+++ b/src/frontend/lib/selectFile.ts
@@ -1,0 +1,35 @@
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+
+export async function selectFile(validFileTypes: string[]) {
+  let result;
+  try {
+    result = await DocumentPicker.getDocumentAsync({
+      copyToCacheDirectory: true,
+      multiple: false,
+    });
+  } catch (err) {
+    throw err;
+  }
+
+  if (result.canceled) return;
+
+  const asset = result.assets[0];
+
+  // Shouldn't happen based on how the library works
+  if (!asset) {
+    return;
+  }
+
+  const isValidFileType = validFileTypes.some(type =>
+    asset.name.endsWith(type),
+  );
+
+  // Only allow importing files with the desired extension
+  if (isValidFileType) {
+    return asset;
+  } else {
+    FileSystem.deleteAsync(asset.uri);
+    throw new Error('Invalid file type');
+  }
+}

--- a/src/frontend/screens/Settings/Config.tsx
+++ b/src/frontend/screens/Settings/Config.tsx
@@ -1,10 +1,20 @@
 import * as React from 'react';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
 import {defineMessages, useIntl} from 'react-intl';
 import {StyleSheet, View} from 'react-native';
 import {Text} from '../../sharedComponents/Text';
-import {useProjectSettings} from '../../hooks/server/projects';
+import {
+  useImportProjectConfig,
+  useProjectSettings,
+} from '../../hooks/server/projects';
 import {Loading} from '../../sharedComponents/Loading';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
+import {COMAPEO_BLUE, MEDIUM_GREY} from '../../lib/styles';
+import {Button} from '../../sharedComponents/Button';
+import {convertFileUriToPosixPath} from '../../lib/file-system';
+import {UIActivityIndicator} from 'react-native-indicators';
+import {ErrorBottomSheet} from '../../sharedComponents/ErrorBottomSheet';
 
 const m = defineMessages({
   navTitle: {
@@ -23,11 +33,68 @@ const m = defineMessages({
     id: 'screens.Settings.Config.created',
     defaultMessage: 'Created {date} at {time}',
   },
+  importConfig: {
+    id: 'screens.Settings.Config.importConfig',
+    defaultMessage: 'Import Config',
+  },
 });
 
-export const Config: NativeNavigationComponent<'Config'> = () => {
+export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
   const {formatMessage} = useIntl();
   const {data, isPending} = useProjectSettings();
+  const [importError, setImportError] = React.useState<Error | null>(null);
+
+  const importProjectConfigMutation = useImportProjectConfig();
+
+  React.useEffect(() => {
+    // Prevent back navigation while project creation mutation is pending
+    const unsubscribe = navigation.addListener('beforeRemove', event => {
+      if (!importProjectConfigMutation.isPending) {
+        return;
+      }
+
+      event.preventDefault();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [navigation, importProjectConfigMutation.isPending]);
+
+  async function importConfigFile() {
+    let result;
+    try {
+      result = await DocumentPicker.getDocumentAsync({
+        copyToCacheDirectory: true,
+        multiple: false,
+      });
+    } catch (_err) {
+      setImportError(_err as Error);
+      return;
+    }
+
+    if (result.canceled) {
+      return;
+    }
+
+    const asset = result.assets[0];
+
+    // Shouldn't happen based on how the library works
+    if (!asset) return;
+
+    importProjectConfigMutation.mutate(convertFileUriToPosixPath(asset.uri), {
+      onSuccess: async () => {
+        await FileSystem.deleteAsync(asset.uri).catch((err: unknown) => {
+          console.log(err);
+        });
+      },
+      onError: async () => {
+        await FileSystem.deleteAsync(asset.uri).catch((err: unknown) => {
+          console.log(err);
+        });
+      },
+    });
+  }
 
   if (!data || isPending) {
     return <Loading />;
@@ -35,12 +102,16 @@ export const Config: NativeNavigationComponent<'Config'> = () => {
 
   return (
     <View style={styles.container}>
-      <Text>{formatMessage(m.projectName)}</Text>
-      <Text>{data.name}</Text>
+      {data.name && (
+        <>
+          <Text>{formatMessage(m.projectName)}</Text>
+          <Text style={{marginBottom: 20}}>{data.name}</Text>
+        </>
+      )}
       {data.configMetadata && (
         <>
           <Text>{formatMessage(m.name)}</Text>
-          <Text>
+          <Text style={{color: MEDIUM_GREY}}>
             {formatMessage(m.created, {
               date: formatDate(data.configMetadata.buildDate),
               time: formatHours(data.configMetadata.buildDate),
@@ -49,6 +120,27 @@ export const Config: NativeNavigationComponent<'Config'> = () => {
           <Text>{data.configMetadata.name}</Text>
         </>
       )}
+      {!importProjectConfigMutation.isPending ? (
+        <Button
+          style={{marginTop: 20}}
+          fullWidth
+          variant="outlined"
+          onPress={importConfigFile}>
+          <Text style={{color: COMAPEO_BLUE}}>
+            {formatMessage(m.importConfig)}
+          </Text>
+        </Button>
+      ) : (
+        <UIActivityIndicator style={{marginTop: 20, flex: 0}} />
+      )}
+      <ErrorBottomSheet
+        error={importProjectConfigMutation.error || importError}
+        clearError={() => {
+          importProjectConfigMutation.reset();
+          setImportError(null);
+        }}
+        tryAgain={importConfigFile}
+      />
     </View>
   );
 };
@@ -58,6 +150,8 @@ Config.navTitle = m.navTitle;
 const styles = StyleSheet.create({
   container: {
     padding: 20,
+    paddingTop: 40,
+    flex: 1,
   },
 });
 

--- a/src/frontend/screens/Settings/Config.tsx
+++ b/src/frontend/screens/Settings/Config.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import {defineMessages, useIntl} from 'react-intl';
+import {StyleSheet, View} from 'react-native';
+import {Text} from '../../sharedComponents/Text';
+import {useProjectSettings} from '../../hooks/server/projects';
+import {Loading} from '../../sharedComponents/Loading';
+import {NativeNavigationComponent} from '../../sharedTypes/navigation';
+
+const m = defineMessages({
+  navTitle: {
+    id: 'screens.Settings.Config.navTitle',
+    defaultMessage: 'Configuration',
+  },
+  name: {
+    id: 'screens.Settings.Config.name',
+    defaultMessage: 'Config Name:',
+  },
+  projectName: {
+    id: 'screens.Settings.Config.projectName',
+    defaultMessage: 'Project Name:',
+  },
+  created: {
+    id: 'screens.Settings.Config.created',
+    defaultMessage: 'Created {date} at {time}',
+  },
+});
+
+export const Config: NativeNavigationComponent<'Config'> = () => {
+  const {formatMessage} = useIntl();
+  const {data, isPending} = useProjectSettings();
+
+  if (!data || isPending) {
+    return <Loading />;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text>{formatMessage(m.projectName)}</Text>
+      <Text>{data.name}</Text>
+      {data.configMetadata && (
+        <>
+          <Text>{formatMessage(m.name)}</Text>
+          <Text>
+            {formatMessage(m.created, {
+              date: formatDate(data.configMetadata.buildDate),
+              time: formatHours(data.configMetadata.buildDate),
+            })}
+          </Text>
+          <Text>{data.configMetadata.name}</Text>
+        </>
+      )}
+    </View>
+  );
+};
+
+Config.navTitle = m.navTitle;
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+});
+
+function formatDate(rfc3339Date: string) {
+  const date = new Date(rfc3339Date);
+
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+
+  return `${day}/${month}/${year}`;
+}
+
+function formatHours(rfc3339Date: string) {
+  const date = new Date(rfc3339Date);
+  const hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  const ampm = hours >= 12 ? 'pm' : 'am';
+  const formattedHours = hours % 12 || 12;
+
+  return `${formattedHours}:${minutes} ${ampm}`;
+}

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -125,7 +125,7 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
 
   async function importConfigFile() {
     try {
-      const asset = await selectFile(['mapeoconfig', 'mapeosettings']);
+      const asset = await selectFile(['comapeocat']);
       if (!asset) return;
       setConfigFileResult({type: 'success', file: asset});
     } catch (err) {

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -21,6 +21,7 @@ import {ErrorBottomSheet} from '../../../../sharedComponents/ErrorBottomSheet';
 import {HookFormTextInput} from '../../../../sharedComponents/HookFormTextInput';
 import {Text} from '../../../../sharedComponents/Text';
 import {NativeNavigationComponent} from '../../../../sharedTypes/navigation';
+import {selectFile} from '../../../../lib/selectFile';
 
 const m = defineMessages({
   title: {
@@ -123,38 +124,16 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
   }
 
   async function importConfigFile() {
-    let result;
     try {
-      result = await DocumentPicker.getDocumentAsync({
-        copyToCacheDirectory: true,
-        multiple: false,
-      });
+      const asset = await selectFile(['mapeoconfig', 'mapeosettings']);
+      if (!asset) return;
+      setConfigFileResult({type: 'success', file: asset});
     } catch (err) {
       if (err instanceof Error) {
         setConfigFileResult({type: 'error', error: err});
       }
 
       return;
-    }
-
-    if (result.canceled) return;
-
-    const asset = result.assets[0];
-
-    // Shouldn't happen based on how the library works
-    if (!asset) return;
-
-    // Only allow importing files with the desired extension
-    if (asset.name.endsWith('.mapeosettings')) {
-      setConfigFileResult({type: 'success', file: asset});
-    } else {
-      setConfigFileResult({
-        type: 'error',
-        error: new Error(t(m.importConfigFileError)),
-      });
-      // No need to block UI on this
-      // no-op if something fails here. caches can eventually get cleared by the OS automatically.
-      FileSystem.deleteAsync(asset.uri).catch(noop);
     }
   }
 

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -1,5 +1,11 @@
+import * as React from 'react';
 import {ScrollView} from 'react-native';
-import {List, ListItem, ListItemText} from '../../../sharedComponents/List';
+import {
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from '../../../sharedComponents/List';
 import {FormattedMessage, defineMessages} from 'react-intl';
 import {NativeNavigationComponent} from '../../../sharedTypes/navigation';
 
@@ -15,6 +21,11 @@ const m = defineMessages({
   yourTeam: {
     id: 'Screens.Settings.ProjectSettings.yourTeam',
     defaultMessage: 'Your Team',
+  },
+  config: {
+    id: 'screens.Settings.config',
+    defaultMessage: 'Project Configuration',
+    description: 'Primary text for project config settings',
   },
 });
 
@@ -37,6 +48,14 @@ export const ProjectSettings: NativeNavigationComponent<'ProjectSettings'> = ({
             navigation.navigate('YourTeam');
           }}>
           <ListItemText primary={<FormattedMessage {...m.yourTeam} />} />
+        </ListItem>
+        <ListItem
+          onPress={() => {
+            navigation.navigate('Config');
+          }}
+          testID="settingsConfigButton">
+          <ListItemIcon iconName="assignment" />
+          <ListItemText primary={<FormattedMessage {...m.config} />} />
         </ListItem>
       </List>
     </ScrollView>

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -54,7 +54,10 @@ export const ProjectSettings: NativeNavigationComponent<'ProjectSettings'> = ({
             navigation.navigate('Config');
           }}
           testID="settingsConfigButton">
-          <ListItemIcon iconName="assignment" />
+          <ListItemIcon
+            style={{minWidth: 0, marginRight: 10}}
+            iconName="assignment"
+          />
           <ListItemText primary={<FormattedMessage {...m.config} />} />
         </ListItem>
       </List>

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -37,7 +37,7 @@ export type RootStackParamsList = {
   Home: NavigatorScreenParams<HomeTabsParamsList>;
   GpsModal: undefined;
   Settings: undefined;
-  ProjectConfig: undefined;
+  Config: undefined;
   AboutSettings: undefined;
   LanguageSettings: undefined;
   CoordinateFormat: undefined;


### PR DESCRIPTION
Exposes the config name and created at date to the user. 

Also allows for the user to upload a new config

<img width="291" alt="image" src="https://github.com/user-attachments/assets/fd707246-fb91-4508-8a32-a9d1796040f3">
