### PR TITLE
fix: sizing of full screen modal

### DIFF
--- a/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
+++ b/src/frontend/screens/Audio/PermissionAudioBottomSheetContent.tsx
@@ -103,22 +103,24 @@ export const PermissionAudioBottomSheetContent: FC<
         : t(m.allowButtonText);
 
   return (
-    <BottomSheetModalContent
-      icon={<AudioPermission />}
-      title={t(m.title)}
-      description={t(m.description)}
-      buttonConfigs={[
-        {
-          variation: 'outlined',
-          onPress: closeSheet,
-          text: t(m.notNowButtonText),
-        },
-        {
-          variation: 'filled',
-          onPress: onPressActionButton,
-          text: actionButtonText,
-        },
-      ]}
-    />
+    <View style={{paddingTop: 80}}>
+      <BottomSheetModalContent
+        icon={<AudioPermission />}
+        title={t(m.title)}
+        description={t(m.description)}
+        buttonConfigs={[
+          {
+            variation: 'outlined',
+            onPress: closeSheet,
+            text: t(m.notNowButtonText),
+          },
+          {
+            variation: 'filled',
+            onPress: onPressActionButton,
+            text: actionButtonText,
+          },
+        ]}
+      />
+    </View>
   );
 };

--- a/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
@@ -60,7 +60,7 @@ export const Content = ({
     <View
       style={[
         styles.container,
-        fullScreen ? {height: window.height} : {maxHeight: window.height * 0.8},
+        fullScreen ? {height: '100%'} : {maxHeight: window.height * 0.8},
       ]}>
       <View style={[styles.infoContainer, fullScreen && {flex: 1}]}>
         {icon ? <View style={styles.iconContainer}>{icon}</View> : null}

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -92,6 +92,7 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
     return (
       <RNBottomSheetModal
         enableDynamicSizing
+        snapPoints={fullScreen ? ['100%'] : undefined}
         ref={ref}
         backgroundStyle={
           fullScreen ? styles.backgroundFullScreen : styles.backgroundDynamic


### PR DESCRIPTION
closes #875 

- Adds snappoints prop to bottom sheet modal to help sizing on full screen modals.
- The original issue was that the project invite sheet wasn't occupying the full screen when fullScreen was true, so a user couldn't see or check the box that is in there
- If we set snapPoints={['100%']} when fullScreen is true that makes the modal "snap to" 100% of the screen height, so now the modal always occupies the full screen when needed and doesn't affect any other modals

This PR also:

- Reverts modal sizing to 100% so the modals that already were working aren't broken anymore
- Reverts the reversal of the top margin on the audio permission sheet because that is no longer needed

Here is a screen shot of the modal that had been causing the issue that made me change the height in the Content file which caused the other modals to break -- now it is good!

<image src="https://github.com/user-attachments/assets/09868c6b-38f7-4b8e-b5f6-3faec6dc1c06" width="250" />

