### PR TITLE
chore: use more lenient type for `createProject`

### DIFF
--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -43,7 +43,7 @@ export function useCreateProject() {
 
   return useMutation({
     mutationKey: [CREATE_PROJECT_KEY],
-    mutationFn: (opts?: {name?: string; configPath?: string}) => {
+    mutationFn: (opts?: Parameters<typeof api.createProject>[0]) => {
       if (opts) {
         return api.createProject(opts);
       } else {


### PR DESCRIPTION
This is a types-only change.

Soon, we plan to add new properties to `api.createProject`. We'll need to update this function parameter to support it.

Rather than change this function signature every time, let's just make it match `api.createProject` so we don't have to keep updating it every time.