### PR TITLE
chore: uninstall unused mock data package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@formatjs/intl-pluralrules": "^5.2.4",
         "@formatjs/intl-relativetimeformat": "^11.2.4",
         "@gorhom/bottom-sheet": "^4.5.1",
-        "@mapeo/mock-data": "2.0.0",
         "@osm_borders/maritime_10000m": "^1.1.0",
         "@react-native-community/hooks": "^2.8.0",
         "@react-native-community/netinfo": "11.1.0",
@@ -4551,21 +4550,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@faker-js/faker": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
-      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
-      }
-    },
     "node_modules/@fastify/accept-negotiator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-1.1.0.tgz",
@@ -5827,24 +5811,6 @@
         "lodash": "^4.17.21",
         "sodium-universal": "^4.0.0",
         "z32": "^1.0.0"
-      }
-    },
-    "node_modules/@mapeo/mock-data": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mapeo/mock-data/-/mock-data-2.0.0.tgz",
-      "integrity": "sha512-aYB11zpR2mYojUhwMDIhsaBPjzqa7HgEFkf4HNRyAs9N+zKJN4/X3PBm6Q9+QJjAqB0soS363U9j3Kljnu/QIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@faker-js/faker": "^8.3.1",
-        "json-schema-faker": "^0.5.3",
-        "type-fest": "^4.8.0"
-      },
-      "bin": {
-        "generate-mapeo-data": "bin/generate-mapeo-data.js",
-        "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
-      },
-      "peerDependencies": {
-        "@comapeo/schema": "^1.0.0"
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
@@ -11238,11 +11204,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
-    },
     "node_modules/caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -15317,11 +15278,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/format-util": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -18766,29 +18722,6 @@
         "is-buffer": "~1.1.1"
       }
     },
-    "node_modules/json-schema-faker": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.6.tgz",
-      "integrity": "sha512-u/cFC26/GDxh2vPiAC8B8xVvpXAW+QYtG2mijEbKrimCk8IHtiwQBjCE8TwvowdhALWq9IcdIWZ+/8ocXvdL3Q==",
-      "dependencies": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^7.2.0"
-      },
-      "bin": {
-        "jsf": "bin/gen.cjs"
-      }
-    },
-    "node_modules/json-schema-ref-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "deprecated": "Please switch to @apidevtools/json-schema-ref-parser",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -18853,14 +18786,6 @@
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -21321,14 +21246,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dependencies": {
-        "format-util": "^1.0.3"
       }
     },
     "node_modules/open": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@formatjs/intl-pluralrules": "^5.2.4",
     "@formatjs/intl-relativetimeformat": "^11.2.4",
     "@gorhom/bottom-sheet": "^4.5.1",
-    "@mapeo/mock-data": "2.0.0",
     "@osm_borders/maritime_10000m": "^1.1.0",
     "@react-native-community/hooks": "^2.8.0",
     "@react-native-community/netinfo": "11.1.0",


### PR DESCRIPTION
This change should have no user impact.

This uninstalls `@mapeo/mock-data`, as it is unused.
