### PR TITLE
chore: update `@types/react-native-zeroconf` to latest version (#763)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "@types/react": "^18.2.58",
         "@types/react-native-indicators": "^0.16.2",
         "@types/react-native-vector-icons": "^6.4.8",
-        "@types/react-native-zeroconf": "^0.12.3",
+        "@types/react-native-zeroconf": "^0.13.1",
         "@types/react-test-renderer": "^18.0.0",
         "@types/semver": "^7.5.8",
         "@types/utm": "^1.1.2",
@@ -9556,9 +9556,9 @@
       }
     },
     "node_modules/@types/react-native-zeroconf": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@types/react-native-zeroconf/-/react-native-zeroconf-0.12.3.tgz",
-      "integrity": "sha512-IV9BSqbVf+I8ZNLMd4Vc8O3GPc4RVkHTlkGq7lHXaSd3egGZ9v2yoeNTZM2DNTNmFGb18Xn3mSYfAM8BkYLU1A==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-native-zeroconf/-/react-native-zeroconf-0.13.1.tgz",
+      "integrity": "sha512-edAbIS+1/o9OTYU6S7stNli9ATHlJA2z2jOv6ZC+n38Q2qyUKqzycuD+hLqRLIxe1BibYYcpOoJtuoBkLSsdYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@types/react": "^18.2.58",
     "@types/react-native-indicators": "^0.16.2",
     "@types/react-native-vector-icons": "^6.4.8",
-    "@types/react-native-zeroconf": "^0.12.3",
+    "@types/react-native-zeroconf": "^0.13.1",
     "@types/react-test-renderer": "^18.0.0",
     "@types/semver": "^7.5.8",
     "@types/utm": "^1.1.2",


### PR DESCRIPTION
Cherry picks 544f5c80 for release v1.0.0