### PR TITLE
fix: microphone permission modal has correct text

### DIFF
--- a/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
+++ b/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
@@ -1,10 +1,9 @@
-import React, {FC, useState} from 'react';
-import {Linking, View} from 'react-native';
+import React, {FC, useEffect, useRef} from 'react';
+import {Linking, View, AppState, AppStateStatus} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import AudioPermission from '../../images/observationEdit/AudioPermission.svg';
 import {BottomSheetModalContent} from '../../sharedComponents/BottomSheetModal';
 import {Audio} from 'expo-av';
-import {PermissionResponse} from 'expo-modules-core';
 
 const m = defineMessages({
   title: {
@@ -39,14 +38,42 @@ const m = defineMessages({
 interface PermissionAudioBottomSheetContentProps {
   closeSheet: () => void;
   setShouldNavigateToAudioTrue: () => void;
+  permissionStatus: Audio.PermissionStatus | null;
+  isOpen: boolean;
 }
 
 export const PermissionAudioBottomSheetContent: FC<
   PermissionAudioBottomSheetContentProps
-> = ({closeSheet, setShouldNavigateToAudioTrue}) => {
+> = ({closeSheet, setShouldNavigateToAudioTrue, permissionStatus, isOpen}) => {
   const {formatMessage: t} = useIntl();
-  const [permissionResponse, setPermissionResponse] =
-    useState<PermissionResponse | null>(null);
+  const appState = useRef(AppState.currentState);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleAppStateChange = async (nextAppState: AppStateStatus) => {
+      if (
+        appState.current.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        const {status} = await Audio.getPermissionsAsync();
+        if (status === 'granted') {
+          closeSheet();
+          setShouldNavigateToAudioTrue();
+        }
+      }
+      appState.current = nextAppState;
+    };
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange,
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isOpen, closeSheet, setShouldNavigateToAudioTrue]);
 
   const handleOpenSettings = () => {
     Linking.openSettings();
@@ -55,7 +82,6 @@ export const PermissionAudioBottomSheetContent: FC<
   const handleRequestPermission = async () => {
     const response = await Audio.requestPermissionsAsync();
     closeSheet();
-    setPermissionResponse(response);
     if (response.status === 'granted') {
       setShouldNavigateToAudioTrue();
     } else if (response.status === 'denied' && !response.canAskAgain) {
@@ -63,16 +89,18 @@ export const PermissionAudioBottomSheetContent: FC<
     }
   };
 
-  const onPressActionButton = !permissionResponse
-    ? handleRequestPermission
-    : permissionResponse.status === 'denied'
-      ? handleOpenSettings
-      : handleRequestPermission;
-  const actionButtonText = !permissionResponse
-    ? t(m.allowButtonText)
-    : permissionResponse.status === 'denied'
-      ? t(m.goToSettingsButtonText)
-      : t(m.allowButtonText);
+  const onPressActionButton =
+    !permissionStatus || permissionStatus === 'undetermined'
+      ? handleRequestPermission
+      : permissionStatus === 'denied'
+        ? handleOpenSettings
+        : handleRequestPermission;
+  const actionButtonText =
+    !permissionStatus || permissionStatus === 'undetermined'
+      ? t(m.allowButtonText)
+      : permissionStatus === 'denied'
+        ? t(m.goToSettingsButtonText)
+        : t(m.allowButtonText);
 
   return (
     <View style={{paddingTop: 80}}>

--- a/src/frontend/screens/Audio/index.tsx
+++ b/src/frontend/screens/Audio/index.tsx
@@ -13,7 +13,6 @@ export function Audio({route}: NativeRootNavigationProps<'Audio'>) {
   const {deleteAudio} = useDraftObservation();
   const {isEditing, uri, isSavedUri = false} = route.params;
 
-  console.log({isEditing});
   return (
     <>
       {uri ? (

--- a/src/frontend/sharedComponents/ActionRow.tsx
+++ b/src/frontend/sharedComponents/ActionRow.tsx
@@ -55,6 +55,8 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
   });
 
   const [shouldNavigateToAudio, setShouldNavigateToAudio] = useState(false);
+  const [permissionStatus, setPermissionStatus] =
+    useState<Audio.PermissionStatus | null>(null);
 
   const handleCameraPress = () => {
     navigation.navigate('AddPhoto');
@@ -65,6 +67,7 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
 
   const handleAudioPress = useCallback(async () => {
     const {status} = await Audio.getPermissionsAsync();
+    setPermissionStatus(status);
     if (status === 'granted') {
       navigation.navigate('Audio', {
         isEditing: currentRoute?.name === 'ObservationEdit',
@@ -118,6 +121,8 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
         <PermissionAudioBottomSheetContent
           closeSheet={closeAudioPermissionSheet}
           setShouldNavigateToAudioTrue={() => setShouldNavigateToAudio(true)}
+          permissionStatus={permissionStatus}
+          isOpen={isAudioPermissionSheetOpen}
         />
       </BottomSheetModal>
     </>

--- a/src/frontend/sharedComponents/ActionRow.tsx
+++ b/src/frontend/sharedComponents/ActionRow.tsx
@@ -55,7 +55,7 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
   });
 
   const [shouldNavigateToAudio, setShouldNavigateToAudio] = useState(false);
-  const [permissionStatus, setPermissionStatus] =
+  const [audioPermissionStatus, setAudioPermissionStatus] =
     useState<Audio.PermissionStatus | null>(null);
 
   const handleCameraPress = () => {
@@ -67,7 +67,7 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
 
   const handleAudioPress = useCallback(async () => {
     const {status} = await Audio.getPermissionsAsync();
-    setPermissionStatus(status);
+    setAudioPermissionStatus(status);
     if (status === 'granted') {
       navigation.navigate('Audio', {
         isEditing: currentRoute?.name === 'ObservationEdit',
@@ -121,7 +121,7 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
         <PermissionAudioBottomSheetContent
           closeSheet={closeAudioPermissionSheet}
           setShouldNavigateToAudioTrue={() => setShouldNavigateToAudio(true)}
-          permissionStatus={permissionStatus}
+          permissionStatus={audioPermissionStatus}
           isOpen={isAudioPermissionSheetOpen}
         />
       </BottomSheetModal>

--- a/src/frontend/sharedComponents/MediaScrollView/AudioThumbnail.tsx
+++ b/src/frontend/sharedComponents/MediaScrollView/AudioThumbnail.tsx
@@ -31,13 +31,9 @@ export const AudioThumbnail: FC<AudioThumbnailProps> = ({
   const {projectApi} = useActiveProject();
   const [loading, setLoading] = React.useState(false);
 
-  console.log({currentRoute});
-
   if ('deleted' in audioAttachment && audioAttachment.deleted === true) {
     return null;
   }
-
-  console.log();
 
   const handlePress = async () => {
     setLoading(true);


### PR DESCRIPTION
closes #831 

### Description
This PR removes some old console.logs.
Also! 
1. it makes sure that the text on the permission modal is correct. It should say allow, not now if someone has not denied permissions.
2. Once someone has denied permissions, it should say Go to Settings, which now it does.
I had to add the useEffect so that when someone returns from settings, the behavior is correct. There were many ways to achieve this! I hope you like the way I landed on. I considered at least 4 other ways that also worked.

As a reminder, `adb shell pm reset-permissions` will reset the permissions (from "granted") but if they are denied, they will remain "denied"... Not sure why that is.

### To test
1. Start an observation. 
2. Press microphone. Modal should open and say "Allow/ Not Now". Press Not Now. Modal should close.
3. Press microphone. Modal should say "Allow/ Now Now". Press Allow. Grant permission. You should navigate to the the audio recording screen.
4. Run `adb shell pm reset-permissions`
5. Reopen the app, grant other permissions
6. Press microphone. Modal should now say Not Now, Go to Settings. Hit Not Now and modal should close.
7. Press microphone. Modal should now say Not Now, Go to Settings. Hit Go to Settings and you should Go to settings. Don't enable microphone permissions. Modal should still be open. You can hit Not Now and it will close.
8. Press microphone. Modal should now say Not Now, Go to Settings. Hit Go to Settings and you should Go to settings. Enable Microphone permissions. Use back button to go back to the app. You should navigate to audio now (sorry there is some flashing as the sheet closes).

