### PR TITLE
fix: removes audio from observation sharing

### DIFF
--- a/src/frontend/lib/attachmentTypeChecks.ts
+++ b/src/frontend/lib/attachmentTypeChecks.ts
@@ -81,7 +81,3 @@ export function isDraftPhoto(attachment: any): attachment is DraftPhoto {
 export function isPhoto(attachment: any): attachment is Photo {
   return isSavedPhoto(attachment) || isDraftPhoto(attachment);
 }
-
-export function isPhotoOrAudio(attachment: any): attachment is Photo | Audio {
-  return isSavedPhoto(attachment) || isAudioAttachment(attachment);
-}

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -17,7 +17,7 @@ import {CoordinateFormat} from '../../sharedTypes/index.ts';
 import {getValueLabel} from '../../sharedComponents/FormattedData.tsx';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
-import {isPhotoOrAudio} from '../../lib/attachmentTypeChecks.ts';
+import {isSavedPhoto} from '../../lib/attachmentTypeChecks.ts';
 
 const m = defineMessages({
   delete: {
@@ -120,13 +120,17 @@ export const ButtonFields = ({
     if (!attachments || attachments.length === 0) {
       return [];
     }
+    const photoAttachments = attachments.filter(isSavedPhoto);
+    if (photoAttachments.length === 0) {
+      return [];
+    }
 
     return await Promise.all(
-      attachments.filter(isPhotoOrAudio).map(async attachment => {
+      photoAttachments.map(async attachment => {
         return projectApi.$blobs.getUrl({
           driveId: attachment.driveDiscoveryId,
           name: attachment.name,
-          type: attachment.type as 'photo' | 'audio',
+          type: 'photo',
           variant: 'original',
         });
       }),


### PR DESCRIPTION
closes #812 
See issue for explanation.
From Gregor in Slack:

> This issue was discussed during co-design, and the limitation of being unable to share audio along with an observation was clearly explained, and that is why we added the ability to share audio attachments individually as a work-around / compromise. It does seem perhaps that that previous conversation has been forgotten - I tried to be very clear from the start that we would be unable to reliably support sending an observation with audio attachments via whatsapp. 

And Jen's response:

> I will need to dig into issues in coming days, but even if it is a known issue for whatsapp share, adding audio should not degrade the ability to send an observation with the photos, excluding audio files.

So, this PR removes audio attachments from being shared. At this point, the only type of attachments to share is of type photo, so the function focuses on just photos.