### PR TITLE
fix: handle category-related changes after importing a config more elegantly

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -773,6 +773,10 @@
     "description": "Title of dialog asking confirmation to delete an observation",
     "message": "Delete observation?"
   },
+  "screens.Observation.fallbackCategoryName": {
+    "description": "Fallback name used when category name cannot be determined for observation",
+    "message": "Observation"
+  },
   "screens.Observation.shareMediaTitle": {
     "description": "Title of dialog to share an observation with media",
     "message": "Sharing image"

--- a/src/frontend/hooks/server/fields.ts
+++ b/src/frontend/hooks/server/fields.ts
@@ -1,11 +1,13 @@
 import {useQuery} from '@tanstack/react-query';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
+export const FIELDS_KEY = 'fields';
+
 export const useFieldsQuery = () => {
   const {projectId, projectApi} = useActiveProject();
 
   return useQuery({
-    queryKey: ['fields', projectId],
+    queryKey: [FIELDS_KEY, projectId],
     queryFn: async () => {
       return projectApi.field.getMany();
     },

--- a/src/frontend/hooks/server/icons.ts
+++ b/src/frontend/hooks/server/icons.ts
@@ -1,0 +1,20 @@
+import {useQuery} from '@tanstack/react-query';
+import {IconSize} from '../../sharedTypes';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
+
+export const ICONS_KEY = 'icons';
+
+export function useIconUrl(iconId: string, size: IconSize) {
+  const {projectId, projectApi} = useActiveProject();
+
+  return useQuery({
+    queryKey: [ICONS_KEY, projectId, iconId, size],
+    queryFn: async () => {
+      return projectApi.$icons.getIconUrl(iconId, {
+        mimeType: 'image/png',
+        size,
+        pixelDensity: 3,
+      });
+    },
+  });
+}

--- a/src/frontend/hooks/server/icons.ts
+++ b/src/frontend/hooks/server/icons.ts
@@ -16,9 +16,9 @@ export function useIconUrl(iconId: string, size: IconSize) {
         pixelDensity: 3,
       });
     },
-    // already defaults to 3 if not specified
-    // but being explicit about needing a non-zero retry value
-    // due to https://github.com/digidem/comapeo-core/issues/821#issuecomment-2344231495
-    retry: 3,
+    // Defaults to 3 if not specified but due to an edge case when pausing and resuming the app
+    // (see https://github.com/digidem/comapeo-core/issues/821#issuecomment-2344231495),
+    // we reduce the retry count for the benefit of more immediate UI feedback in that scenario
+    retry: 2,
   });
 }

--- a/src/frontend/hooks/server/icons.ts
+++ b/src/frontend/hooks/server/icons.ts
@@ -16,5 +16,9 @@ export function useIconUrl(iconId: string, size: IconSize) {
         pixelDensity: 3,
       });
     },
+    // already defaults to 3 if not specified
+    // but being explicit about needing a non-zero retry value
+    // due to https://github.com/digidem/comapeo-core/issues/821#issuecomment-2344231495
+    retry: 3,
   });
 }

--- a/src/frontend/hooks/server/presets.ts
+++ b/src/frontend/hooks/server/presets.ts
@@ -2,11 +2,8 @@ import {
   useSuspenseQuery,
   useMutation,
   useQueryClient,
-  useQuery,
-  keepPreviousData,
 } from '@tanstack/react-query';
 import {PresetValue} from '@mapeo/schema';
-import {IconSize} from '../../sharedTypes';
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
@@ -34,28 +31,5 @@ export function usePresetsMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: [PRESETS_KEY]});
     },
-  });
-}
-
-export function useGetPresetIcon(docId: string | undefined, size: IconSize) {
-  const {projectId, projectApi} = useActiveProject();
-
-  return useQuery<string, Error>({
-    queryKey: ['presetIconFromDocId', projectId, docId, size],
-    enabled: !!docId,
-    queryFn: async () => {
-      if (!docId) {
-        throw new Error('Preset icon reference not found');
-      }
-      return await projectApi.$icons.getIconUrl(docId, {
-        mimeType: 'image/png',
-        size: size,
-        pixelDensity: 3,
-      });
-    },
-    retry: 2,
-    retryDelay: 2000,
-    staleTime: 60000,
-    placeholderData: keepPreviousData,
   });
 }

--- a/src/frontend/hooks/useObservationWithPreset.ts
+++ b/src/frontend/hooks/useObservationWithPreset.ts
@@ -7,13 +7,5 @@ export const useObservationWithPreset = (observationId: string) => {
   const {data: presets} = usePresetsQuery();
   const preset = matchPreset(observation.tags, presets);
 
-  if (!observation) {
-    throw new Error('Observation does not exist');
-  }
-
-  if (!preset) {
-    throw new Error('Preset does not exist');
-  }
-
   return {observation, preset};
 };

--- a/src/frontend/hooks/useSelectFileAndImportConfig.ts
+++ b/src/frontend/hooks/useSelectFileAndImportConfig.ts
@@ -3,6 +3,8 @@ import {selectFile} from '../lib/selectFile';
 import * as FileSystem from 'expo-file-system';
 import {PROJECT_SETTINGS_KEY, useImportProjectConfig} from './server/projects';
 import {convertFileUriToPosixPath} from '../lib/file-system';
+import {FIELDS_KEY} from './server/fields';
+import {ICONS_KEY} from './server/icons';
 import {PRESETS_KEY} from './server/presets';
 
 export function useSelectFileAndImportConfig() {
@@ -26,6 +28,8 @@ export function useSelectFileAndImportConfig() {
     },
     onSuccess: () => {
       return Promise.all([
+        queryClient.invalidateQueries({queryKey: [FIELDS_KEY]}),
+        queryClient.invalidateQueries({queryKey: [ICONS_KEY]}),
         queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]}),
         queryClient.invalidateQueries({queryKey: [PRESETS_KEY]}),
       ]);

--- a/src/frontend/hooks/useSelectFileAndImportConfig.ts
+++ b/src/frontend/hooks/useSelectFileAndImportConfig.ts
@@ -3,6 +3,7 @@ import {selectFile} from '../lib/selectFile';
 import * as FileSystem from 'expo-file-system';
 import {PROJECT_SETTINGS_KEY, useImportProjectConfig} from './server/projects';
 import {convertFileUriToPosixPath} from '../lib/file-system';
+import {PRESETS_KEY} from './server/presets';
 
 export function useSelectFileAndImportConfig() {
   const importProjectConfigMutation = useImportProjectConfig();
@@ -24,7 +25,10 @@ export function useSelectFileAndImportConfig() {
       }
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]});
+      return Promise.all([
+        queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]}),
+        queryClient.invalidateQueries({queryKey: [PRESETS_KEY]}),
+      ]);
     },
   });
 }

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -65,6 +65,12 @@ const m = defineMessages({
       '{coordinates}',
     description: 'Message that will be shared along with image',
   },
+  fallbackCategoryName: {
+    id: 'screens.Observation.fallbackCategoryName',
+    defaultMessage: 'Observation',
+    description:
+      'Fallback name used when category name cannot be determined for observation',
+  },
 });
 
 export const ButtonFields = ({
@@ -134,7 +140,7 @@ export const ButtonFields = ({
           base64Urls.length > 0 ? t(m.shareMediaTitle) : t(m.shareTextTitle),
         urls: base64Urls,
         message: t(m.shareMessage, {
-          category_name: preset.name,
+          category_name: preset?.name || t(m.fallbackCategoryName),
           date: Date.now(),
           time: Date.now(),
           coordinates:

--- a/src/frontend/screens/Observation/ObservationHeaderRight.tsx
+++ b/src/frontend/screens/Observation/ObservationHeaderRight.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {View, StyleSheet} from 'react-native';
 
 import {IconButton} from '../../sharedComponents/IconButton';
-import {useObservationWithPreset} from '../../hooks/useObservationWithPreset';
 
 import {EditIcon} from '../../sharedComponents/icons';
 import {SyncIcon} from '../../sharedComponents/icons/SyncIconCircle';
@@ -10,17 +9,16 @@ import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeviceInfo} from '../../hooks/server/deviceInfo';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {useOriginalVersionIdToDeviceId} from '../../hooks/server/projects.ts';
+import {useObservation} from '../../hooks/server/observations.ts';
 
 export const ObservationHeaderRight = ({
   observationId,
 }: {
   observationId: string;
 }) => {
-  const observationWithPreset = useObservationWithPreset(observationId);
+  const {data: observation} = useObservation(observationId);
   const {data: createdByDeviceId, isPending: isCreatedByDeviceIdPending} =
-    useOriginalVersionIdToDeviceId(
-      observationWithPreset.observation.originalVersionId,
-    );
+    useOriginalVersionIdToDeviceId(observation.originalVersionId);
 
   const {data: deviceInfo, isPending: isDeviceInfoPending} = useDeviceInfo();
   const navigation = useNavigationFromRoot();

--- a/src/frontend/screens/Observation/PresetHeader.tsx
+++ b/src/frontend/screens/Observation/PresetHeader.tsx
@@ -10,7 +10,7 @@ export const PresetHeader = ({preset}: {preset?: Preset}) => {
     <View style={styles.categoryIconContainer}>
       <PresetCircleIcon
         size="medium"
-        presetDocId={preset?.iconRef?.docId}
+        iconId={preset?.iconRef?.docId}
         testID={`OBS.${preset?.name}-view-icon`}
       />
       <Text style={styles.categoryLabel} numberOfLines={1}>

--- a/src/frontend/screens/Observation/PresetHeader.tsx
+++ b/src/frontend/screens/Observation/PresetHeader.tsx
@@ -5,7 +5,7 @@ import {FormattedPresetName} from '../../sharedComponents/FormattedData';
 import {PresetCircleIcon} from '../../sharedComponents/icons/PresetIcon';
 import {Preset} from '@mapeo/schema';
 
-export const PresetHeader = ({preset}: {preset: Preset}) => {
+export const PresetHeader = ({preset}: {preset?: Preset}) => {
   return (
     <View style={styles.categoryIconContainer}>
       <PresetCircleIcon

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -53,13 +53,16 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
   const {data: fieldData} = useFieldsQuery();
 
   const defaultAcc: Field[] = [];
-  const fields = fieldData
-    ? preset.fieldRefs.reduce((acc, pres) => {
-        const fieldToAdd = fieldData.find(field => field.docId === pres.docId);
-        if (!fieldToAdd) return acc;
-        return [...acc, fieldToAdd];
-      }, defaultAcc)
-    : [];
+  const fields =
+    preset && fieldData
+      ? preset.fieldRefs.reduce((acc, pres) => {
+          const fieldToAdd = fieldData.find(
+            field => field.docId === pres.docId,
+          );
+          if (!fieldToAdd) return acc;
+          return [...acc, fieldToAdd];
+        }, defaultAcc)
+      : [];
 
   const {lat, lon, originalVersionId} = observation;
   const {data: deviceInfo, isPending: isDeviceInfoPending} = useDeviceInfo();
@@ -92,7 +95,7 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
           </Text>
         </View>
         <View style={[styles.section, {flex: 1}]}>
-          {preset && <PresetHeader preset={preset} />}
+          <PresetHeader preset={preset} />
 
           {typeof observation.tags.notes === 'string' ? (
             <View style={{paddingTop: 15}}>

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -194,6 +194,7 @@ export const ObservationCreate = ({
         presetName={presetName}
         PresetIcon={
           <PresetCircleIcon
+            size="medium"
             presetDocId={preset?.iconRef?.docId}
             testID={`OBS.${preset?.name}-icon`}
           />

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -195,7 +195,7 @@ export const ObservationCreate = ({
         PresetIcon={
           <PresetCircleIcon
             size="medium"
-            presetDocId={preset?.iconRef?.docId}
+            iconId={preset?.iconRef?.docId}
             testID={`OBS.${preset?.name}-icon`}
           />
         }

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -192,6 +192,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
         presetName={presetName}
         PresetIcon={
           <PresetCircleIcon
+            size="medium"
             presetDocId={preset?.iconRef?.docId}
             testID={`OBS.${preset?.name}-icon`}
           />

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -193,7 +193,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
         PresetIcon={
           <PresetCircleIcon
             size="medium"
-            presetDocId={preset?.iconRef?.docId}
+            iconId={preset?.iconRef?.docId}
             testID={`OBS.${preset?.name}-icon`}
           />
         }

--- a/src/frontend/screens/ObservationsList/ObservationListItem.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationListItem.tsx
@@ -64,11 +64,9 @@ function ObservationListItemNotMemoized({
           queriesSucceeded && !isMine && styles.syncedObservation,
         ]}>
         <View style={styles.text}>
-          {preset && (
-            <Text style={styles.title}>
-              <FormattedPresetName preset={preset} />
-            </Text>
-          )}
+          <Text style={styles.title}>
+            <FormattedPresetName preset={preset} />
+          </Text>
           <Text>
             <FormattedObservationDate
               createdDate={observation.createdAt}

--- a/src/frontend/screens/ObservationsList/ObservationListItem.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationListItem.tsx
@@ -78,15 +78,12 @@ function ObservationListItemNotMemoized({
           <View style={styles.photoContainer}>
             <PhotoStack photos={photos} />
             <View style={styles.smallIconContainer}>
-              <PresetCircleIcon
-                presetDocId={preset?.iconRef?.docId}
-                size="small"
-              />
+              <PresetCircleIcon iconId={preset?.iconRef?.docId} size="small" />
             </View>
           </View>
         ) : (
           <PresetCircleIcon
-            presetDocId={preset?.iconRef?.docId}
+            iconId={preset?.iconRef?.docId}
             size="medium"
             testID={`OBS.${preset?.name}-list-icon`}
           />

--- a/src/frontend/screens/PresetChooser.tsx
+++ b/src/frontend/screens/PresetChooser.tsx
@@ -151,7 +151,7 @@ const Item = React.memo(
       activeOpacity={1}
       underlayColor="#000033">
       <View style={styles.cellContainer}>
-        <PresetCircleIcon presetDocId={item.iconRef?.docId} size="medium" />
+        <PresetCircleIcon iconId={item.iconRef?.docId} size="medium" />
         <Text numberOfLines={3} style={styles.categoryName}>
           <DynFormattedMessage
             id={`presets.${item.docId}.name`}

--- a/src/frontend/sharedComponents/FormattedData.tsx
+++ b/src/frontend/sharedComponents/FormattedData.tsx
@@ -135,7 +135,7 @@ export const FormattedObservationDate = React.memo(
 
 // Format the translated preset name, with a fallback to "Observation" if no
 // preset is defined
-export const FormattedPresetName = ({preset}: {preset: Preset | void}) => {
+export const FormattedPresetName = ({preset}: {preset?: Preset}) => {
   const {formatMessage: t} = useIntl();
   const name = preset
     ? t({id: `presets.${preset.docId}.name`, defaultMessage: preset.name})

--- a/src/frontend/sharedComponents/icons/PresetIcon.tsx
+++ b/src/frontend/sharedComponents/icons/PresetIcon.tsx
@@ -1,14 +1,14 @@
-import React, {memo, useState, useEffect} from 'react';
+import React, {memo} from 'react';
 import {Image} from 'react-native';
 import {Circle} from './Circle';
-import {IconSize} from '../../sharedTypes';
+import {type IconSize} from '../../sharedTypes';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {useGetPresetIcon} from '../../hooks/server/presets';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 interface PresetIconProps {
   presetDocId?: string;
-  size?: IconSize;
+  size: IconSize;
   testID?: string;
 }
 
@@ -24,42 +24,41 @@ const radii = {
   large: 35,
 };
 
-export const PresetIcon = memo<PresetIconProps>(
-  ({presetDocId, size = 'medium', testID}) => {
-    const iconSize = iconSizes[size] || 35;
-    if (!presetDocId) {
-      return <MaterialIcon name="place" size={iconSize} />;
-    }
-    const {
-      data: iconUrl,
-      isPending,
-      error,
-    } = useGetPresetIcon(presetDocId, size);
-    if (isPending) return <UIActivityIndicator size={30} />;
+const PresetIcon = memo<PresetIconProps>(({presetDocId, size, testID}) => {
+  const iconSize = iconSizes[size] || 35;
 
-    if (error || !iconUrl) {
-      return <MaterialIcon name="place" size={iconSize} />;
-    }
+  const {data: iconUrl, isPending, error} = useGetPresetIcon(presetDocId, size);
 
-    return (
-      <Image
-        style={{width: iconSize, height: iconSize}}
-        resizeMode="contain"
-        source={{uri: iconUrl}}
-        testID={testID}
-      />
-    );
-  },
-);
+  if (isPending) return <UIActivityIndicator size={30} />;
+
+  if (error || !iconUrl) {
+    return <MaterialIcon name="place" size={iconSize} />;
+  }
+
+  return (
+    <Image
+      style={{width: iconSize, height: iconSize}}
+      resizeMode="contain"
+      source={{uri: iconUrl}}
+      testID={testID}
+    />
+  );
+});
 
 export const PresetCircleIcon = ({
   presetDocId,
-  size = 'medium',
+  size,
   testID,
 }: PresetIconProps) => {
+  const iconSize = iconSizes[size] || 35;
+
   return (
     <Circle radius={radii[size]} style={{elevation: 5}}>
-      <PresetIcon presetDocId={presetDocId} size={size} testID={testID} />
+      {presetDocId ? (
+        <PresetIcon presetDocId={presetDocId} size={size} testID={testID} />
+      ) : (
+        <MaterialIcon name="place" size={iconSize} />
+      )}
     </Circle>
   );
 };

--- a/src/frontend/sharedComponents/icons/PresetIcon.tsx
+++ b/src/frontend/sharedComponents/icons/PresetIcon.tsx
@@ -3,7 +3,7 @@ import {Image} from 'react-native';
 import {Circle} from './Circle';
 import {type IconSize} from '../../sharedTypes';
 import {UIActivityIndicator} from 'react-native-indicators';
-import {useIconUrl} from '../../hooks/server/presets';
+import {useIconUrl} from '../../hooks/server/icons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 interface PresetIconProps {


### PR DESCRIPTION
Fixes #686 
Towards #611

More closely emulates the behavior of Mapeo Mobile when it comes to displaying an observation that has an unknown/unmatched preset/category.

Also properly invalidates query caches for other kinds of data that are affected by the introduction of a new project config.

Note that this doesn't fully fix the issue described in #611 , as I believe the cause is out of the scope of this PR. See https://github.com/digidem/comapeo-core/issues/821#issuecomment-2344231495. It does however make some progress towards fixing it. Before, I don't think those icons would ever load. Now, they will eventually load (helps to navigate in and out of screens for now).

---

https://github.com/user-attachments/assets/8c3487e9-fe90-4943-ba51-b9726ff5304b