### PR TITLE
fix: remove unused permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -67,10 +67,12 @@
       "permissions": [
         "android.permission.ACCESS_COARSE_LOCATION",
         "android.permission.ACCESS_FINE_LOCATION",
-        "android.permission.FOREGROUND_SERVICE",
-        "android.permission.FOREGROUND_SERVICE_LOCATION",
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO"
+      ],
+      "blockedPermissions": [
+        "android.permission.ACTIVITY_RECOGNITION",
+        "com.google.android.gms.permission.ACTIVITY_RECOGNITION"
       ],
       "package": "com.comapeo"
     },


### PR DESCRIPTION
`FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_LOCATION` and `ACTIVITY_RECOGNITION` are only used by tracks, and are not needed for this build which does not have tracks enabled. `ACTIVITY_RECOGNITION` comes from the dependency `io.nlopez.smartlocation` so it needs to be explicitly blocked.