### PR TITLE
fix: create test data with proper metadata

### DIFF
--- a/src/frontend/screens/Settings/CreateTestData.tsx
+++ b/src/frontend/screens/Settings/CreateTestData.tsx
@@ -17,6 +17,7 @@ import {Button} from '../../sharedComponents/Button';
 import {LocationView} from '../../sharedComponents/Editor/LocationView';
 import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
 import {Text} from '../../sharedComponents/Text';
+import type {Metadata} from '../../sharedTypes';
 
 const DISTANCE_BUFFER_KM = 50;
 
@@ -258,24 +259,35 @@ function useCreateFakeObservationsMutation() {
       const promises = [];
 
       for (let i = 0; i < count; i++) {
-        const fakeCoordinates = randomPosition({
-          bbox,
-        });
+        const [lon, lat] = randomPosition({bbox});
+        if (lon === undefined || lat === undefined) {
+          throw new Error('randomPosition returned invalid position');
+        }
 
         const randomPreset = presets.at(
           Math.floor(Math.random() * presets.length),
         );
 
+        const isManualLocation = Math.random() < 0.25;
+        let metadata: Metadata;
+        if (isManualLocation) {
+          metadata = {manualLocation: true};
+        } else {
+          metadata = {
+            manualLocation: false,
+            position: {
+              mocked: false,
+              timestamp: new Date().toISOString(),
+              coords: {latitude: lat, longitude: lon},
+            },
+          };
+        }
+
         const value = {
           attachments: [],
-          lon: fakeCoordinates[0] || 0,
-          lat: fakeCoordinates[1] || 0,
-          metadata: {
-            manualLocation: !!location.mocked,
-            position: {
-              mocked: !!location.mocked,
-            },
-          },
+          lon,
+          lat,
+          metadata,
           schemaName: 'observation' as const,
           tags: {...randomPreset!.tags, notes},
         };

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -18,11 +18,11 @@ export type IconSize = 'small' | 'medium' | 'large';
 
 export type Status = 'idle' | 'loading' | 'error' | 'success' | void;
 
-export type Position = NonNullable<Observation['metadata']>['position'];
+export type Metadata = NonNullable<Observation['metadata']>;
 
-export type PositionProvider = NonNullable<
-  Observation['metadata']
->['positionProvider'];
+export type Position = Metadata['position'];
+
+export type PositionProvider = Metadata['positionProvider'];
 
 export type ClientGeneratedObservation = Omit<ObservationValue, 'schemaName'>;
 


### PR DESCRIPTION
When creating test data, this will create a "manual location" observation ¼ of the time. The rest of the time, it will populate fake metadata properly.

I think this is a useful change on its own, but it will also be required when we update to the latest `@comapeo/schema`.