### PR TITLE
fix: use proper timestamp for location metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "geojson-geometries-lookup": "^0.5.0",
         "lodash.isequal": "^4.5.0",
         "luxon": "^3.4.4",
+        "map-obj": "^5.0.2",
         "nanoid": "^5.0.1",
         "nodejs-mobile-react-native": "^18.17.8",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "geojson-geometries-lookup": "^0.5.0",
     "lodash.isequal": "^4.5.0",
     "luxon": "^3.4.4",
+    "map-obj": "^5.0.2",
     "nanoid": "^5.0.1",
     "nodejs-mobile-react-native": "^18.17.8",
     "react": "18.2.0",


### PR DESCRIPTION
We should be using an ISO timestamp instead of a string number here.

Because `position` can be undefined and we were checking that earlier, I moved things around a tiny bit to only check that once.

Closes #644.