### PR TITLE
chore: update postion from expo

### DIFF
--- a/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
+++ b/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
@@ -43,17 +43,9 @@ export function useMostAccurateLocationForObservation() {
         },
         debounceLocation()(location => {
           if (ignore) return;
-          const newCoord = !location
-            ? undefined
-            : Object.entries(location.coords).map(
-                ([key, val]) => [key, val === null ? undefined : val] as const,
-              );
+
           updateObservationPosition({
-            position: {
-              mocked: false,
-              coords: !newCoord ? undefined : Object.fromEntries(newCoord),
-              timestamp: location?.timestamp.toString(),
-            },
+            position: location,
             manualLocation: false,
           });
         }),


### PR DESCRIPTION
previously when creating an observation, the `mocked` property was manually set. This property now comes from the expo-location object (ensuring data integrity as the value now comes from the phone as opposed to manually being set). I also simplified how the position object turns "null" into "undefined" and allowed the function to do that conversion.