### PR TITLE
fix: clears observation refs when clearing tracks

### DIFF
--- a/src/frontend/hooks/persistedState/usePersistedTrack.ts
+++ b/src/frontend/hooks/persistedState/usePersistedTrack.ts
@@ -72,7 +72,7 @@ export const tracksStore = createPersistedStore<TracksStoreState>(
           trackingSince: null,
           distance: 0,
           isTracking: false,
-          observations: [],
+          observationRefs: [],
           description: '',
         };
       }),

--- a/src/frontend/hooks/persistedState/usePersistedTrack.ts
+++ b/src/frontend/hooks/persistedState/usePersistedTrack.ts
@@ -66,15 +66,13 @@ export const tracksStore = createPersistedStore<TracksStoreState>(
         };
       }),
     clearCurrentTrack: () =>
-      set(() => {
-        return {
-          locationHistory: [],
-          trackingSince: null,
-          distance: 0,
-          isTracking: false,
-          observationRefs: [],
-          description: '',
-        };
+      set({
+        locationHistory: [],
+        trackingSince: null,
+        distance: 0,
+        isTracking: false,
+        observationRefs: [],
+        description: '',
       }),
     setTracking: (val: boolean) =>
       set(() =>


### PR DESCRIPTION
fixes #634 
Properly clears the observation refs when clearing a track. Previously was resetting `observation` to and empty array but `observationRefs` needs to be reset instead. This was due to a schema change and the front end did not update properly.