### PR TITLE
feat: adds audio permissions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -354,7 +354,7 @@
   },
   "screens.AudioPermission.description": {
     "description": "Screen description for audio permission screen",
-    "message": "To record audio while using the app and in the background CoMapeo needs to access your microphone."
+    "message": "To record audio while using the app and in the background CoMapeo needs to access your microphone. Please enable microphone permissions in your app settings."
   },
   "screens.AudioPermission.title": {
     "description": "Screen title for audio permission screen",

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -326,11 +326,13 @@ export const createDefaultScreenGroup = ({
       component={HowToLeaveProject}
       options={{headerShown: false}}
     />
-    <RootStack.Screen
-      name="Audio"
-      options={audioNavigationOptions}
-      component={Audio}
-    />
+    {process.env.EXPO_PUBLIC_FEATURE_AUDIO && (
+      <RootStack.Screen
+        name="Audio"
+        options={audioNavigationOptions}
+        component={Audio}
+      />
+    )}
     {process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI && (
       <RootStack.Screen
         name="CreateTestData"

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -76,6 +76,10 @@ import {SettingsPrivacyPolicy} from '../../screens/Settings/DataAndPrivacy/Setti
 import {TrackEdit} from '../../screens/TrackEdit/index.tsx';
 import {Config} from '../../screens/Settings/Config';
 import {HowToLeaveProject} from '../../screens/HowToLeaveProject.tsx';
+import {
+  Audio,
+  navigationOptions as audioNavigationOptions,
+} from '../../screens/Audio/index.tsx';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -322,7 +326,11 @@ export const createDefaultScreenGroup = ({
       component={HowToLeaveProject}
       options={{headerShown: false}}
     />
-
+    <RootStack.Screen
+      name="Audio"
+      options={audioNavigationOptions}
+      component={Audio}
+    />
     {process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI && (
       <RootStack.Screen
         name="CreateTestData"

--- a/src/frontend/screens/Audio/CreateRecording/index.tsx
+++ b/src/frontend/screens/Audio/CreateRecording/index.tsx
@@ -1,0 +1,40 @@
+import React, {useEffect} from 'react';
+import {Text, View, StyleSheet} from 'react-native';
+import {WHITE} from '../../../lib/styles';
+
+import {useNavigationFromRoot} from '../../../hooks/useNavigationWithTypes';
+import {CustomHeaderLeft} from '../../../sharedComponents/CustomHeaderLeft';
+
+export function CreateRecording() {
+  const navigation = useNavigationFromRoot();
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: props => (
+        <CustomHeaderLeft
+          tintColor={props.tintColor}
+          headerBackButtonProps={props}
+        />
+      ),
+    });
+  }, [navigation]);
+  return (
+    <View style={styles.contentContainer}>
+      <View style={styles.container}>
+        <Text style={styles.message}>Create Recording</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  contentContainer: {flex: 1},
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  message: {
+    color: WHITE,
+    fontSize: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
+++ b/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
@@ -1,11 +1,11 @@
 import React, {FC, useState} from 'react';
 import {Linking, View} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
-import AudioPermission from '../images/observationEdit/AudioPermission.svg';
-import {BottomSheetModalContent} from './BottomSheetModal';
+import AudioPermission from '../../images/observationEdit/AudioPermission.svg';
+import {BottomSheetModalContent} from '../../sharedComponents/BottomSheetModal';
 import {Audio} from 'expo-av';
 import {PermissionResponse} from 'expo-modules-core';
-import {NativeRootNavigationProps} from '../sharedTypes/navigation';
+import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 
 const m = defineMessages({
   title: {

--- a/src/frontend/screens/Audio/index.tsx
+++ b/src/frontend/screens/Audio/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
+
+import {DARK_GREY, WHITE} from '../../lib/styles';
+import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
+import {StatusBar} from 'expo-status-bar';
+import {CreateRecording} from './CreateRecording';
+
+export function Audio() {
+  return (
+    <>
+      <StatusBar style="light" />
+      <CreateRecording />
+    </>
+  );
+}
+
+export const navigationOptions: NativeStackNavigationOptions = {
+  contentStyle: {backgroundColor: DARK_GREY},
+  headerTintColor: WHITE,
+  headerShadowVisible: false,
+  headerTitle: () => null,
+  headerStyle: {backgroundColor: 'transparent'},
+  headerTransparent: true,
+  headerLeft: props => (
+    <CustomHeaderLeft
+      tintColor={props.tintColor}
+      headerBackButtonProps={props}
+    />
+  ),
+};

--- a/src/frontend/sharedComponents/ActionRow.tsx
+++ b/src/frontend/sharedComponents/ActionRow.tsx
@@ -6,7 +6,7 @@ import AudioIcon from '../images/observationEdit/Audio.svg';
 import DetailsIcon from '../images/observationEdit/Details.svg';
 import {useNavigation} from '@react-navigation/native';
 import {Preset} from '@comapeo/schema';
-import {PermissionAudioBottomSheetContent} from './PermissionAudioBottomSheetContent';
+import {PermissionAudioBottomSheetContent} from '../screens/Audio/PermissionAudioBottomSheetContent';
 import {Audio} from 'expo-av';
 import {useBottomSheetModal} from '../sharedComponents/BottomSheetModal';
 import {BottomSheetModal} from './BottomSheetModal';

--- a/src/frontend/sharedComponents/ActionRow.tsx
+++ b/src/frontend/sharedComponents/ActionRow.tsx
@@ -4,11 +4,14 @@ import {ActionTab} from './ActionTab';
 import PhotoIcon from '../images/observationEdit/Photo.svg';
 import AudioIcon from '../images/observationEdit/Audio.svg';
 import DetailsIcon from '../images/observationEdit/Details.svg';
-import {useNavigationFromRoot} from '../hooks/useNavigationWithTypes';
+import {useNavigation} from '@react-navigation/native';
 import {Preset} from '@comapeo/schema';
-import {PermissionAudio} from './PermissionAudio';
+import {PermissionAudioBottomSheetContent} from './PermissionAudioBottomSheetContent';
 import {Audio} from 'expo-av';
 import {useBottomSheetModal} from '../sharedComponents/BottomSheetModal';
+import {BottomSheetModal} from './BottomSheetModal';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {AppStackParamsList} from '../sharedTypes/navigation';
 
 const m = defineMessages({
   audioButton: {
@@ -27,12 +30,18 @@ const m = defineMessages({
     description: 'Button label to add details',
   },
 });
+
+type ObservationCreateNavigationProp = NativeStackNavigationProp<
+  AppStackParamsList,
+  'ObservationCreate'
+>;
+
 interface ActionButtonsProps {
   fieldRefs?: Preset['fieldRefs'];
 }
 export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
   const {formatMessage: t} = useIntl();
-  const navigation = useNavigationFromRoot();
+  const navigation = useNavigation<ObservationCreateNavigationProp>();
   const {
     openSheet: openAudioPermissionSheet,
     sheetRef: audioPermissionSheetRef,
@@ -87,11 +96,16 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
   return (
     <>
       <ActionTab items={bottomSheetItems} />
-      <PermissionAudio
-        closeSheet={closeAudioPermissionSheet}
+      <BottomSheetModal
+        ref={audioPermissionSheetRef}
         isOpen={isAudioPermissionSheetOpen}
-        sheetRef={audioPermissionSheetRef}
-      />
+        onDismiss={closeAudioPermissionSheet}
+        fullScreen>
+        <PermissionAudioBottomSheetContent
+          closeSheet={closeAudioPermissionSheet}
+          navigation={navigation}
+        />
+      </BottomSheetModal>
     </>
   );
 };

--- a/src/frontend/sharedComponents/ActionRow.tsx
+++ b/src/frontend/sharedComponents/ActionRow.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {ActionTab} from './ActionTab';
 import PhotoIcon from '../images/observationEdit/Photo.svg';
+import AudioIcon from '../images/observationEdit/Audio.svg';
 import DetailsIcon from '../images/observationEdit/Details.svg';
 import {useNavigationFromRoot} from '../hooks/useNavigationWithTypes';
 import {Preset} from '@comapeo/schema';
+import {PermissionAudio} from './PermissionAudio';
+import {Audio} from 'expo-av';
+import {useBottomSheetModal} from '../sharedComponents/BottomSheetModal';
 
 const m = defineMessages({
   audioButton: {
@@ -23,22 +27,36 @@ const m = defineMessages({
     description: 'Button label to add details',
   },
 });
-
 interface ActionButtonsProps {
   fieldRefs?: Preset['fieldRefs'];
 }
-
 export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
   const {formatMessage: t} = useIntl();
   const navigation = useNavigationFromRoot();
+  const {
+    openSheet: openAudioPermissionSheet,
+    sheetRef: audioPermissionSheetRef,
+    closeSheet: closeAudioPermissionSheet,
+    isOpen: isAudioPermissionSheetOpen,
+  } = useBottomSheetModal({
+    openOnMount: false,
+  });
 
   const handleCameraPress = () => {
     navigation.navigate('AddPhoto');
   };
-
   const handleDetailsPress = () => {
     navigation.navigate('ObservationFields', {question: 1});
   };
+
+  const handleAudioPress = useCallback(async () => {
+    const {status} = await Audio.getPermissionsAsync();
+    if (status === 'granted') {
+      navigation.navigate('Audio');
+    } else {
+      openAudioPermissionSheet();
+    }
+  }, [navigation, openAudioPermissionSheet]);
 
   const bottomSheetItems = [
     {
@@ -49,8 +67,15 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
     },
   ];
 
+  if (process.env.EXPO_PUBLIC_FEATURE_AUDIO) {
+    bottomSheetItems.unshift({
+      icon: <AudioIcon width={30} height={30} />,
+      label: t(m.audioButton),
+      onPress: handleAudioPress,
+      testID: 'OBS.add-audio-btn',
+    });
+  }
   if (fieldRefs?.length) {
-    // Only show the option to add details if preset fields are defined.
     bottomSheetItems.push({
       icon: <DetailsIcon width={30} height={30} />,
       label: t(m.detailsButton),
@@ -59,5 +84,14 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
     });
   }
 
-  return <ActionTab items={bottomSheetItems} />;
+  return (
+    <>
+      <ActionTab items={bottomSheetItems} />
+      <PermissionAudio
+        closeSheet={closeAudioPermissionSheet}
+        isOpen={isAudioPermissionSheetOpen}
+        sheetRef={audioPermissionSheetRef}
+      />
+    </>
+  );
 };

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -102,6 +102,7 @@ export type RootStackParamsList = {
   DataAndPrivacy: undefined;
   SettingsPrivacyPolicy: undefined;
   HowToLeaveProject: undefined;
+  Audio: undefined;
 };
 
 export type OnboardingParamsList = {


### PR DESCRIPTION
Adds functionality for asking for permissions for Audio. Adds Audio navigation and dummy screen. Starts to address this issue: [#360 ](https://github.com/digidem/comapeo-mobile/issues/360)
Here are the [designs](https://www.figma.com/design/1Knqv1NrijUuqMo1pvYyF7/%22Ready-for-Dev%22-Hand-off-Assets?node-id=0-1&node-type=canvas&t=DhW0UI0lwgUo0EC5-0)
I found this command helpful to reset the permissions to be able to test different scenarios:
` adb shell pm reset-permissions`
Make sure to add this to your env file: EXPO_PUBLIC_FEATURE_AUDIO=true 