### PR TITLE
Fix: share button sometimes not working after first share

### DIFF
--- a/src/frontend/lib/attachmentTypeChecks.ts
+++ b/src/frontend/lib/attachmentTypeChecks.ts
@@ -81,3 +81,7 @@ export function isDraftPhoto(attachment: any): attachment is DraftPhoto {
 export function isPhoto(attachment: any): attachment is Photo {
   return isSavedPhoto(attachment) || isDraftPhoto(attachment);
 }
+
+export function isPhotoOrAudio(attachment: any): attachment is Photo | Audio {
+  return isSavedPhoto(attachment) || isAudioAttachment(attachment);
+}

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -6,7 +6,6 @@ import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import {defineMessages, useIntl} from 'react-intl';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeleteObservation} from '../../hooks/server/observations';
-import {Text} from '../../sharedComponents/Text';
 import Share from 'react-native-share';
 import {useObservationWithPreset} from '../../hooks/useObservationWithPreset.ts';
 import {formatCoords} from '../../lib/utils.ts';
@@ -17,6 +16,8 @@ import * as Sentry from '@sentry/react-native';
 import {CoordinateFormat} from '../../sharedTypes/index.ts';
 import {getValueLabel} from '../../sharedComponents/FormattedData.tsx';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
+import {isPhotoOrAudio} from '../../lib/attachmentTypeChecks.ts';
 
 const m = defineMessages({
   delete: {
@@ -120,27 +121,16 @@ export const ButtonFields = ({
       return [];
     }
 
-    const urls = await Promise.all(
-      attachments.map(async attachment => {
-        if (attachment.type !== 'photo' && attachment.type !== 'audio') {
-          return [];
-        }
-
-        try {
-          const url = await projectApi.$blobs.getUrl({
-            driveId: attachment.driveDiscoveryId,
-            name: attachment.name,
-            type: attachment.type,
-            variant: 'original',
-          });
-          return url;
-        } catch (error) {
-          return null;
-        }
+    return await Promise.all(
+      attachments.filter(isPhotoOrAudio).map(async attachment => {
+        return projectApi.$blobs.getUrl({
+          driveId: attachment.driveDiscoveryId,
+          name: attachment.name,
+          type: attachment.type as 'photo' | 'audio',
+          variant: 'original',
+        });
       }),
     );
-
-    return urls.filter((url): url is string => url !== null);
   }
 
   async function handlePressShare() {
@@ -230,7 +220,9 @@ const Button = ({onPress, isLoading, iconName, title}: ButtonProps) => (
           style={styles.buttonIcon}
         />
       )}
-      <Text style={styles.buttonText}>{title}</Text>
+      <BodyText variant="smallMeta" style={styles.buttonText}>
+        {title}
+      </BodyText>
     </View>
   </TouchableOpacity>
 );

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Alert, StyleSheet, TouchableOpacity, View} from 'react-native';
 import {Field, Observation} from '@comapeo/schema';
 import {DARK_GREY} from '../../lib/styles';
@@ -8,16 +8,15 @@ import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeleteObservation} from '../../hooks/server/observations';
 import {Text} from '../../sharedComponents/Text';
 import Share from 'react-native-share';
-import {useAttachmentUrlQueries} from '../../hooks/server/media.ts';
 import {useObservationWithPreset} from '../../hooks/useObservationWithPreset.ts';
 import {formatCoords} from '../../lib/utils.ts';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {convertUrlToBase64} from '../../utils/base64.ts';
-import {useState} from 'react';
 import {usePersistedSettings} from '../../hooks/persistedState/usePersistedSettings.ts';
 import * as Sentry from '@sentry/react-native';
 import {CoordinateFormat} from '../../sharedTypes/index.ts';
 import {getValueLabel} from '../../sharedComponents/FormattedData.tsx';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
 const m = defineMessages({
   delete: {
@@ -95,11 +94,8 @@ export const ButtonFields = ({
   const deleteObservationMutation = useDeleteObservation();
   const {observation, preset} = useObservationWithPreset(observationId);
   const format = usePersistedSettings(store => store.coordinateFormat);
-  const attachmentUrlQueries = useAttachmentUrlQueries(
-    observation.attachments,
-    'original',
-  );
   const [isShareButtonLoading, setShareButtonLoading] = useState(false);
+  const {projectApi} = useActiveProject();
 
   function handlePressDelete() {
     Alert.alert(t(m.deleteTitle), undefined, [
@@ -117,36 +113,47 @@ export const ButtonFields = ({
     ]);
   }
 
-  async function handlePressShare() {
+  async function fetchFreshUrls() {
     const {attachments} = observation;
-    setShareButtonLoading(true);
-    const getValidUrls = (queries: typeof attachmentUrlQueries) => {
-      const urls = queries
-        .map(query => query.data?.url)
-        .filter((url): url is string => url !== undefined && url !== null);
 
-      return urls;
-    };
-
-    let urls: string[] = [];
-
-    if (attachments.length > 0) {
-      urls = getValidUrls(attachmentUrlQueries);
-
-      if (urls.length === 0) {
-        setShareButtonLoading(false);
-        Alert.alert('Error', 'Unable to share this observation.');
-        return;
-      }
+    if (!attachments || attachments.length === 0) {
+      return [];
     }
 
+    const urls = await Promise.all(
+      attachments.map(async attachment => {
+        if (attachment.type !== 'photo' && attachment.type !== 'audio') {
+          return [];
+        }
+
+        try {
+          const url = await projectApi.$blobs.getUrl({
+            driveId: attachment.driveDiscoveryId,
+            name: attachment.name,
+            type: attachment.type,
+            variant: 'original',
+          });
+          return url;
+        } catch (error) {
+          return null;
+        }
+      }),
+    );
+
+    return urls.filter((url): url is string => url !== null);
+  }
+
+  async function handlePressShare() {
+    setShareButtonLoading(true);
+
     try {
-      const base64Urls = await Promise.all(
-        urls.map(url => convertUrlToBase64(url)),
-      );
+      const urls = await fetchFreshUrls();
+      const base64Urls =
+        urls.length > 0
+          ? await Promise.all(urls.map(url => convertUrlToBase64(url)))
+          : [];
 
       const completedFields: Array<{label: string; value: string}> = [];
-
       for (const field of fields) {
         const value = observation.tags[field.tagKey];
 
@@ -155,9 +162,7 @@ export const ButtonFields = ({
         }
 
         const displayedValue = (Array.isArray(value) ? value : [value])
-          .map(v => {
-            return getValueLabel(v, field).trim();
-          })
+          .map(v => getValueLabel(v, field).trim())
           .join(', ');
 
         completedFields.push({label: field.label, value: displayedValue});
@@ -177,6 +182,7 @@ export const ButtonFields = ({
           timestamp: formatDate(observation.createdAt, {format: 'long'}),
           titleText: t(m.shareMessageTitle),
         }),
+        failOnCancel: false,
       });
     } catch (err) {
       Sentry.captureException(err);


### PR DESCRIPTION
closes #834 

### Description

- I came across this when developing Audio
- The urls for the attachments only work once for converting into readable files.
- So, in the Share button, after the first Share was pressed, the network call for converting the url to a base64 image was failing and no amount of time waiting would fix that.
- This PR uses the getUrl query to fetch a new url for each attachment every time the share button is pressed because the hook can't be used in regular functions or conditionally.
- We can't set the base64 in state because technically opening the share menu is putting the app in the background and state would clear out when share is pressed (something else I came across in the Audio development)
- This is working well, so hoping it works for you too!
- I also added failOnCancel: false so there is no error thrown if a user decides not to share the observation

### To test

1. Create an observation or observations with attachments and some without
2. Share them as many times as you want without leaving the observation screen.
3. I can't test on What's App so please test on What's App for me 



