### PR TITLE
style: add close icon to DrawerMenuIcon

### DIFF
--- a/src/frontend/Navigation/Drawer.tsx
+++ b/src/frontend/Navigation/Drawer.tsx
@@ -119,6 +119,7 @@ const DrawerContent = ({navigation}: DrawerContentComponentProps) => {
           <DrawerMenuIcon
             style={{alignSelf: 'flex-end', marginRight: 20}}
             onPress={navigation.closeDrawer}
+            close
           />
           {/* This text component is one of the exceptions that does not use the shared text components as requested by Sabella */}
           <Text

--- a/src/frontend/sharedComponents/icons/DrawerMenuIcon.tsx
+++ b/src/frontend/sharedComponents/icons/DrawerMenuIcon.tsx
@@ -6,13 +6,19 @@ import {ViewStyleProp} from '../../sharedTypes';
 export const DrawerMenuIcon = ({
   onPress,
   style,
+  close,
 }: {
   onPress: () => void;
   style?: ViewStyleProp;
+  close?: boolean;
 }) => (
   <TouchableOpacity
     style={[{justifyContent: 'center'}, style]}
     onPress={onPress}>
-    <IonIcon name="menu" size={32} testID="MAIN.drawer-icon" />
+    <IonIcon
+      name={close ? 'close' : 'menu'}
+      size={32}
+      testID="MAIN.drawer-icon"
+    />
   </TouchableOpacity>
 );


### PR DESCRIPTION
Adds a close icon option to the DrawerMenuIcon component, making ui clearer.

![comapeo_close_button](https://github.com/user-attachments/assets/20f744d3-617e-4fe6-bd65-a386d0643be0)
