### PR TITLE
chore: use GitHub App token to create PR in workflow

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -68,10 +68,16 @@ jobs:
             echo "DEPLOY_BRANCH_EXISTS=false" >> $GITHUB_ENV
           fi
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_BOT_APP_ID }}
+          private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
+
       - name: Create Pull Request to deploy
         if: env.DEPLOY_BRANCH_EXISTS == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           new_version=${{ env.VERSION }}
           branch_name=${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Fixes #662

This is a non-urgent fix, because the workaround in #662 works when needed.

This switches the github token used to create a pull request for a release candidate to use a token from a GitHub App that I have created for Awana Digital called "Awana PR Bot".

The reason for this change is so that PR checks run when the PR is opened by the [`create-release-candidate.yml`](.github/workflows/create-release-candidate.yml) workflow. Without this change, workflows are not triggered by the PR being opened.


I have added the secret `PR_BOT_PRIVATE_KEY` as an organization secret, and I have added `PR_BOT_APP_ID` as an organization variable.

This fix is not tested. We could try a dummy run and then delete the PR, although running this action also kicks off a new EAS build.
