### PR TITLE
fix: update message content when sharing observation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -784,10 +784,6 @@
     "description": "Title of dialog to share an observation with media",
     "message": "Sharing image"
   },
-  "screens.Observation.shareMessageFieldNoAnswer": {
-    "description": "Placeholder text for fields on an observation which are not answered",
-    "message": "No answer"
-  },
   "screens.Observation.shareMessageFooter": {
     "message": "Sent from CoMapeo"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -784,9 +784,15 @@
     "description": "Title of dialog to share an observation with media",
     "message": "Sharing image"
   },
-  "screens.Observation.shareMessage": {
-    "description": "Message that will be shared along with image",
-    "message": "CoMapeo Alert — _*{category_name}*_ {date, date, full} {time, time, long} {coordinates}"
+  "screens.Observation.shareMessageFieldNoAnswer": {
+    "description": "Placeholder text for fields on an observation which are not answered",
+    "message": "No answer"
+  },
+  "screens.Observation.shareMessageFooter": {
+    "message": "Sent from CoMapeo"
+  },
+  "screens.Observation.shareMessageTitle": {
+    "message": "CoMapeo Alert"
   },
   "screens.Observation.shareTextTitle": {
     "description": "Title of dialog to share an observation without media",

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -3,6 +3,8 @@ import {fromLatLon} from 'utm';
 import {Preset, Observation, Track} from '@mapeo/schema';
 import {LocationObject, LocationProviderStatus} from 'expo-location';
 import {FeatureCollection, LineString} from 'geojson';
+
+import {type CoordinateFormat} from '../sharedTypes';
 import {LocationHistoryPoint} from '../sharedTypes/location';
 
 // import type {
@@ -169,7 +171,7 @@ export function formatCoords({
 }: {
   lon: number;
   lat: number;
-  format?: 'utm' | 'dd' | 'dms';
+  format?: CoordinateFormat;
 }): string {
   switch (format) {
     case 'dd':

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -69,12 +69,6 @@ const m = defineMessages({
     id: 'screens.Observation.shareMessageFooter',
     defaultMessage: 'Sent from CoMapeo',
   },
-  shareMessageFieldNoAnswer: {
-    id: 'screens.Observation.shareMessageFieldNoAnswer',
-    defaultMessage: 'No answer',
-    description:
-      'Placeholder text for fields on an observation which are not answered',
-  },
   fallbackCategoryName: {
     id: 'screens.Observation.fallbackCategoryName',
     defaultMessage: 'Observation',
@@ -160,12 +154,11 @@ export const ButtonFields = ({
           continue;
         }
 
-        const displayedValue =
-          (Array.isArray(value) ? value : [value])
-            .map(v => {
-              return getValueLabel(v, field).trim();
-            })
-            .join(', ') || t(m.shareMessageFieldNoAnswer);
+        const displayedValue = (Array.isArray(value) ? value : [value])
+          .map(v => {
+            return getValueLabel(v, field).trim();
+          })
+          .join(', ');
 
         completedFields.push({label: field.label, value: displayedValue});
       }

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -178,7 +178,7 @@ export const ButtonFields = ({
         message: createObservationShareMessage({
           categoryName: preset ? preset.name : t(m.fallbackCategoryName),
           coordinateFormat: format,
-          fields: completedFields,
+          completedFields,
           footerText: t(m.shareMessageFooter),
           observation,
           timestamp: formatDate(observation.createdAt, {format: 'long'}),
@@ -256,7 +256,7 @@ const styles = StyleSheet.create({
 function createObservationShareMessage({
   categoryName,
   coordinateFormat,
-  fields,
+  completedFields,
   footerText,
   observation,
   timestamp,
@@ -264,7 +264,7 @@ function createObservationShareMessage({
 }: {
   categoryName?: string;
   coordinateFormat: CoordinateFormat;
-  fields: Array<{label: string; value: string}>;
+  completedFields: Array<{label: string; value: string}>;
   footerText: string;
   observation: Observation;
   timestamp: string;
@@ -287,8 +287,8 @@ function createObservationShareMessage({
       : '';
 
   const displayedFields =
-    fields.length > 0
-      ? fields
+    completedFields.length > 0
+      ? completedFields
           .map(({label, value}) => {
             return `*${label}*\n_${value}_`;
           })

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import {Alert, StyleSheet, TouchableOpacity, View} from 'react-native';
+import {Field, Observation} from '@mapeo/schema';
 import {DARK_GREY} from '../../lib/styles';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import {defineMessages, useIntl} from 'react-intl';
@@ -14,6 +16,8 @@ import {convertUrlToBase64} from '../../utils/base64.ts';
 import {useState} from 'react';
 import {usePersistedSettings} from '../../hooks/persistedState/usePersistedSettings.ts';
 import * as Sentry from '@sentry/react-native';
+import {CoordinateFormat} from '../../sharedTypes/index.ts';
+import {getValueLabel} from '../../sharedComponents/FormattedData.tsx';
 
 const m = defineMessages({
   delete: {
@@ -57,13 +61,19 @@ const m = defineMessages({
     defaultMessage: 'Sharing image',
     description: 'Title of dialog to share an observation with media',
   },
-  shareMessage: {
-    id: 'screens.Observation.shareMessage',
-    defaultMessage:
-      'CoMapeo Alert — _*{category_name}*_\n' +
-      '{date, date, full} {time, time, long}\n' +
-      '{coordinates}',
-    description: 'Message that will be shared along with image',
+  shareMessageTitle: {
+    id: 'screens.Observation.shareMessageTitle',
+    defaultMessage: 'CoMapeo Alert',
+  },
+  shareMessageFooter: {
+    id: 'screens.Observation.shareMessageFooter',
+    defaultMessage: 'Sent from CoMapeo',
+  },
+  shareMessageFieldNoAnswer: {
+    id: 'screens.Observation.shareMessageFieldNoAnswer',
+    defaultMessage: 'No answer',
+    description:
+      'Placeholder text for fields on an observation which are not answered',
   },
   fallbackCategoryName: {
     id: 'screens.Observation.fallbackCategoryName',
@@ -78,9 +88,11 @@ const m = defineMessages({
 });
 
 export const ButtonFields = ({
+  fields,
   isMine,
   observationId,
 }: {
+  fields: Array<Field>;
   isMine: boolean;
   observationId: string;
 }) => {
@@ -112,7 +124,7 @@ export const ButtonFields = ({
   }
 
   async function handlePressShare() {
-    const {lon, lat, attachments} = observation;
+    const {attachments} = observation;
     setShareButtonLoading(true);
     const getValidUrls = (queries: typeof attachmentUrlQueries) => {
       const urls = queries
@@ -139,19 +151,38 @@ export const ButtonFields = ({
         urls.map(url => convertUrlToBase64(url)),
       );
 
+      const completedFields: Array<{label: string; value: string}> = [];
+
+      for (const field of fields) {
+        const value = observation.tags[field.tagKey];
+
+        if (value === undefined || value === null || value === '') {
+          continue;
+        }
+
+        const displayedValue =
+          (Array.isArray(value) ? value : [value])
+            .map(v => {
+              return getValueLabel(v, field).trim();
+            })
+            .join(', ') || t(m.shareMessageFieldNoAnswer);
+
+        completedFields.push({label: field.label, value: displayedValue});
+      }
+
       await Share.open({
         subject: `${t(m.comapeoAlert)} — _*${preset ? preset.name : t(m.fallbackCategoryName)}*_ — ${formatDate(observation.createdAt, {format: 'long'})}`,
         title:
           base64Urls.length > 0 ? t(m.shareMediaTitle) : t(m.shareTextTitle),
         urls: base64Urls,
-        message: t(m.shareMessage, {
-          category_name: preset?.name || t(m.fallbackCategoryName),
-          date: Date.now(),
-          time: Date.now(),
-          coordinates:
-            typeof lon === 'number' && typeof lat === 'number'
-              ? formatCoords({lon, lat, format})
-              : '',
+        message: createObservationShareMessage({
+          categoryName: preset ? preset.name : t(m.fallbackCategoryName),
+          coordinateFormat: format,
+          fields: completedFields,
+          footerText: t(m.shareMessageFooter),
+          observation,
+          timestamp: formatDate(observation.createdAt, {format: 'long'}),
+          titleText: t(m.shareMessageTitle),
         }),
       });
     } catch (err) {
@@ -221,3 +252,59 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
   },
 });
+
+function createObservationShareMessage({
+  categoryName,
+  coordinateFormat,
+  fields,
+  footerText,
+  observation,
+  timestamp,
+  titleText,
+}: {
+  categoryName?: string;
+  coordinateFormat: CoordinateFormat;
+  fields: Array<{label: string; value: string}>;
+  footerText: string;
+  observation: Observation;
+  timestamp: string;
+  titleText: string;
+}): string {
+  const header = titleText + (categoryName ? ` — _*${categoryName}*_` : '');
+
+  const coordinates =
+    observation.lat !== undefined && observation.lon !== undefined
+      ? formatCoords({
+          lon: observation.lon,
+          lat: observation.lat,
+          format: coordinateFormat,
+        })
+      : '';
+
+  const notes = `${observation.tags.notes}`;
+
+  const displayedFields =
+    fields.length > 0
+      ? fields
+          .map(({label, value}) => {
+            return `*${label}*\n_${value}_`;
+          })
+          .join('\n\n')
+      : '';
+
+  const footer = `— ${footerText} —`;
+
+  return (
+    header +
+    '\n' +
+    timestamp +
+    '\n' +
+    coordinates +
+    '\n\n' +
+    notes +
+    '\n\n' +
+    displayedFields +
+    '\n\n' +
+    footer
+  );
+}

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -281,7 +281,10 @@ function createObservationShareMessage({
         })
       : '';
 
-  const notes = `${observation.tags.notes}`;
+  const notes =
+    observation.tags.notes !== undefined && observation.tags.notes !== null
+      ? `${observation.tags.notes}`
+      : '';
 
   const displayedFields =
     fields.length > 0
@@ -294,17 +297,14 @@ function createObservationShareMessage({
 
   const footer = `— ${footerText} —`;
 
-  return (
-    header +
-    '\n' +
-    timestamp +
-    '\n' +
-    coordinates +
-    '\n\n' +
-    notes +
-    '\n\n' +
-    displayedFields +
-    '\n\n' +
-    footer
-  );
+  // No empty line between each item
+  const sectionTop = [header, timestamp, coordinates]
+    .filter(v => !!v)
+    .join('\n');
+
+  // One empty line between each item
+  const sectionMiddle = [notes, displayedFields].filter(v => !!v).join('\n\n');
+
+  // One empty line between each section
+  return [sectionTop, sectionMiddle, footer].filter(s => !!s).join('\n\n');
 }

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -116,7 +116,11 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
         {isDeviceInfoPending || isDeviceIdPending ? (
           <UIActivityIndicator size={20} />
         ) : (
-          <ButtonFields isMine={isMine} observationId={observationId} />
+          <ButtonFields
+            isMine={isMine}
+            observationId={observationId}
+            fields={fields}
+          />
         )}
       </>
     </ScrollView>

--- a/src/frontend/sharedComponents/FormattedData.tsx
+++ b/src/frontend/sharedComponents/FormattedData.tsx
@@ -146,7 +146,7 @@ export const FormattedPresetName = ({preset}: {preset?: Preset}) => {
 
 // TODO: Better hangling of boolean and null values (we don't create these
 // anywhere yet)
-function getValueLabel(
+export function getValueLabel(
   value: null | boolean | number | string,
   field: Field,
 ): string {


### PR DESCRIPTION
Fixes #516 

Haven't extensively tested this on various kinds of categories (yet) but tried my best to port over what Mapeo Mobile does in terms of the final result

---

<img width="200" alt="image" src="https://github.com/user-attachments/assets/a2255c43-0253-4094-ac73-e13f347c38bd">

<br/>

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8d285fb9-6f20-4f9a-9dcc-04dea5b3294f">

<br/>

<img width="200" alt="image" src="https://github.com/user-attachments/assets/2ccd4302-5fa2-4e62-9224-f6f1241955c5">