### PR TITLE
chore: remove project config icon

### DIFF
--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import {ScrollView} from 'react-native';
-import {
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-} from '../../../sharedComponents/List';
+import {List, ListItem, ListItemText} from '../../../sharedComponents/List';
 import {FormattedMessage, defineMessages} from 'react-intl';
 import {NativeNavigationComponent} from '../../../sharedTypes/navigation';
 
@@ -70,10 +65,6 @@ export const ProjectSettings: NativeNavigationComponent<'ProjectSettings'> = ({
             navigation.navigate('Config');
           }}
           testID="settingsConfigButton">
-          <ListItemIcon
-            style={{minWidth: 0, marginRight: 10}}
-            iconName="assignment"
-          />
           <ListItemText primary={<FormattedMessage {...m.config} />} />
         </ListItem>
       </List>


### PR DESCRIPTION
closes #703 .
removes project configuration icon:
<img width="273" alt="image" src="https://github.com/user-attachments/assets/ea377c06-bff5-443d-8bfe-4e1227bc6f63">
