### PR TITLE
chore: add workflow for lockfile checks

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,34 @@
+name: Check Lockfile
+on:
+  pull_request:
+
+jobs:
+  lockfile_version:
+    name: Lockfile version check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v4
+      - name: Check package-lock.json version has not been changed
+        uses: mansona/npm-lockfile-version@v1
+        with:
+          version: 3
+  lockfile_changes:
+    name: Lockfile changes check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v4
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.LOCKFILE_BOT_APP_ID }}
+          private-key: ${{ secrets.LOCKFILE_BOT_PRIVATE_KEY }}
+      - name: NPM Lockfile Changes
+        # The original doesn't support v3 lockfiles so we use a fork that adds support for them
+        # The fork doesn't update comments by an app token, so we use our own fork
+        uses: digidem/npm-lockfile-changes@614dfc33742374cb40bec2878e5b690580d11ede
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          updateComment: true


### PR DESCRIPTION
Copies over the workflow we've set up in [core](https://github.com/digidem/comapeo-core/blob/main/.github/workflows/lockfile.yml). On pull requests, it runs a job for each of the following:

1. checking that the lockfile version doesn't change. this usually happens if someone uses an incompatible package manager version to manage dependencies, which we want to prevent

2. highlighting changes in dependencies that the PR introduces, if any, by writing a PR comment with a table

Introducing this will be helpful for avoiding any surprise updates and highlighting intended changes moving forward

---

Note that this only does a check on the top-level lockfile. Ideally this would also account for the backend's lockfile, but haven't fully figured out how to get that working just yet.