### PR TITLE
fix: populate subject field when sharing observation via email

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -765,6 +765,9 @@
     "description": "Button to cancel delete of observation",
     "message": "Cancel"
   },
+  "screens.Observation.comapeoAlert": {
+    "message": "CoMapeo Alert"
+  },
   "screens.Observation.confirm": {
     "description": "Button to confirm delete of observation",
     "message": "Yes, delete"

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -71,6 +71,10 @@ const m = defineMessages({
     description:
       'Fallback name used when category name cannot be determined for observation',
   },
+  comapeoAlert: {
+    id: 'screens.Observation.comapeoAlert',
+    defaultMessage: 'CoMapeo Alert',
+  },
 });
 
 export const ButtonFields = ({
@@ -80,7 +84,7 @@ export const ButtonFields = ({
   isMine: boolean;
   observationId: string;
 }) => {
-  const {formatMessage: t} = useIntl();
+  const {formatMessage: t, formatDate} = useIntl();
   const navigation = useNavigationFromRoot();
   const deleteObservationMutation = useDeleteObservation();
   const {observation, preset} = useObservationWithPreset(observationId);
@@ -136,6 +140,7 @@ export const ButtonFields = ({
       );
 
       await Share.open({
+        subject: `${t(m.comapeoAlert)} — _*${preset ? preset.name : t(m.fallbackCategoryName)}*_ — ${formatDate(observation.createdAt, {format: 'long'})}`,
         title:
           base64Urls.length > 0 ? t(m.shareMediaTitle) : t(m.shareTextTitle),
         urls: base64Urls,


### PR DESCRIPTION
Closes #517 

Note that despite the issue mentioning fixing the email body text, this PR does not address that specifically. That issue is being addressed via #676 

---

<img width="200" alt="image" src="https://github.com/user-attachments/assets/0eeada41-94ed-425a-aca2-2f8de77156b0">
