### PR TITLE
style: add white background to DrawerMenuIcon

### DIFF
--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -28,7 +28,15 @@ export const HomeHeader: FC<
         <SyncIconCircle testID="MAIN.sync-icon" />
       </IconButton>
       <GPSPill navigation={navigation} />
-      <DrawerMenuIcon style={{marginRight: 20}} onPress={openDrawer} />
+      <View
+        style={{
+          backgroundColor: 'white',
+          borderRadius: 30,
+          marginRight: 20,
+          padding: 5,
+        }}>
+        <DrawerMenuIcon onPress={openDrawer} />
+      </View>
     </View>
   );
 };


### PR DESCRIPTION
Adds a white background to the DrawerMenuIcon to improve visibility and contrast, important for when using a custom background map which makes the button invisible.

Logged issue: https://www.notion.so/digidem/Menu-not-visible-with-satellite-imagery-14a1b08162d580d1a5aef5362d809991?pvs=4

### Before
![comapeo_dark_menu](https://github.com/user-attachments/assets/26c4c09c-2779-423c-8323-d72555fa866d)

### After
![mapeo_background_button](https://github.com/user-attachments/assets/11f031ed-4f11-4c57-9d99-a09e88c145ce)


