### PR TITLE
fix: simplify technical implementation of importing custom map file

### DIFF
--- a/src/frontend/hooks/server/maps.ts
+++ b/src/frontend/hooks/server/maps.ts
@@ -47,7 +47,7 @@ export function useImportCustomMapFile() {
 
   return useMutation({
     mutationFn: async (opts: {uri: string}) => {
-      await FileSystem.moveAsync({
+      await FileSystem.copyAsync({
         from: opts.uri,
         to: DEFAULT_CUSTOM_MAP_FILE_PATH,
       });

--- a/src/frontend/lib/file-system.ts
+++ b/src/frontend/lib/file-system.ts
@@ -28,17 +28,22 @@ export async function selectFile(opts: {
     throw new Error();
   }
 
-  const hasValidExtension = opts.extensionFilters
-    ? opts.extensionFilters.some(extension =>
-        asset.uri.endsWith(`.${extension}`),
-      )
-    : true;
-
-  if (!hasValidExtension) {
-    FileSystem.deleteAsync(asset.uri).catch(err => {
-      console.log(err);
+  if (opts.extensionFilters) {
+    const hasValidExtension = opts.extensionFilters.some(extension => {
+      return asset.name.endsWith(`.${extension}`);
     });
-    throw new Error('Invalid extension');
+
+    if (!hasValidExtension) {
+      if (opts.copyToCache) {
+        FileSystem.deleteAsync(asset.uri, {
+          idempotent: true,
+        }).catch(err => {
+          console.log(err);
+        });
+      }
+
+      throw new Error('Invalid extension');
+    }
   }
 
   return asset;

--- a/src/frontend/lib/file-system.ts
+++ b/src/frontend/lib/file-system.ts
@@ -9,14 +9,16 @@ export function convertFileUriToPosixPath(fileUri: string) {
 }
 
 // TODO: Some overlap with selectFile() from lib/utils but fixes some usage limitations. Ideally use this for everything
-export async function selectFile(opts: {
-  copyToCache?: boolean;
+export async function selectFile({
+  mimeFilters,
+  extensionFilters,
+}: {
   mimeFilters?: Array<string>;
   extensionFilters?: Array<string>;
-}) {
+} = {}) {
   const documentResult = await DocumentPicker.getDocumentAsync({
-    type: opts.mimeFilters,
-    copyToCacheDirectory: opts.copyToCache,
+    type: mimeFilters,
+    copyToCacheDirectory: false,
     multiple: false,
   });
 
@@ -28,20 +30,12 @@ export async function selectFile(opts: {
     throw new Error();
   }
 
-  if (opts.extensionFilters) {
-    const hasValidExtension = opts.extensionFilters.some(extension => {
+  if (extensionFilters) {
+    const hasValidExtension = extensionFilters.some(extension => {
       return asset.name.endsWith(`.${extension}`);
     });
 
     if (!hasValidExtension) {
-      if (opts.copyToCache) {
-        FileSystem.deleteAsync(asset.uri, {
-          idempotent: true,
-        }).catch(err => {
-          console.log(err);
-        });
-      }
-
       throw new Error('Invalid extension');
     }
   }

--- a/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
+++ b/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
@@ -1,5 +1,4 @@
 import {type NativeStackNavigationOptions} from '@react-navigation/native-stack';
-import * as FileSystem from 'expo-file-system';
 import React from 'react';
 import {defineMessages, useIntl, type MessageDescriptor} from 'react-intl';
 import {ScrollView, StyleSheet, View} from 'react-native';
@@ -13,7 +12,6 @@ import {
 } from '../../../hooks/server/maps';
 import ErrorSvg from '../../../images/Error.svg';
 import GreenCheckSvg from '../../../images/GreenCheck.svg';
-import noop from '../../../lib/noop';
 import {RED, WHITE} from '../../../lib/styles';
 import {
   BottomSheetModal,
@@ -143,6 +141,7 @@ export function BackgroundMapsScreen() {
           onChooseFile={() => {
             selectFileMutation.mutate(
               {
+                copyToCache: false,
                 extensionFilters: ['smp'],
               },
               {
@@ -154,11 +153,6 @@ export function BackgroundMapsScreen() {
                       uri: asset.uri,
                     },
                     {
-                      onError: () => {
-                        FileSystem.deleteAsync(asset.uri, {
-                          idempotent: true,
-                        }).catch(noop);
-                      },
                       onSuccess: () => {
                         mapAddedBottomSheet.openSheet();
                       },

--- a/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
+++ b/src/frontend/screens/Settings/MapManagement/BackgroundMaps.tsx
@@ -141,7 +141,6 @@ export function BackgroundMapsScreen() {
           onChooseFile={() => {
             selectFileMutation.mutate(
               {
-                copyToCache: false,
                 extensionFilters: ['smp'],
               },
               {


### PR DESCRIPTION
The previous approach:

1. Pick a map file via the file picker, which **_copies the file to the app's cache storage_**.
2. If valid, **_move_** the file from the cache storage into the app's document storage.

Both steps have a performance overhead that is most noticeable when working with large files. The overhead in (1) is something we've run into before. The issue in (2) is more theoretical, with the suspicion that potentially expensive deletions need to happen internally when moving a file from one storage directory.

This PR changes the approach to the following:

1. Pick a map file via the file picker, which no longer copies it into the cache storage.
2. **_Copy_** the selected file into the app document storage using the SAF uri, which represents the original location of the selected file.

This should have no user-facing impact, aside from potential performance improvements due to doing less work internally.