### PR TITLE
chore: tidy type for location callback

### DIFF
--- a/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
+++ b/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
@@ -80,7 +80,7 @@ export function useMostAccurateLocationForObservation() {
 function debounceLocation() {
   let lastLocation: LocationObject | undefined;
 
-  return function (callback: (location: LocationObject | undefined) => any) {
+  return function (callback: (location: LocationObject) => unknown) {
     return function (location: LocationObject) {
       if (!lastLocation) {
         lastLocation = location;


### PR DESCRIPTION
*This is a types-only change that should have no user impact.*

This change makes two small improvements to a location callback type:

- It always provides a location, so we can use `LocationObject` instead of `LocationObject | undefined`.

- We don't care what it returns, so we should use `unknown` instead of `any`, because that's more exact.