### PR TITLE
fix: fix issue with category icons not loading within reasonable time after importing a config

### DIFF
--- a/src/backend/patches/@comapeo+core+1.0.1+001+fastify-controller-force-close.patch
+++ b/src/backend/patches/@comapeo+core+1.0.1+001+fastify-controller-force-close.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@comapeo/core/src/fastify-controller.js b/node_modules/@comapeo/core/src/fastify-controller.js
+index a84c600..d7c748c 100644
+--- a/node_modules/@comapeo/core/src/fastify-controller.js
++++ b/node_modules/@comapeo/core/src/fastify-controller.js
+@@ -64,7 +64,14 @@ export class FastifyController {
+ 
+   async #stopServer() {
+     const { server } = this.#fastify
+-    await promisify(server.close.bind(server))()
++
++    const closePromise = promisify(server.close.bind(server))()
++
++    // Need to force close some connections (see https://github.com/digidem/comapeo-mobile/issues/611#issuecomment-2368795563)
++    // We call this after `server.close()` as recommended by the Node docs (see https://nodejs.org/docs/latest-v20.x/api/http.html#servercloseidleconnections)
++    server.closeIdleConnections()
++
++    await closePromise
+   }
+ 
+   /**


### PR DESCRIPTION
Fixes #611 

Doing this as a patch for the backend for now. Will port this to core shortly so that it's available in the next release.

The primary issue was that stopping the HTTP server was taking a long time due to Node HTTP's default behavior when calling its `close()` method. In this case, it attempts to gracefully close longstanding connections (such as keep-alive connections created by a fetch client). In our case, what was happening when importing a config was:

1. Leave app to go to file picker. This triggered the `'pause'` event in the backend, in which we close the HTTP server:

    https://github.com/digidem/comapeo-mobile/blob/9b121f0a64f00fb7f3c2339d66bcf91fb9e3dd3c/src/backend/src/app.js#L115-L119
    
    Due to the behavior described earlier, the initial stopping of the server here could take many seconds (I saw 40 seconds on my device). This affects the resume behavior as described in the next step.
  
2. Return to the app after choosing a file. This triggered the `'resume'` event in the backend, in which we start the HTTP server again:

    https://github.com/digidem/comapeo-mobile/blob/9b121f0a64f00fb7f3c2339d66bcf91fb9e3dd3c/src/backend/src/app.js#L121-L124
    
    Because we wait for the server to stop before starting again, what was happening here is that this step was waiting for the many seconds that step (1) took. During this time, the app is interactive again but does not have access to the server that provides the HTTP-based assets (such as category icons), so things fail to load and you see lots of loading UI as a result.

Not sure if this entirely fixes all issues related to category icons not loading properly, but it fixes a common user path which is more related to the changing config and how we need to refetch data after that.

---

https://github.com/user-attachments/assets/c7b716c6-f7da-4c30-bc34-d77eef3ba60b
