### PR TITLE
fix: project leaving inconsistencies

### DIFF
--- a/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
@@ -60,7 +60,7 @@ export const Content = ({
     <View
       style={[
         styles.container,
-        fullScreen ? {height: '100%'} : {maxHeight: window.height * 0.8},
+        fullScreen ? {height: window.height} : {maxHeight: window.height * 0.8},
       ]}>
       <View style={[styles.infoContainer, fullScreen && {flex: 1}]}>
         {icon ? <View style={styles.iconContainer}>{icon}</View> : null}

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -51,6 +51,7 @@ export const ProjectInviteBottomSheet = ({
 
   const [leaveModalState, setLeaveModalState] =
     React.useState<LeaveProjectModalState>('AlreadyOnProj');
+  const [modalVisible, setModalVisible] = React.useState(false);
 
   const invite = invites[0];
 
@@ -64,9 +65,23 @@ export const ProjectInviteBottomSheet = ({
   const accept = useAcceptInvite();
   const reject = useRejectInvite();
 
-  if (invite && !inviteIsOpen && enabledForCurrentScreen) {
-    openInviteSheet();
-  }
+  React.useEffect(() => {
+    if (
+      (invite || acceptedInvite) &&
+      !modalVisible &&
+      enabledForCurrentScreen
+    ) {
+      setModalVisible(true);
+    }
+  }, [invite, acceptedInvite, modalVisible, enabledForCurrentScreen]);
+
+  React.useEffect(() => {
+    if (modalVisible && !inviteIsOpen) {
+      openInviteSheet();
+    } else if (!modalVisible && inviteIsOpen) {
+      closeInviteSheet();
+    }
+  }, [modalVisible, inviteIsOpen, openInviteSheet, closeInviteSheet]);
 
   if (currentInviteCanceled && leaveIsOpen) {
     closeLeaveSheet();
@@ -77,20 +92,20 @@ export const ProjectInviteBottomSheet = ({
       reject.mutate(invite, {
         onSuccess: () => {
           if (invites.length <= 1) {
-            closeInviteSheet();
+            setModalVisible(false);
           }
         },
       });
     }
     if (invites.length <= 1) {
-      closeInviteSheet();
+      setModalVisible(false);
     }
   }
 
   function handleCanceledInvite() {
     resetCacheAndClearCanceled();
     if (invites.length <= 1) {
-      closeInviteSheet();
+      setModalVisible(false);
     }
   }
 
@@ -115,6 +130,7 @@ export const ProjectInviteBottomSheet = ({
           accept.reset();
           reject.reset();
           acceptedInvite?.remove();
+          setModalVisible(false);
         }}>
         {currentInviteCanceled ? (
           <InviteCanceledBottomSheetContent
@@ -123,7 +139,9 @@ export const ProjectInviteBottomSheet = ({
           />
         ) : acceptedInvite ? (
           <InviteSuccessBottomSheetContent
-            closeSheet={closeInviteSheet}
+            closeSheet={() => {
+              setModalVisible(false);
+            }}
             projectName={acceptedInvite.value.projectName}
           />
         ) : (

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -51,7 +51,7 @@ export const ProjectInviteBottomSheet = ({
 
   const [leaveModalState, setLeaveModalState] =
     React.useState<LeaveProjectModalState>('AlreadyOnProj');
-  const [modalVisible, setModalVisible] = React.useState(false);
+  const [inviteModalVisible, setInviteModalVisible] = React.useState(false);
 
   const invite = invites[0];
 
@@ -68,20 +68,20 @@ export const ProjectInviteBottomSheet = ({
   React.useEffect(() => {
     if (
       (invite || acceptedInvite) &&
-      !modalVisible &&
+      !inviteModalVisible &&
       enabledForCurrentScreen
     ) {
-      setModalVisible(true);
+      setInviteModalVisible(true);
     }
-  }, [invite, acceptedInvite, modalVisible, enabledForCurrentScreen]);
+  }, [invite, acceptedInvite, inviteModalVisible, enabledForCurrentScreen]);
 
   React.useEffect(() => {
-    if (modalVisible && !inviteIsOpen) {
+    if (inviteModalVisible && !inviteIsOpen) {
       openInviteSheet();
-    } else if (!modalVisible && inviteIsOpen) {
+    } else if (!inviteModalVisible && inviteIsOpen) {
       closeInviteSheet();
     }
-  }, [modalVisible, inviteIsOpen, openInviteSheet, closeInviteSheet]);
+  }, [inviteModalVisible, inviteIsOpen, openInviteSheet, closeInviteSheet]);
 
   if (currentInviteCanceled && leaveIsOpen) {
     closeLeaveSheet();
@@ -92,20 +92,20 @@ export const ProjectInviteBottomSheet = ({
       reject.mutate(invite, {
         onSuccess: () => {
           if (invites.length <= 1) {
-            setModalVisible(false);
+            setInviteModalVisible(false);
           }
         },
       });
     }
     if (invites.length <= 1) {
-      setModalVisible(false);
+      setInviteModalVisible(false);
     }
   }
 
   function handleCanceledInvite() {
     resetCacheAndClearCanceled();
     if (invites.length <= 1) {
-      setModalVisible(false);
+      setInviteModalVisible(false);
     }
   }
 
@@ -130,7 +130,7 @@ export const ProjectInviteBottomSheet = ({
           accept.reset();
           reject.reset();
           acceptedInvite?.remove();
-          setModalVisible(false);
+          setInviteModalVisible(false);
         }}>
         {currentInviteCanceled ? (
           <InviteCanceledBottomSheetContent
@@ -140,7 +140,7 @@ export const ProjectInviteBottomSheet = ({
         ) : acceptedInvite ? (
           <InviteSuccessBottomSheetContent
             closeSheet={() => {
-              setModalVisible(false);
+              setInviteModalVisible(false);
             }}
             projectName={acceptedInvite.value.projectName}
           />


### PR DESCRIPTION
closes #832 
### Description
- The invite modal was closing prematurely, causing the success modal to flash and disappear when a user accepted an invite while already on a project, so users couldn't see the confirmation of their accepted invite.
- The cause of the issue was the way the modal's visibility was being controlled. The isOpen prop of the BottomSheetModal was directly tied to state variables that changed during the invite acceptance process, specifically invite, acceptedInvite, and accept.status. Here's what was happening:
  -  When the invite was accepted, the invite became undefined, and accept.status changed from 'pending' to 'success'.
  - Due to these state changes, the isOpen prop evaluated to false, causing the modal to close before the success modal could be displayed.
### Things I tried that didn't work
- Including accept.status === 'success' and then eventually accept.status==='pending' also in isOpen: I modified the conditions controlling the modal's visibility to include the accepts statueses. This approach was intended to keep the modal open during the transition. However, it didn't fully resolve the issue because the state changes still caused the modal to close unexpectedly.
- I tried so many different dependencies in the useEffect hook/ useEffect hooks to settle on the ones that finally worked.
- Controlling Modal Visibility with shouldShowInviteModal: I introduced a new state variable shouldShowInviteModal to manage the modal's visibility. While this improved control, the modal didn't open as expected because the BottomSheetModal component didn't automatically open or close when the isOpen prop changed. It relies on imperative methods like openSheet() and closeSheet().
- Attempting to Remove the isOpen Prop: I tried removing the isOpen prop from the BottomSheetModal to prevent conflicts. However, this broke functionalities like the back handler, which relies on isOpen.

### Solution
- I introduced inviteModalVisible as a state variable to be the single source of truth for whether the invite modal should be visible.
- I then added the useEffect hook to ensure that the modal becomes visible when there's an invite or acceptedInvite, and the user is on the appropriate screen.
- The second hook synchronizes the modal's actual open state (inviteIsOpen) with our inviteModalVisible state.
- We only set inviteModalVisible to false only when the modal is dismissed by the user and when someone rejects an invite, preventing unexpected closures.

Now there is no flashing or disappearing!


### Bonus!
Something with the changes we made to the npm packages with the modal or the animations made it so the fullSheet for the modal wasn't always working for my devices. This change I made fixed the problem.




