### PR TITLE
fix: delete map shows confirmation twice

### DIFF
--- a/src/frontend/lib/styles.ts
+++ b/src/frontend/lib/styles.ts
@@ -24,3 +24,4 @@ export const DARK_ORANGE = '#E86826';
 export const SYNC_BACKGROUND = '#2348B2';
 export const GPS_MODAL_TEXT = 'rgb(40,40,40)';
 export const DARK_GREEN = '#59A553';
+export const WARNING_RED = '#D92222';

--- a/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
+++ b/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
@@ -14,7 +14,7 @@ import {
 import ErrorSvg from '../../../images/Error.svg';
 import GreenCheckSvg from '../../../images/GreenCheck.svg';
 import noop from '../../../lib/noop';
-import {DARK_GREY, RED, WHITE} from '../../../lib/styles';
+import {RED, WHITE} from '../../../lib/styles';
 import {
   BottomSheetModal,
   BottomSheetModalContent,
@@ -23,7 +23,8 @@ import {
 import {Button} from '../../../sharedComponents/Button';
 import {ErrorBottomSheet} from '../../../sharedComponents/ErrorBottomSheet';
 import {Loading} from '../../../sharedComponents/Loading';
-import {Text} from '../../../sharedComponents/Text';
+import {HeaderText} from '../../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../../sharedComponents/Text/BodyText';
 import {type NativeRootNavigationProps} from '../../../sharedTypes/navigation';
 import {ChooseMapFile} from './ChooseMapFile';
 import {CustomMapDetails} from './CustomMapDetails';
@@ -130,10 +131,12 @@ export function BackgroundMapsScreen() {
   return (
     <>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.aboutText}>{t(m.about)}</Text>
+        <HeaderText variant="header2" style={styles.aboutText}>
+          {t(m.about)}
+        </HeaderText>
         <View style={styles.descriptionContainer}>
-          <Text>{t(m.description1)}</Text>
-          <Text>{t(m.description2)}</Text>
+          <BodyText>{t(m.description1)}</BodyText>
+          <BodyText>{t(m.description2)}</BodyText>
         </View>
 
         <CustomMapInfoSection
@@ -172,18 +175,20 @@ export function BackgroundMapsScreen() {
 
         {customMapInfoQuery.status === 'error' && (
           <>
-            <Text style={styles.infoLoadErrorText}>
+            <BodyText variant="large" style={styles.infoLoadErrorText}>
               {t(m.customMapInfoLoadError)}
-            </Text>
+            </BodyText>
             <Button
               fullWidth
               variant="outlined"
               onPress={() => {
                 removeCustomMapMutation.mutate();
               }}>
-              <Text style={styles.removeMapFileButtonText}>
+              <HeaderText
+                variant="header5"
+                style={styles.removeMapFileButtonText}>
                 {t(m.removeMapFile)}
-              </Text>
+              </HeaderText>
             </Button>
           </>
         )}
@@ -325,22 +330,16 @@ const styles = StyleSheet.create({
   },
   aboutText: {
     textAlign: 'center',
-    fontWeight: 'bold',
-    fontSize: 36,
-    color: DARK_GREY,
   },
   infoLoadErrorText: {
     textAlign: 'center',
     color: RED,
-    fontSize: 20,
   },
   removeMapFileButton: {
     backgroundColor: RED,
   },
   removeMapFileButtonText: {
-    fontWeight: '700',
     letterSpacing: 0.5,
-    fontSize: 18,
     color: RED,
   },
 });

--- a/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
+++ b/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
@@ -206,8 +206,11 @@ export function BackgroundMapsScreen() {
               text: t(m.deleteMapButtonText),
               icon: <MaterialIcon size={30} name="delete" color={WHITE} />,
               onPress: () => {
-                removeCustomMapMutation.mutate();
-                removeMapBottomSheet.closeSheet();
+                removeCustomMapMutation.mutate(undefined, {
+                  onSuccess: () => {
+                    removeMapBottomSheet.closeSheet();
+                  },
+                });
               },
             },
             {

--- a/src/frontend/screens/Settings/MapManagement/ChooseMapFile.tsx
+++ b/src/frontend/screens/Settings/MapManagement/ChooseMapFile.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {StyleSheet, View} from 'react-native';
 
-import {MEDIUM_GREY, RED} from '../../../lib/styles';
+import {NEW_DARK_GREY, RED} from '../../../lib/styles';
 import {Button} from '../../../sharedComponents/Button';
-import {Text} from '../../../sharedComponents/Text';
 import {DownloadIcon} from '../../../sharedComponents/icons';
+import {HeaderText} from '../../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../../sharedComponents/Text/BodyText';
 
 const m = defineMessages({
   chooseFile: {
@@ -27,14 +28,19 @@ export function ChooseMapFile({onChooseFile}: {onChooseFile: () => void}) {
         <View style={styles.buttonContentContainer}>
           <DownloadIcon size={24} />
           <View>
-            <Text style={styles.buttonTextBase}>
+            <HeaderText variant="header5" style={styles.buttonTextBase}>
               {t(m.chooseFile)}
-              <Text style={styles.asteriskText}> *</Text>
-            </Text>
+              <HeaderText variant="header5" style={styles.asteriskText}>
+                {' '}
+                *
+              </HeaderText>
+            </HeaderText>
           </View>
         </View>
       </Button>
-      <Text style={styles.fileTypeText}>{t(m.acceptedFileTypes)}</Text>
+      <BodyText variant="smallMeta" style={styles.fileTypeText}>
+        {t(m.acceptedFileTypes)}
+      </BodyText>
     </View>
   );
 }
@@ -49,17 +55,13 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   buttonTextBase: {
-    fontWeight: '700',
     letterSpacing: 0.5,
-    fontSize: 18,
   },
   asteriskText: {
-    fontSize: 18,
     color: RED,
   },
   fileTypeText: {
-    color: MEDIUM_GREY,
-    fontSize: 14,
     textAlign: 'center',
+    color: NEW_DARK_GREY,
   },
 });

--- a/src/frontend/screens/Settings/MapManagement/CustomMapDetails.tsx
+++ b/src/frontend/screens/Settings/MapManagement/CustomMapDetails.tsx
@@ -4,9 +4,15 @@ import {StyleSheet, View} from 'react-native';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 
 import {bytesToMegabytes} from '../../../lib/bytesToMegabytes';
-import {BLACK, MEDIUM_GREY, RED, VERY_LIGHT_GREY} from '../../../lib/styles';
+import {
+  BLACK,
+  NEW_DARK_GREY,
+  WARNING_RED,
+  VERY_LIGHT_GREY,
+} from '../../../lib/styles';
 import {Loading} from '../../../sharedComponents/Loading';
-import {Text} from '../../../sharedComponents/Text';
+import {BodyText} from '../../../sharedComponents/Text/BodyText';
+import {HeaderText} from '../../../sharedComponents/Text/HeaderText';
 
 const m = defineMessages({
   mapNameColumn: {
@@ -53,34 +59,40 @@ export function CustomMapDetails({
   return (
     <View style={styles.rootContainer}>
       <View style={styles.columnHeadersContainer}>
-        <Text style={styles.columnTitleText}>{t(m.mapNameColumn)}</Text>
-        <Text style={styles.columnTitleText}>{t(m.dateAddedColumn)}</Text>
+        <BodyText variant="smallMeta" style={styles.columnTitleText}>
+          {t(m.mapNameColumn)}
+        </BodyText>
+        <BodyText variant="smallMeta" style={styles.columnTitleText}>
+          {t(m.dateAddedColumn)}
+        </BodyText>
       </View>
       <View style={styles.cardContainer}>
         <View style={styles.cardRow}>
           <View style={styles.columnLeft}>
-            <Text style={styles.nameText}>{name}</Text>
-            <Text style={styles.sizeText}>
+            <HeaderText variant="header5">{name}</HeaderText>
+            <BodyText variant="smallMeta" style={styles.sizeText}>
               {displayedSize !== undefined &&
                 t(m.sizeInMegabytes, {
                   value: displayedSize,
                 })}
-            </Text>
+            </BodyText>
           </View>
           <View style={styles.columnRight}>
-            <Text style={styles.dateAddedText}>
+            <BodyText variant="smallMeta" style={styles.dateAddedText}>
               <FormattedDate
                 year="numeric"
                 month="short"
                 day="2-digit"
                 value={dateAdded}
               />
-            </Text>
+            </BodyText>
           </View>
         </View>
         <View style={styles.cardRow}>
           <TouchableOpacity onPress={onRemove} hitSlop={20}>
-            <Text style={styles.removeMapText}>{t(m.removeMap)}</Text>
+            <BodyText variant="smallMeta" style={styles.removeMapText}>
+              {t(m.removeMap)}
+            </BodyText>
           </TouchableOpacity>
         </View>
         {loading && <LoadingOverlay />}
@@ -119,21 +131,17 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   columnTitleText: {
-    color: MEDIUM_GREY,
+    color: NEW_DARK_GREY,
   },
   dateAddedText: {
-    color: MEDIUM_GREY,
+    color: NEW_DARK_GREY,
   },
   sizeText: {
-    color: MEDIUM_GREY,
+    color: NEW_DARK_GREY,
   },
   removeMapText: {
     fontWeight: 'bold',
-    color: RED,
-  },
-  nameText: {
-    fontWeight: 'bold',
-    fontSize: 18,
+    color: WARNING_RED,
   },
   columnLeft: {
     flex: 1,

--- a/src/frontend/screens/Settings/MapManagement/index.tsx
+++ b/src/frontend/screens/Settings/MapManagement/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import {type NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import {defineMessages, useIntl, type MessageDescriptor} from 'react-intl';
-import {ScrollView} from 'react-native';
-
-import {List, ListItem, ListItemText} from '../../../sharedComponents/List';
 import {type NativeRootNavigationProps} from '../../../sharedTypes/navigation';
+import {FullScreenMenuList} from '../../../sharedComponents/MenuList/FullScreenMenuList';
+import {MenuListItemType} from '../../../sharedComponents/MenuList/MenuListItem';
 
 const m = defineMessages({
   screenTitle: {
@@ -21,18 +20,17 @@ export function MapManagementScreen({
   navigation,
 }: NativeRootNavigationProps<'MapManagement'>) {
   const {formatMessage: t} = useIntl();
-  return (
-    <ScrollView>
-      <List>
-        <ListItem
-          onPress={() => {
-            navigation.navigate('BackgroundMaps');
-          }}>
-          <ListItemText primary={t(m.backgroundMaps)} />
-        </ListItem>
-      </List>
-    </ScrollView>
-  );
+
+  const menuItems: MenuListItemType[] = [
+    {
+      onPress: () => {
+        navigation.navigate('BackgroundMaps');
+      },
+      primaryText: t(m.backgroundMaps),
+    },
+  ];
+
+  return <FullScreenMenuList data={menuItems} />;
 }
 
 export function createNavigationOptions({


### PR DESCRIPTION
closes #833 

### Description
The problem: We were closing the modal immediately after initiating the mutation, but the mutation itself triggers a state change that might cause the modal to re-open. Specifically, the onSuccess handler calls refresh(), which updates the refreshToken and may cause components depending on it to re-render, such as the BackgroundMaps which would then rerender the BottomSheetModal (would still be isOpen true)

Solution: Move the close sheet into the onSuccess handler of removeCustomMapMutation, so the modal closes only after the mutation completes and any state changes settle.

I built an APK to test this because it wasn't happening for me while debugging

### To test
You can download map files from here: https://drive.google.com/drive/folders/19iZUWrlTQIBpqr7MnP0u5E5dmFudJYKt?ths=true if you need to
App Settings -> Map Management -> Background Maps -> Choose File
Hit Close once the modal appears
UI Box with Map and Date should be on the screen
Hit Remove Map -> Delete Map
Modal should close and Box with Map should no longer be there
If you go to the map screen it should be back to the default map
