### PR TITLE
fix: unpublish dns-sd service

### DIFF
--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -340,7 +340,7 @@ function publishZeroconf(
     };
 
     zeroconf.on(
-      // @ts-expect-error - the types are wrong, this is the correct event name
+      // @ts-expect-error We can remove this when <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70693> is merged.
       'published',
       onPublish,
     );

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -373,9 +373,9 @@ function stopZeroconf(zeroconf: Zeroconf): Promise<void> {
 
 function unpublishZeroconf(
   zeroconf: Zeroconf,
-  publishedNames: Set<string>,
+  publishedNamesToBeMutated: Set<string>,
 ): Promise<void> {
-  if (publishedNames.size === 0) return Promise.resolve();
+  if (publishedNamesToBeMutated.size === 0) return Promise.resolve();
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       cleanup();
@@ -387,14 +387,14 @@ function unpublishZeroconf(
       zeroconf.off('remove', onRemove);
     };
     const onRemove = (name: string) => {
-      publishedNames.delete(name);
-      if (publishedNames.size === 0) {
+      publishedNamesToBeMutated.delete(name);
+      if (publishedNamesToBeMutated.size === 0) {
         cleanup();
         resolve();
       }
     };
     zeroconf.on('remove', onRemove);
-    for (const name of publishedNames) {
+    for (const name of publishedNamesToBeMutated) {
       zeroconf.unpublishService(name);
     }
   });

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -111,17 +111,17 @@ export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
       // publishedName could be different from the name we requested, if there
       // was a conflict on the network (the conflict could come from the same
       // name still being registered on the network and not yet cleaned up)
-      const publishedName = await publishZeroconf(zeroconf, {name, port}).catch(
-        e => {
-          // Publishing could fail (timeout), but we don't want to throw the
-          // state machine start(), because that would leave the state machine
-          // in an "error" state and stop other things from working. By silently
-          // failing (with the report to Sentry), we are able to try again next
-          // time.
-          Sentry.captureException(e);
-        },
-      );
-      if (publishedName) publishedNames.add(publishedName);
+      try {
+        const publishedName = await publishZeroconf(zeroconf, {name, port});
+        publishedNames.add(publishedName);
+      } catch (e) {
+        // Publishing could fail (timeout), but we don't want to throw the
+        // state machine start(), because that would leave the state machine
+        // in an "error" state and stop other things from working. By silently
+        // failing (with the report to Sentry), we are able to try again next
+        // time.
+        Sentry.captureException(e);
+      }
       await startZeroconfPromise;
     },
     async stop() {

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -8,6 +8,7 @@ import NetInfo, {
 import StateMachine from 'start-stop-state-machine';
 import Zeroconf, {type Service as ZeroconfService} from 'react-native-zeroconf';
 import {type MapeoClientApi} from '@comapeo/ipc';
+import * as Sentry from '@sentry/react-native';
 import noop from '../lib/noop';
 
 type LocalDiscoveryController = ReturnType<
@@ -33,6 +34,12 @@ const POLL_WIFI_STATE_INTERVAL_MS = 2000;
 const ZEROCONF_SERVICE_TYPE = 'comapeo';
 const ZEROCONF_PROTOCOL = 'tcp';
 const ZEROCONF_DOMAIN = 'local.';
+// react-native-zeroconf does not notify when a service fails to register or unregister
+// https://github.com/balthazar/react-native-zeroconf/blob/master/android/src/main/java/com/balthazargronon/RCTZeroconf/nsd/NsdServiceImpl.java#L210
+// so we need a timeout, otherwise the service would never be considered
+// "started" or "stopped", which would stop browsing for peers.
+const ZEROCONF_PUBLISH_TIMEOUT_MS = 5000;
+const ZEROCONF_UNPUBLISH_TIMEOUT_MS = 5000;
 
 const LocalDiscoveryContext = React.createContext<
   LocalDiscoveryController | undefined
@@ -91,33 +98,48 @@ export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
   };
   let cancelNetInfoFetch: undefined | (() => void);
   const zeroconf = new Zeroconf();
+  // In edge-cases, we may end up with multiple published names (NSD service
+  // will append ` (1)` to the name if there is a conflict), so we need to track
+  // them here so that we can unpublish them when we stop the service.
+  const publishedNames = new Set<string>();
 
   const sm = new StateMachine({
     async start() {
-      const [{name, port}] = await Promise.all([
-        mapeoApi.startLocalPeerDiscoveryServer(),
-        startZeroconf(zeroconf),
-      ]);
-      zeroconf.publishService(
-        ZEROCONF_SERVICE_TYPE,
-        ZEROCONF_PROTOCOL,
-        ZEROCONF_DOMAIN,
-        name,
-        port,
+      // start browsing straight away
+      const startZeroconfPromise = startZeroconf(zeroconf);
+      const {name, port} = await mapeoApi.startLocalPeerDiscoveryServer();
+      // publishedName could be different from the name we requested, if there
+      // was a conflict on the network (the conflict could come from the same
+      // name still being registered on the network and not yet cleaned up)
+      const publishedName = await publishZeroconf(zeroconf, {name, port}).catch(
+        e => {
+          // Publishing could fail (timeout), but we don't want to throw the
+          // state machine start(), because that would leave the state machine
+          // in an "error" state and stop other things from working. By silently
+          // failing (with the report to Sentry), we are able to try again next
+          // time.
+          Sentry.captureException(e);
+        },
       );
+      if (publishedName) publishedNames.add(publishedName);
+      await startZeroconfPromise;
     },
     async stop() {
       await Promise.all([
         mapeoApi.stopLocalPeerDiscoveryServer(),
         stopZeroconf(zeroconf),
+        unpublishZeroconf(zeroconf, publishedNames).catch(e => {
+          // See above for why we silently fail here
+          Sentry.captureException(e);
+        }),
       ]);
     },
   });
-  sm.on('state', state => {
-    if (state.value === 'error') {
-      updateState({status: 'error', error: state.error});
+  sm.on('state', smState => {
+    if (smState.value === 'error') {
+      updateState({status: 'error', error: smState.error});
     } else {
-      updateState({status: state.value});
+      updateState({status: smState.value});
     }
   });
   const listeners = new Set<() => void>();
@@ -163,9 +185,9 @@ export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
       cancel = true;
     };
     NetInfo.fetch('wifi')
-      .then(state => {
+      .then(netInfoState => {
         if (cancel) return;
-        onNetInfo(state);
+        onNetInfo(netInfoState);
       })
       .catch(noop);
   }
@@ -298,6 +320,40 @@ function startZeroconf(zeroconf: Zeroconf): Promise<void> {
   });
 }
 
+function publishZeroconf(
+  zeroconf: Zeroconf,
+  {name, port}: {name: string; port: number},
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out publishing zeroconf service'));
+    }, ZEROCONF_PUBLISH_TIMEOUT_MS);
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      zeroconf.off('published', onPublish);
+    };
+    const onPublish = ({name: publishedName}: ZeroconfService) => {
+      cleanup();
+      resolve(publishedName);
+    };
+
+    zeroconf.on(
+      // @ts-expect-error - the types are wrong, this is the correct event name
+      'published',
+      onPublish,
+    );
+    zeroconf.publishService(
+      ZEROCONF_SERVICE_TYPE,
+      ZEROCONF_PROTOCOL,
+      ZEROCONF_DOMAIN,
+      name,
+      port,
+    );
+  });
+}
+
 function stopZeroconf(zeroconf: Zeroconf): Promise<void> {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
@@ -316,6 +372,35 @@ function stopZeroconf(zeroconf: Zeroconf): Promise<void> {
     zeroconf.on('error', onError);
 
     zeroconf.stop();
+  });
+}
+
+function unpublishZeroconf(
+  zeroconf: Zeroconf,
+  publishedNames: Set<string>,
+): Promise<void> {
+  if (publishedNames.size === 0) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out unpublishing zeroconf service'));
+    }, ZEROCONF_UNPUBLISH_TIMEOUT_MS);
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      zeroconf.off('remove', onRemove);
+    };
+    const onRemove = (name: string) => {
+      publishedNames.delete(name);
+      if (publishedNames.size === 0) {
+        cleanup();
+        resolve();
+      }
+    };
+    zeroconf.on('remove', onRemove);
+    for (const name of publishedNames) {
+      zeroconf.unpublishService(name);
+    }
   });
 }
 

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -339,11 +339,7 @@ function publishZeroconf(
       resolve(publishedName);
     };
 
-    zeroconf.on(
-      // @ts-expect-error We can remove this when <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70693> is merged.
-      'published',
-      onPublish,
-    );
+    zeroconf.on('published', onPublish);
     zeroconf.publishService(
       ZEROCONF_SERVICE_TYPE,
       ZEROCONF_PROTOCOL,


### PR DESCRIPTION
We were not unpublishing the zeroconf service when the app went into the background, but we were re-publishing the service when the app came into the foreground (the same with wifi coming off and on).

When zeroconf attempts to publish a service with the same name, it appends ` (${n})` to the published service name.

The result of this was that the app would leave multiple published dns-sd services e.g.

```
8130fb3b21ac48b6
8130fb3b21ac48b6 (1)
8130fb3b21ac48b6 (2)
```

Only the most recent would have the correct port - the older services would have the port from previous app opens.

Leaving these services published does not break anything per se, but the consequences are:

1. Increased mdns network traffic, because other mdns devices share the service information.
2. Slower connections between CoMapeo devices and possible performance overhead, because CoMapeo will attempt to connect to _every_ service published.

This PR correctly unpublishes the service when the app goes into the background or the wifi turns off. Unfortunately the react-native-zeroconf library has not implemented an event for publishing or unpublishing failing, so we implement a timeout, but don't throw an error, because just trying again is a reasonable solution. We do report the error to Sentry though so that we can track these failures.

I have tested this by opening and closing the app while viewing [this DNS-SD Browser](https://apps.apple.com/gb/app/discovery-dns-sd-browser/id1381004916?mt=12) for MacOS, but you could also test via `avahi-browse -a -v --ignore-local --resolve`.

I do not have two devices at the moment to test on real devices, this would benefit from that.

I don't think this is necessary for MVP, but could be worth releasing in a hotfix if there are discovery issues with large numbers of devices on the same network.