### PR TITLE
fix: only show connected devices that appeared during lifetime of device invite screen

### DIFF
--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -82,7 +82,7 @@ function InvitableDeviceList() {
         // TODO: Use `device.deviceType`
         const deviceType = 'mobile';
 
-        // TODO: Update DeviceCard component to better handle potentially undefined fields
+        // TODO: Update DeviceCard component to better handle potentially undefined fields, deviceType enum
         return (
           <DeviceCard
             key={deviceId}

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -54,7 +54,7 @@ export const SelectDevice: NativeNavigationComponent<'SelectDevice'> = () => {
 
 function InvitableDeviceList() {
   const navigation = useNavigationFromRoot();
-  const devices = usePeersConnectedDuringSession();
+  const devices = useInitiallyConnectedPeers();
   const projectMembersQuery = useProjectMembers();
 
   if (projectMembersQuery.status === 'pending') {
@@ -119,12 +119,10 @@ const styles = StyleSheet.create({
 /**
  * Applies specialized, context-specific behavior on top of `useLocalPeers()` in the following ways:
  *
- * - Resets to only connected peers when consuming component remounts
- * - Updates when either:
- *   1. A peer that hasn't been discovered during the session (i.e. lifetime of consuming component) appears
- *   2. A peer that has been discovered during the session has an updated state
+ * - State is bound to the lifetime of the consuming component i.e. gets re-initialized during remounts
+ * - Only connected peers are ever *added* to the state. However, subsequent updates to those peers (e.g. disconnecting) are still reflected in the state.
  */
-function usePeersConnectedDuringSession() {
+function useInitiallyConnectedPeers() {
   const peers = useLocalPeers();
   const [result, setResult] = React.useState<Array<(typeof peers)[number]>>(
     () => {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -139,11 +139,10 @@ function useInitiallyConnectedPeers() {
 
         if (included) {
           next.push(p.deviceId);
-          continue;
-        }
-
-        if (!included && p.status === 'connected') {
-          next.push(p.deviceId);
+        } else {
+          if (p.status === 'connected') {
+            next.push(p.deviceId);
+          }
         }
       }
 

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -119,14 +119,18 @@ const styles = StyleSheet.create({
 /**
  * Applies specialized, context-specific behavior on top of `useLocalPeers()` in the following ways:
  *
- * - Always initialized to be empty (i.e. state resets when remounted)
+ * - Resets to only connected peers when consuming component remounts
  * - Updates when either:
  *   1. A peer that hasn't been discovered during the session (i.e. lifetime of consuming component) appears
  *   2. A peer that has been discovered during the session has an updated state
  */
 function usePeersConnectedDuringSession() {
   const peers = useLocalPeers();
-  const [result, setResult] = React.useState<Array<(typeof peers)[number]>>([]);
+  const [result, setResult] = React.useState<Array<(typeof peers)[number]>>(
+    () => {
+      return peers.filter(p => p.status === 'connected');
+    },
+  );
 
   React.useEffect(() => {
     setResult(prev => {

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -137,11 +137,11 @@ function useInitiallyConnectedPeers() {
       for (const p of peers) {
         const existing = prev.find(({deviceId}) => deviceId === p.deviceId);
 
-        // Use the most recent information for any peer discovered during lifetime of session
+        // Use the most recent information for included peers
         if (existing) {
           next.push(p);
         }
-        // only add newly discovered peers if they're connected
+        // only initially include peer if they're connected
         else if (!existing && p.status === 'connected') {
           next.push(p);
         }

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -47,12 +47,12 @@ export const SelectDevice: NativeNavigationComponent<'SelectDevice'> = () => {
       {/* Divider */}
       <View style={{marginTop: 20}} />
 
-      <InvitableDeviceList />
+      <InvitableDevicesList />
     </ScrollView>
   );
 };
 
-function InvitableDeviceList() {
+function InvitableDevicesList() {
   const navigation = useNavigationFromRoot();
   const devices = useInitiallyConnectedPeers();
   const projectMembersQuery = useProjectMembers();


### PR DESCRIPTION
Fixes #589 

Avoids updating `useLocalPeers()` because I'd rather that remains as close to the server state as possible, given that it's global state and can eventually be used in other areas of the app (with potentially different UX needs). The UX needs from the issue seem specific to this screen, so this opted for a wrapper hook that provides a more opinionated subset of the global state.

Testing steps:

1. Set up 2 devices, A and B. Create a new project for A.
2. On A, go through device invite flow. Stop at device list screen. If B has the app opened, it should be listed on the screen. If not, open the app on B and wait for it to show up in A.
3. Close the app on B. On A, you should see that B is still listed but marked as disconnected.
4. On A, navigate to the previous screen (or any other screen, really) and then navigate back to this device list screen. You should see that B is no longer listed. If you have other devices that are connected, those should still be listed.
5. If you open the app on B again, it should be reappear in the list on A.
---

https://github.com/user-attachments/assets/b43bfeaf-d9fb-4dbb-bed9-6f6cea7ac76f
