### PR TITLE
chore: update `@comapeo/core` to v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "@babel/core": "^7.20.0",
         "@babel/preset-env": "^7.20.0",
         "@babel/runtime": "^7.20.0",
-        "@comapeo/core": "2.1.0",
+        "@comapeo/core": "2.2.0",
         "@comapeo/schema": "1.2.0",
         "@formatjs/cli": "^6.2.0",
         "@react-native-community/cli": "^12.3.6",
@@ -2399,9 +2399,9 @@
       "license": "MIT"
     },
     "node_modules/@comapeo/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-Fvi/EO1RJIQfpmKFUs4QApM2TsV8JrKw3HbNZ3hmlXiPl1oVVvIce0KkfdPJOoYHbEznTc9dIN1A2vkaoi431A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-ugxpgboXIxkG2hqcrrAAD94dF6yhTfVlouB+p0R3TRyIdERHWIZKMvalxut/rp44RjUAi/aQsW7JmoqBu7rHzg==",
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
@@ -2413,6 +2413,7 @@
         "@mapeo/crypto": "1.0.0-alpha.10",
         "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
         "@sinclair/typebox": "^0.29.6",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "b4a": "^1.6.3",
         "bcp-47": "^2.1.0",
         "better-sqlite3": "^8.7.0",
@@ -2450,6 +2451,7 @@
         "tiny-typed-emitter": "^2.1.0",
         "type-fest": "^4.5.0",
         "undici": "^6.13.0",
+        "unix-path-resolve": "^1.0.2",
         "varint": "^6.0.0",
         "ws": "^8.18.0",
         "yauzl-promise": "^4.0.0"
@@ -8124,6 +8126,18 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@comapeo/core": "2.1.0",
+    "@comapeo/core": "2.2.0",
     "@comapeo/schema": "1.2.0",
     "@formatjs/cli": "^6.2.0",
     "@react-native-community/cli": "^12.3.6",

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@comapeo/core": "2.1.0",
+        "@comapeo/core": "2.2.0",
         "@comapeo/ipc": "2.0.2",
         "@mapeo/default-config": "5.0.0",
         "debug": "^4.3.4"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@comapeo/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-Fvi/EO1RJIQfpmKFUs4QApM2TsV8JrKw3HbNZ3hmlXiPl1oVVvIce0KkfdPJOoYHbEznTc9dIN1A2vkaoi431A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-ugxpgboXIxkG2hqcrrAAD94dF6yhTfVlouB+p0R3TRyIdERHWIZKMvalxut/rp44RjUAi/aQsW7JmoqBu7rHzg==",
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
@@ -70,6 +70,7 @@
         "@mapeo/crypto": "1.0.0-alpha.10",
         "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
         "@sinclair/typebox": "^0.29.6",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "b4a": "^1.6.3",
         "bcp-47": "^2.1.0",
         "better-sqlite3": "^8.7.0",
@@ -107,6 +108,7 @@
         "tiny-typed-emitter": "^2.1.0",
         "type-fest": "^4.5.0",
         "undici": "^6.13.0",
+        "unix-path-resolve": "^1.0.2",
         "varint": "^6.0.0",
         "ws": "^8.18.0",
         "yauzl-promise": "^4.0.0"
@@ -1272,6 +1274,18 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
       "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ==",
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@tsconfig/node16": {
       "version": "16.1.1",
@@ -6875,9 +6889,9 @@
       }
     },
     "@comapeo/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-Fvi/EO1RJIQfpmKFUs4QApM2TsV8JrKw3HbNZ3hmlXiPl1oVVvIce0KkfdPJOoYHbEznTc9dIN1A2vkaoi431A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-ugxpgboXIxkG2hqcrrAAD94dF6yhTfVlouB+p0R3TRyIdERHWIZKMvalxut/rp44RjUAi/aQsW7JmoqBu7rHzg==",
       "requires": {
         "@comapeo/fallback-smp": "^1.0.0",
         "@comapeo/schema": "1.2.0",
@@ -6888,6 +6902,7 @@
         "@mapeo/crypto": "1.0.0-alpha.10",
         "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
         "@sinclair/typebox": "^0.29.6",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "b4a": "^1.6.3",
         "bcp-47": "^2.1.0",
         "better-sqlite3": "^8.7.0",
@@ -6925,6 +6940,7 @@
         "tiny-typed-emitter": "^2.1.0",
         "type-fest": "^4.5.0",
         "undici": "^6.13.0",
+        "unix-path-resolve": "^1.0.2",
         "varint": "^6.0.0",
         "ws": "^8.18.0",
         "yauzl-promise": "^4.0.0"
@@ -7699,6 +7715,11 @@
       "version": "0.29.6",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
       "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
+    },
+    "@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
     },
     "@tsconfig/node16": {
       "version": "16.1.1",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -13,7 +13,7 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "dependencies": {
-    "@comapeo/core": "2.1.0",
+    "@comapeo/core": "2.2.0",
     "@comapeo/ipc": "2.0.2",
     "@mapeo/default-config": "5.0.0",
     "debug": "^4.3.4"


### PR DESCRIPTION
This updates `@comapeo/core` to v2.2.0. This version includes:

- Feature: `MapeoManager.prototype.getIsArchiveDevice()` and `MapeoManager.prototype.setIsArchiveDevice(bool)` now fully work.

- Feature: handle some more errors from remote archive servers.

- Fix: only the project creator can change their role.
