### PR TITLE
Fixes crash when permission is taken away.

### DIFF
--- a/src/frontend/hooks/useFormattedTimeSince.ts
+++ b/src/frontend/hooks/useFormattedTimeSince.ts
@@ -3,7 +3,7 @@ import {Duration} from 'luxon';
 
 export const useFormattedTimeSince = (start: Date | null, interval: number) => {
   const [currentTime, setCurrentTime] = useState(new Date());
-  let startDate = start ? start : new Date();
+  let startDate = start ? new Date(start) : new Date();
 
   useEffect(() => {
     setCurrentTime(new Date());


### PR DESCRIPTION
closes #848 

### Description

- The error that was showing when permission was removed while a track is in progress was `startDate.getTime() is undefined or is not a function.` (or something like that)
- The error is fixed by the change in this PR
- Now you can start a track, revoke permission, go back to the app, and when you click on the Track dude in the bottom tabs, the "Use Your Location" modal pops up.
- The timer is still timing though...
- It looks like the track is continuous but it is hard to tell because the space I have wifi is limited
- This doesn't solve the problem of what to include in the track but it does fix the crash as far as I can tell
- I built it as a release candidate and the behavior was the same -- no crash

