### PR TITLE
chore: use Invite type directly from core

### DIFF
--- a/src/frontend/hooks/useProjectInvitesListener.ts
+++ b/src/frontend/hooks/useProjectInvitesListener.ts
@@ -2,11 +2,7 @@ import {useCallback, useEffect, useState} from 'react';
 import {useApi} from '../contexts/ApiContext';
 import {useQueryClient} from '@tanstack/react-query';
 import {INVITE_KEY} from './server/invites';
-import {MapBuffers} from '@comapeo/core/dist/types';
-import {
-  InviteInternal,
-  InviteRemovalReason,
-} from '@comapeo/core/dist/invite-api';
+import {Invite, InviteRemovalReason} from '@comapeo/core/dist/invite-api';
 
 export const useProjectInvitesListener = ({
   inviteId,
@@ -25,10 +21,7 @@ export const useProjectInvitesListener = ({
   }, [queryClient]);
 
   useEffect(() => {
-    function shouldInterceptCancel(
-      val: MapBuffers<InviteInternal>,
-      reason: InviteRemovalReason,
-    ) {
+    function shouldInterceptCancel(val: Invite, reason: InviteRemovalReason) {
       if (
         reason === 'canceled' &&
         inviteId === val.inviteId &&

--- a/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
+++ b/src/frontend/sharedComponents/ProjectInviteBottomSheet/index.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import {MapBuffers} from '@comapeo/core/dist/types';
-import {
-  InviteInternal,
-  InviteRemovalReason,
-} from '@comapeo/core/dist/invite-api';
+import {Invite, InviteRemovalReason} from '@comapeo/core/dist/invite-api';
 
 import {BottomSheetModal, useBottomSheetModal} from '../BottomSheetModal';
 import {
@@ -174,14 +170,12 @@ export const ProjectInviteBottomSheet = ({
 
 function useAcceptedInvite() {
   const api = useApi();
-  const [acceptedInvite, setAcceptedInvite] =
-    React.useState<MapBuffers<InviteInternal> | null>(null);
+  const [acceptedInvite, setAcceptedInvite] = React.useState<Invite | null>(
+    null,
+  );
 
   React.useEffect(() => {
-    function onInviteRemoved(
-      invite: MapBuffers<InviteInternal>,
-      reason: InviteRemovalReason,
-    ) {
+    function onInviteRemoved(invite: Invite, reason: InviteRemovalReason) {
       if (reason === 'accepted') {
         setAcceptedInvite(invite);
       }


### PR DESCRIPTION
There were a couple of places where we were using `MapBuffers<InviteInternal>` to represent an invite from core instead of `Invite`. I believe this was because the latter wasn't available/exported for some time, but [now it is](https://github.com/digidem/comapeo-core/blob/f073ca916f573ab66240f35805b4df5ecceb11e4/src/invite-api.js#L28). This PR shouldn't have any user-facing impact as it only replaces type imports.

