### PR TITLE
fix: audio permission modal spacing hiding button (#865)

### DIFF
--- a/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
+++ b/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
@@ -103,24 +103,22 @@ export const PermissionAudioBottomSheetContent: FC<
         : t(m.allowButtonText);
 
   return (
-    <View style={{paddingTop: 80}}>
-      <BottomSheetModalContent
-        icon={<AudioPermission />}
-        title={t(m.title)}
-        description={t(m.description)}
-        buttonConfigs={[
-          {
-            variation: 'outlined',
-            onPress: closeSheet,
-            text: t(m.notNowButtonText),
-          },
-          {
-            variation: 'filled',
-            onPress: onPressActionButton,
-            text: actionButtonText,
-          },
-        ]}
-      />
-    </View>
+    <BottomSheetModalContent
+      icon={<AudioPermission />}
+      title={t(m.title)}
+      description={t(m.description)}
+      buttonConfigs={[
+        {
+          variation: 'outlined',
+          onPress: closeSheet,
+          text: t(m.notNowButtonText),
+        },
+        {
+          variation: 'filled',
+          onPress: onPressActionButton,
+          text: actionButtonText,
+        },
+      ]}
+    />
   );
 };


### PR DESCRIPTION
* Fixes full sheet on bottom sheet modal back

* Undoes last change. Takes out padding so permission audio fits.