### PR TITLE
fix: simplify "accurate location" hook

### DIFF
--- a/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
+++ b/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
@@ -10,7 +10,6 @@ import {
 import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
 import {useDraftObservation} from '../../hooks/useDraftObservation';
 import {useLocationProviderStatus} from '../../hooks/useLocationProviderStatus';
-import type {Position} from '../../sharedTypes';
 
 export function useMostAccurateLocationForObservation() {
   const value = usePersistedDraftObservation(store => store.value);
@@ -45,17 +44,14 @@ export function useMostAccurateLocationForObservation() {
         },
         debounceLocation()(location => {
           if (ignore) return;
-
-          const position: Position = {mocked: false};
-          if (location) {
-            position.coords = mapObject(location.coords, (key, val) =>
-              val == null ? mapObjectSkip : [key, val],
-            );
-            position.timestamp = new Date(location.timestamp).toISOString();
-          }
-
           updateObservationPosition({
-            position,
+            position: {
+              mocked: location.mocked,
+              coords: mapObject(location.coords, (key, val) =>
+                val == null ? mapObjectSkip : [key, val],
+              ),
+              timestamp: new Date(location.timestamp).toISOString(),
+            },
             manualLocation: false,
           });
         }),


### PR DESCRIPTION
This hook handled a case where no location was provided, but that could never happen (see 306aa518063779971fd97f417fbc95294ca975bc). This simplifies the code because we don't need to handle that case.

I think this is a useful change on its own, but it will also be required when we update to the latest `@comapeo/schema`.