### PR TITLE
fix: add date to project

### DIFF
--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/index.tsx
@@ -152,6 +152,7 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
           style={{marginTop: 10}}
           name={coordinator.name || ''}
           deviceId={coordinator.deviceId}
+          joinedAt={coordinator.joinedAt}
           deviceType="mobile"
           thisDevice={deviceInfo.data?.deviceId === coordinator.deviceId}
         />
@@ -172,6 +173,7 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
           style={{marginTop: 10}}
           name={participant.name || ''}
           deviceId={participant.deviceId}
+          joinedAt={participant.joinedAt}
           deviceType="mobile"
           // This is a weak check. We should be using deviceIds, but those are not exposed
           thisDevice={

--- a/src/frontend/sharedComponents/DeviceCard.tsx
+++ b/src/frontend/sharedComponents/DeviceCard.tsx
@@ -16,7 +16,7 @@ type DeviceCardProps = {
   deviceConnectionStatus?: DeviceConnectionStatus;
   thisDevice?: boolean;
   deviceId?: string;
-  dateAdded?: Date;
+  joinedAt?: string;
   style?: ViewStyleProp;
   onPress?: () => void;
 };
@@ -27,7 +27,7 @@ export const DeviceCard = ({
   style,
   thisDevice,
   deviceId,
-  dateAdded,
+  joinedAt,
   onPress,
   deviceConnectionStatus,
 }: DeviceCardProps) => {
@@ -55,6 +55,7 @@ export const DeviceCard = ({
         thisDevice={thisDevice}
         deviceType={deviceType}
         deviceId={deviceId}
+        joinedAt={joinedAt}
         iconSize={75}
       />
     </TouchableOpacity>

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -7,7 +7,7 @@ import type {
   DeviceConnectionStatus,
   DeviceType,
 } from '../sharedTypes';
-import {defineMessages, useIntl} from 'react-intl';
+import {defineMessages, useIntl, FormattedDate} from 'react-intl';
 import {Text} from './Text';
 import {MEDIUM_GREY} from '../lib/styles';
 import {ExhaustivenessError} from '../lib/ExhaustivenessError';
@@ -68,8 +68,20 @@ export const DeviceNameWithIcon = ({
       ) : (
         <DeviceDesktop width={iconSize || 35} height={iconSize || 35} />
       )}
-      <View style={{marginLeft: 10}}>
-        <Text style={{fontWeight: 'bold'}}>{name}</Text>
+      <View style={{paddingLeft: 10}}>
+        <View style={styles.nameDateRow}>
+          <Text style={{fontWeight: 'bold'}}>{name}</Text>
+          {joinedAt && (
+            <Text>
+              <FormattedDate
+                value={new Date(joinedAt)}
+                year="numeric"
+                month="short"
+                day="2-digit"
+              />
+            </Text>
+          )}
+        </View>
         {deviceId && (
           <Text style={{color: MEDIUM_GREY}} numberOfLines={1}>
             {`${deviceId.slice(0, 12)}...`}
@@ -97,6 +109,11 @@ const styles = StyleSheet.create({
   flexRow: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  nameDateRow: {
+    width: '80%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
   deviceStatusText: {
     flex: 1,

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -28,6 +28,7 @@ type DeviceNameWithIconProps = {
   deviceType: DeviceType;
   name: string;
   deviceId?: string;
+  joinedAt?: string;
   thisDevice?: boolean;
   iconSize?: number;
   style?: ViewStyleProp;
@@ -39,11 +40,13 @@ export const DeviceNameWithIcon = ({
   name,
   deviceConnectionStatus,
   deviceId,
+  joinedAt,
   thisDevice,
   iconSize,
   style,
 }: DeviceNameWithIconProps) => {
   const {formatMessage} = useIntl();
+  console.log('joined at ', joinedAt);
 
   let isDisconnected: boolean;
   switch (deviceConnectionStatus) {

--- a/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
+++ b/src/frontend/sharedComponents/DeviceNameWithIcon.tsx
@@ -46,7 +46,6 @@ export const DeviceNameWithIcon = ({
   style,
 }: DeviceNameWithIconProps) => {
   const {formatMessage} = useIntl();
-  console.log('joined at ', joinedAt);
 
   let isDisconnected: boolean;
   switch (deviceConnectionStatus) {
@@ -70,9 +69,9 @@ export const DeviceNameWithIcon = ({
       )}
       <View style={{paddingLeft: 10}}>
         <View style={styles.nameDateRow}>
-          <Text style={{fontWeight: 'bold'}}>{name}</Text>
+          <Text style={styles.nameText}>{name}</Text>
           {joinedAt && (
-            <Text>
+            <Text style={styles.dateJoinedText}>
               <FormattedDate
                 value={new Date(joinedAt)}
                 year="numeric"
@@ -114,6 +113,15 @@ const styles = StyleSheet.create({
     width: '80%',
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  nameText: {
+    fontWeight: 'bold',
+    flex: 1,
+  },
+  dateJoinedText: {
+    color: MEDIUM_GREY,
+    textAlign: 'right',
+    paddingLeft: 10,
   },
   deviceStatusText: {
     flex: 1,


### PR DESCRIPTION
closes #588 

### Description
- Since we now have access through the member API to a joinedAt property, this PR uses it in the Device Card in the Your Team section of Project Information to indicate when someone joined a project
- Uses react-intl to make sure it is formatted correctly in various languages
- I found the UX [here](https://www.figma.com/proto/uzynHXR0xgJu19lsCoJyXN/%F0%9F%90%9A-Shell-App?node-id=1075-5095&node-type=FRAME&t=EQD08hgLH4dKDmM4-0&scaling=min-zoom&content-scaling=fixed&page-id=1061%3A3746&starting-point-node-id=1070%3A4687)
- The styles will need to be adjusted when leave project is added (I assume it hasn't been added yet)
- I had trouble styling for various font and display sizes and longer device names, so that is why the date is not right aligned for all sizes

### Screenshots
---
large text normal name length
---

<image src="https://github.com/user-attachments/assets/5977ac91-c0eb-4d45-9cb5-f32ba908c62b" width="250" />

---
default text size with normal name length
---

<image src="https://github.com/user-attachments/assets/8aebb0fe-00e4-4963-91b1-3234e4f079d8" width="250" />

---
really long name with default text size
---

<image src="https://github.com/user-attachments/assets/3194c0a6-eb82-4f8a-9321-c58354b5dcbe" width="250" />

---
really long name with larger text size
---

<image src="https://github.com/user-attachments/assets/9488e4a6-2315-4c9d-8542-a74d7d2b832a" width="250" />
