### PR TITLE
fix: allow metrics env variables to be inlined

### DIFF
--- a/src/frontend/metrics/getMetricsRequestInfo.ts
+++ b/src/frontend/metrics/getMetricsRequestInfo.ts
@@ -1,11 +1,5 @@
 import {assert} from '../lib/assert';
 
-const getEnv = (name: string): string => {
-  const result = process.env[name];
-  assert(result, `${name} environment variable should be set`);
-  return result;
-};
-
 /**
  * Get the info to send a metrics request.
  *
@@ -14,8 +8,23 @@ const getEnv = (name: string): string => {
  *
  * @see {sendMetricsData}
  */
-export const getMetricsRequestInfo = () => ({
-  isDevelopment: __DEV__,
-  metricsUrl: getEnv('EXPO_PUBLIC_METRICS_URL'),
-  metricsApiKey: getEnv('EXPO_PUBLIC_METRICS_API_KEY'),
-});
+export function getMetricsRequestInfo(): {
+  isDevelopment: boolean;
+  metricsUrl: string;
+  metricsApiKey: string;
+} {
+  const isDevelopment = __DEV__;
+  const metricsUrl = process.env.EXPO_PUBLIC_METRICS_URL;
+  const metricsApiKey = process.env.EXPO_PUBLIC_METRICS_API_KEY;
+
+  assert(
+    metricsUrl,
+    'EXPO_PUBLICS_METRICS_URL environment variable should be set',
+  );
+  assert(
+    metricsApiKey,
+    'EXPO_PUBLICS_METRICS_API_KEY environment variable should be set',
+  );
+
+  return {isDevelopment, metricsUrl, metricsApiKey};
+}


### PR DESCRIPTION
To quote [Expo's docs][0]:

> **Every environment variable must be statically referenced as a property of `process.env` using JavaScript's dot notation for it to be inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.

Our metrics environment variables weren't doing this, so they couldn't be inlined.

Closes #640.

[0]: https://docs.expo.dev/guides/environment-variables/#how-to-read-from-environment-variables