### PR TITLE
chore: update EAS config

### DIFF
--- a/app.json
+++ b/app.json
@@ -61,7 +61,6 @@
       ["./expo-config-plugins/targetArmArchsOnly.js"]
     ],
     "android": {
-      "versionCode": 1,
       "allowBackup": false,
       "adaptiveIcon": {
         "foregroundImage": "./assets/icon.png",

--- a/eas.json
+++ b/eas.json
@@ -1,46 +1,40 @@
 {
   "cli": {
     "version": ">= 7.8.0",
-    "appVersionSource": "remote"
+    "appVersionSource": "remote",
+    "requireCommit": true
   },
   "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal",
-      "ios": {
-        "image": "latest",
-        "simulator": true
-      },
+    "base": {
       "android": {
         "image": "latest",
-        "buildType": "apk"
+        "node": "20.17.0"
       },
+      "ios": {
+        "image": "latest",
+        "node": "20.17.0"
+      }
+    },
+    "development": {
+      "extends": "base",
+      "developmentClient": true,
+      "distribution": "internal",
       "env": {
         "APP_VARIANT": "development"
       }
     },
     "release-candidate": {
+      "extends": "base",
       "distribution": "internal",
       "channel": "preview",
       "env": {
         "APP_VARIANT": "releaseCandidate",
-        "EXPO_PUBLIC_FEATURE_TEST_DATA_UI":"true"
-      },
-      "android": {
-        "image": "latest",
-        "buildType": "apk"
-      },
-      "ios": {
-        "image": "latest"
+        "EXPO_PUBLIC_FEATURE_TEST_DATA_UI": "true"
       }
     },
     "production": {
-      "android": {
-        "image": "latest"
-      },
-      "ios": {
-        "image": "latest"
-      },
+      "extends": "base",
+      "distribution": "store",
       "channel": "production",
       "env": {
         "APP_VARIANT": "production"
@@ -48,17 +42,11 @@
       "autoIncrement": true
     },
     "pre-release": {
+      "extends": "base",
       "distribution": "internal",
       "channel": "preview",
       "env": {
         "APP_VARIANT": "preRelease"
-      },
-      "android": {
-        "image": "latest",
-        "buildType": "apk"
-      },
-      "ios": {
-        "image": "latest"
       }
     }
   },


### PR DESCRIPTION
This PR updates the EAS config:

- It adds `requireCommit: true`, which enables the [full git workflow](https://github.com/expo/fyi/blob/main/eas-vcs-workflow.md) for EAS. This ensures there is a commit associated with each build.
- It sets the node version used for builds to `20.17.0`. The default version is `18.18.0`, which does not support `import.meta.resolve()` which is used by our prebuild scripts on the backend. I'm not sure how builds were working before.
- It creates a `"base"` build profile, and extends this for other build profiles. This avoid repetition of things like the node version, which would be subject to human error.
- It removes `versionCode` from `app.json`. This value is ignored by EAS for the actual versionCode, but it overrides the actual versionCode when reading it from application code, which is a problem for the about screen.