### PR TITLE
chore: move query invalidation of config-related queries to useImportProjectConfig()

### DIFF
--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -2,6 +2,9 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {useApi} from '../../contexts/ApiContext';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {PRESETS_KEY} from './presets';
+import {ICONS_KEY} from './icons';
+import {FIELDS_KEY} from './fields';
 
 export const ALL_PROJECTS_KEY = 'all_projects';
 export const PROJECT_SETTINGS_KEY = 'project_settings';
@@ -127,7 +130,20 @@ export function useImportProjectConfig() {
       return projectApi.importConfig({configPath});
     },
     onSuccess: () => {
-      return queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]});
+      return Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [FIELDS_KEY],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [ICONS_KEY],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [PROJECT_SETTINGS_KEY],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [PRESETS_KEY],
+        }),
+      ]);
     },
   });
 }

--- a/src/frontend/hooks/useSelectFileAndImportConfig.ts
+++ b/src/frontend/hooks/useSelectFileAndImportConfig.ts
@@ -1,15 +1,11 @@
-import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {useMutation} from '@tanstack/react-query';
 import {selectFile} from '../lib/selectFile';
 import * as FileSystem from 'expo-file-system';
-import {PROJECT_SETTINGS_KEY, useImportProjectConfig} from './server/projects';
+import {useImportProjectConfig} from './server/projects';
 import {convertFileUriToPosixPath} from '../lib/file-system';
-import {FIELDS_KEY} from './server/fields';
-import {ICONS_KEY} from './server/icons';
-import {PRESETS_KEY} from './server/presets';
 
 export function useSelectFileAndImportConfig() {
   const importProjectConfigMutation = useImportProjectConfig();
-  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async () => {
@@ -25,14 +21,6 @@ export function useSelectFileAndImportConfig() {
           console.log(err);
         });
       }
-    },
-    onSuccess: () => {
-      return Promise.all([
-        queryClient.invalidateQueries({queryKey: [FIELDS_KEY]}),
-        queryClient.invalidateQueries({queryKey: [ICONS_KEY]}),
-        queryClient.invalidateQueries({queryKey: [PROJECT_SETTINGS_KEY]}),
-        queryClient.invalidateQueries({queryKey: [PRESETS_KEY]}),
-      ]);
     },
   });
 }


### PR DESCRIPTION
Moves the query invalidations that are relevant to a change in the config (e.g. importing a new one) to `useImportProjectConfig()`, which is the more relevant mutation and is used internally by `useSelectFileAndImportConfig()`. This should not have any notable user-facing impact, as it's only callsite was `useSelectFileAndImportConfig()`.

This will avoid issues where we use `useImportProjectConfig()` but forget to do important query invalidations.

