### PR TITLE
fix: properly inherit style for translated bold text

### DIFF
--- a/src/frontend/contexts/IntlContext.tsx
+++ b/src/frontend/contexts/IntlContext.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import {IntlProvider as ReactIntlProvider, CustomFormats} from 'react-intl';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
 
 import messages from '../../../translations/messages.json';
 import {usePersistedLocale} from '../hooks/persistedState/usePersistedLocale';
 import {TranslatedLocale} from '../lib/intl';
-import {Text} from '../sharedComponents/Text';
 
 export const formats: CustomFormats = {
   date: {


### PR DESCRIPTION
Extracted from #631 

Uses the built-in `Text` component from React Native for wrapping rich-formatted translation strings instead of our custom component. This prevents issues related to style specificity due to our custom component defining its own opinionated styling, when in practice we just want to make sure that these formatted translations are only applying the minimum styling (in this case, bold). The base `Text` component supports nesting and applies styling based on specificity related to nesting. For example, if we have a translation string like `'Hello <bold>World</bold>'` and use it as follows:

```tsx
<CustomText>{t(...)}</CustomText>
```

it will output:

```tsx
<CustomText>Hello <Text style={{fontWeight: 'bold'}}>World</Text></CustomText>
```

The styles from `CustomText` will be applied to `World`, but then any styles specified by the nested `Text` (in this case, `fontWeight`) will take precedence and be applied.

To test, try changing the style of the text containing the formatted translation. The style of the formatted translation should match what's specified, with the exception of it being bold.

Only example as of now is in the passcode settings: 

https://github.com/digidem/comapeo-mobile/blob/c5ee20c1a0af69c8c35f67359676038e4f66c704/src/frontend/screens/AppPasscode/PasscodeIntro.tsx#L60