### PR TITLE
fix: audio permission modal

### DIFF
--- a/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
+++ b/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
@@ -103,24 +103,22 @@ export const PermissionAudioBottomSheetContent: FC<
         : t(m.allowButtonText);
 
   return (
-    <View style={{paddingTop: 80}}>
-      <BottomSheetModalContent
-        icon={<AudioPermission />}
-        title={t(m.title)}
-        description={t(m.description)}
-        buttonConfigs={[
-          {
-            variation: 'outlined',
-            onPress: closeSheet,
-            text: t(m.notNowButtonText),
-          },
-          {
-            variation: 'filled',
-            onPress: onPressActionButton,
-            text: actionButtonText,
-          },
-        ]}
-      />
-    </View>
+    <BottomSheetModalContent
+      icon={<AudioPermission />}
+      title={t(m.title)}
+      description={t(m.description)}
+      buttonConfigs={[
+        {
+          variation: 'outlined',
+          onPress: closeSheet,
+          text: t(m.notNowButtonText),
+        },
+        {
+          variation: 'filled',
+          onPress: onPressActionButton,
+          text: actionButtonText,
+        },
+      ]}
+    />
   );
 };

--- a/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
@@ -60,7 +60,7 @@ export const Content = ({
     <View
       style={[
         styles.container,
-        fullScreen ? {height: window.height} : {maxHeight: window.height * 0.8},
+        fullScreen ? {height: '100%'} : {maxHeight: window.height * 0.8},
       ]}>
       <View style={[styles.infoContainer, fullScreen && {flex: 1}]}>
         {icon ? <View style={styles.iconContainer}>{icon}</View> : null}

--- a/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
@@ -60,7 +60,7 @@ export const Content = ({
     <View
       style={[
         styles.container,
-        fullScreen ? {height: '100%'} : {maxHeight: window.height * 0.8},
+        fullScreen ? {height: window.height} : {maxHeight: window.height * 0.8},
       ]}>
       <View style={[styles.infoContainer, fullScreen && {flex: 1}]}>
         {icon ? <View style={styles.iconContainer}>{icon}</View> : null}


### PR DESCRIPTION
closes #863 
When I was testing modals before, the full sheet modal was not acting like a full sheet (it was only taking up half the screen), so I changed the height property, thinking it related to our update of the modal package.
However, now it seems like using that change, window.height, makes the audio permission modal more than full sheet and some of its contents are off the screen, which makes the modal unusable.
So, this PR takes the padding off the top of that modal so it fits on the screen
FYI, I tested all of the fullSheet size modals and the Audio Permission was the only one that wasn't fitting.