### PR TITLE
fix: edit observation category clickable

### DIFF
--- a/src/frontend/sharedComponents/Editor/PresetView.tsx
+++ b/src/frontend/sharedComponents/Editor/PresetView.tsx
@@ -27,7 +27,7 @@ export const PresetView = ({
   return (
     <TouchableOpacity
       disabled={presetDisabled}
-      onPress={presetDisabled ? onPressPreset : undefined}
+      onPress={presetDisabled ? undefined : onPressPreset}
       style={styles.preset}>
       <View style={{flexDirection: 'row', alignItems: 'center'}}>
         {PresetIcon}


### PR DESCRIPTION
closes #657 
Fixes ternary on editing an observation for changing preset