### PR TITLE
fix: leave current project when joining another project

### DIFF
--- a/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
+++ b/src/frontend/sharedComponents/LeaveProjectModalContent/LeaveProject.tsx
@@ -102,7 +102,11 @@ export const LeaveProject = ({
 
   return (
     <>
-      {accept.status === 'pending' || leaveProject.status === 'pending' ? (
+      {accept.status === 'pending' ||
+      leaveProject.status === 'pending' ||
+      // Prevents a flicker back to non-pending UI while the sheet containing this component
+      // is being closed after both succeed
+      (accept.status === 'success' && leaveProject.status === 'success') ? (
         <LeavingProjectProgress projectName={projectName} />
       ) : (
         <BottomSheetModalContent


### PR DESCRIPTION
Fixes #525 

In case someone runs into this and is initially as confused as I was: after leaving a project, the returned data from `api.listProjects()` still includes the project - it just won't have much information tied to it (except its project id). Related to  https://github.com/digidem/mapeo-core-next/issues/433