### PR TITLE
chore: remove test data generator

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -28,8 +28,7 @@
       "distribution": "internal",
       "channel": "preview",
       "env": {
-        "APP_VARIANT": "releaseCandidate",
-        "EXPO_PUBLIC_FEATURE_TEST_DATA_UI": "true"
+        "APP_VARIANT": "releaseCandidate"
       }
     },
     "production": {


### PR DESCRIPTION
this removes the test data generator for the final build.

this should NOT be cherry picked onto develop and should only exist on the release/v1.0.0 branch