### PR TITLE
chore: updated copy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1313,16 +1313,13 @@
     "message": "All data synced"
   },
   "screens.Sync.ProjectSyncDisplay.devicesAvailableToSync": {
-    "message": "{count} {count, plural, one {device} other {devices}} available"
+    "message": "Devices available"
   },
   "screens.Sync.ProjectSyncDisplay.devicesFound": {
-    "message": "{count} {count, plural, one {Device} other {Devices}} found"
+    "message": "Devices found"
   },
   "screens.Sync.ProjectSyncDisplay.noDevicesAvailableToSync": {
     "message": "No devices available to sync"
-  },
-  "screens.Sync.ProjectSyncDisplay.progressLabelComplete": {
-    "message": "{count} out of {count} {count, plural, one {device} other {devices}}"
   },
   "screens.Sync.ProjectSyncDisplay.progressLabelSyncing": {
     "message": "Syncing…"
@@ -1331,7 +1328,7 @@
     "message": "Waiting…"
   },
   "screens.Sync.ProjectSyncDisplay.progressLabelWithDeviceCount": {
-    "message": "{active} out of {total} {total, plural, one {device} other {devices}}…"
+    "message": "Waiting for other devices"
   },
   "screens.Sync.ProjectSyncDisplay.startSync": {
     "message": "Start Sync"
@@ -1343,13 +1340,13 @@
     "message": "{value}%"
   },
   "screens.Sync.ProjectSyncDisplay.syncingCompleteButWaitingForOthers": {
-    "message": "Complete! Waiting for {count} {count, plural, one {device} other {devices}}"
+    "message": "Complete! Waiting for other devices to join"
   },
   "screens.Sync.ProjectSyncDisplay.syncingFullyComplete": {
     "message": "Complete! You're up to date"
   },
   "screens.Sync.ProjectSyncDisplay.syncingWithDevices": {
-    "message": "Syncing with {active} out of {total} {total, plural, one {device} other {devices}}"
+    "message": "You are syncing with your team"
   },
   "screens.Sync.ProjectSyncDisplay.waitingForDevices": {
     "message": "Waiting for devices"

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -187,9 +187,7 @@ export const ProjectSyncDisplay = ({
       syncInfoContent = (
         <Text style={styles.titleText}>
           {syncStage.connectedPeersCount > 0
-            ? t(m.devicesAvailableToSync, {
-                count: syncStage.connectedPeersCount,
-              })
+            ? t(m.devicesAvailableToSync)
             : t(m.noDevicesAvailableToSync)}
         </Text>
       );
@@ -241,10 +239,7 @@ export const ProjectSyncDisplay = ({
           <Text style={styles.titleText}>
             {syncStage.progress === 0
               ? t(m.waitingForDevices)
-              : t(m.syncingWithDevices, {
-                  active: syncingPeersCount,
-                  total: connectedPeersCount,
-                })}
+              : t(m.syncingWithDevices)}
           </Text>
           <SyncProgress stage={syncStage} />
         </>
@@ -271,10 +266,7 @@ export const ProjectSyncDisplay = ({
       syncInfoContent = (
         <>
           <Text style={styles.titleText}>
-            {t(m.syncingCompleteButWaitingForOthers, {
-              count:
-                syncStage.connectedPeersCount - syncStage.syncingPeersCount,
-            })}
+            {t(m.syncingCompleteButWaitingForOthers)}
           </Text>
           <SyncProgress stage={syncStage} />
         </>
@@ -333,7 +325,7 @@ export const ProjectSyncDisplay = ({
         )}
         <View style={styles.connectedDevicesInfoContainer}>
           <WifiIcon color={DARK_GREY} size={20} />
-          <Text>{t(m.devicesFound, {count: connectedPeersCount})}</Text>
+          <Text>{t(m.devicesFound)}</Text>
         </View>
       </View>
       {syncInfoContent}
@@ -363,10 +355,7 @@ function SyncProgress({
       break;
     }
     case 'complete-partial': {
-      progressLabel = t(m.progressLabelWithDeviceCount, {
-        active: stage.syncingPeersCount,
-        total: stage.connectedPeersCount,
-      });
+      progressLabel = t(m.progressLabelWithDeviceCount);
       break;
     }
     case 'complete-full': {

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -40,8 +40,7 @@ import {Text} from '../../sharedComponents/Text';
 const m = defineMessages({
   devicesFound: {
     id: 'screens.Sync.ProjectSyncDisplay.devicesFound',
-    defaultMessage:
-      '{count} {count, plural, one {Device} other {Devices}} found',
+    defaultMessage: 'Devices found',
   },
 
   noDevicesAvailableToSync: {
@@ -50,8 +49,7 @@ const m = defineMessages({
   },
   devicesAvailableToSync: {
     id: 'screens.Sync.ProjectSyncDisplay.devicesAvailableToSync',
-    defaultMessage:
-      '{count} {count, plural, one {device} other {devices}} available',
+    defaultMessage: 'Devices available',
   },
   waitingForDevices: {
     id: 'screens.Sync.ProjectSyncDisplay.waitingForDevices',
@@ -59,13 +57,11 @@ const m = defineMessages({
   },
   syncingWithDevices: {
     id: 'screens.Sync.ProjectSyncDisplay.syncingWithDevices',
-    defaultMessage:
-      'Syncing with {active} out of {total} {total, plural, one {device} other {devices}}',
+    defaultMessage: 'You are syncing with your team',
   },
   syncingCompleteButWaitingForOthers: {
     id: 'screens.Sync.ProjectSyncDisplay.syncingCompleteButWaitingForOthers',
-    defaultMessage:
-      'Complete! Waiting for {count} {count, plural, one {device} other {devices}}',
+    defaultMessage: 'Complete! Waiting for other devices to join',
   },
   syncingFullyComplete: {
     id: 'screens.Sync.ProjectSyncDisplay.syncingFullyComplete',
@@ -86,13 +82,7 @@ const m = defineMessages({
   },
   progressLabelWithDeviceCount: {
     id: 'screens.Sync.ProjectSyncDisplay.progressLabelWithDeviceCount',
-    defaultMessage:
-      '{active} out of {total} {total, plural, one {device} other {devices}}…',
-  },
-  progressLabelComplete: {
-    id: 'screens.Sync.ProjectSyncDisplay.progressLabelComplete',
-    defaultMessage:
-      '{count} out of {count} {count, plural, one {device} other {devices}}',
+    defaultMessage: 'Waiting for other devices',
   },
   progressSyncPercentage: {
     id: 'screens.Sync.ProjectSyncDisplay.syncProgress',
@@ -380,9 +370,7 @@ function SyncProgress({
       break;
     }
     case 'complete-full': {
-      progressLabel = t(m.progressLabelComplete, {
-        count: stage.connectedPeersCount,
-      });
+      progressLabel = '';
       break;
     }
     default: {


### PR DESCRIPTION
closes #766 

Updates the copy so user does not see the amount of devices available as there is a bug in the count. 

<img width="289" alt="image" src="https://github.com/user-attachments/assets/f350dddc-c9c1-4b36-afe9-142b244aa5df">

<img width="288" alt="image" src="https://github.com/user-attachments/assets/05097255-d7b4-4d04-951f-16d5dc1465ec">
