### PR TITLE
chore: remove unused useClearAllPendingInvites hook

### DIFF
--- a/src/frontend/hooks/server/invites.ts
+++ b/src/frontend/hooks/server/invites.ts
@@ -58,24 +58,6 @@ export function useRejectInvite() {
   });
 }
 
-export function useClearAllPendingInvites() {
-  const queryClient = useQueryClient();
-  const mapeoApi = useApi();
-
-  return useMutation({
-    mutationFn: ({inviteIds}: {inviteIds: Array<string>}) => {
-      return Promise.all(
-        inviteIds.map(id => mapeoApi.invite.reject({inviteId: id})),
-      );
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [INVITE_KEY],
-      });
-    },
-  });
-}
-
 export function useSendInvite() {
   const queryClient = useQueryClient();
   const {projectApi} = useActiveProject();


### PR DESCRIPTION
Noticed this hook is no longer used in the codebase so it should be safe to remove.