### PR TITLE
chore: standardize usage of config files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+/** @type {import('jest').Config} */
+const config = {
+  preset: 'jest-expo',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  setupFilesAfterEnv: ['@rnmapbox/maps/setup-jest'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(...|@rnmapbox|(jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)',
+  ],
+};
+
+module.exports = config;

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+/** @type {import('lint-staged').Config} */
+const config = {
+  '*.{js,ts,jsx,tsx}': 'prettier --write',
+  'src/frontend/**/*.{ts,tsx}': 'npm run extract-messages',
+};
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,7 @@
         "@types/debug": "4.1.12",
         "@types/geojson": "7946.0.15",
         "@types/jest": "29.5.13",
+        "@types/lint-staged": "13.3.0",
         "@types/lodash.isequal": "4.5.6",
         "@types/node": "20.8.4",
         "@types/react": "18.2.60",
@@ -8999,6 +9000,13 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lint-staged": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@types/lint-staged/-/lint-staged-13.3.0.tgz",
+      "integrity": "sha512-WxGjVP+rA4OJlEdbZdT9MS9PFKQ7kVPhLn26gC+2tnBWBEFEj/KW+IbFfz6sxdxY5U6V7BvyF+3BzCGsAMHhNg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -167,23 +167,6 @@
     "type-fest": "4.26.0",
     "typescript": "5.3.3"
   },
-  "jest": {
-    "preset": "jest-expo",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "setupFilesAfterEnv": [
-      "@rnmapbox/maps/setup-jest"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!(...|@rnmapbox|(jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)"
-    ]
-  },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": "prettier --write",
     "src/frontend/**/*.{ts,tsx}": "npm run extract-messages"

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@types/debug": "4.1.12",
     "@types/geojson": "7946.0.15",
     "@types/jest": "29.5.13",
+    "@types/lint-staged": "13.3.0",
     "@types/lodash.isequal": "4.5.6",
     "@types/node": "20.8.4",
     "@types/react": "18.2.60",
@@ -166,9 +167,5 @@
     "semver": "7.6.0",
     "type-fest": "4.26.0",
     "typescript": "5.3.3"
-  },
-  "lint-staged": {
-    "*.{js,ts,jsx,tsx}": "prettier --write",
-    "src/frontend/**/*.{ts,tsx}": "npm run extract-messages"
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,12 @@
-module.exports = {
+// @ts-check
+
+/** @type {import('prettier').Config} */
+const config = {
   arrowParens: 'avoid',
   bracketSameLine: true,
   bracketSpacing: false,
   singleQuote: true,
   trailingComma: 'all',
 };
+
+module.exports = config;


### PR DESCRIPTION
The unofficial convention for configuring different tooling has moved towards having a file named `<name>.config.js` for each tool that supports it. In most cases, tools support a variety of configuration approaches but in general, I prefer using a config file when possible because it allows for types-based checking + assistance when writing/updating the configuration, which is massively useful.

This PR does the following:

- ports the jest configuration from `package.json` to `jest.config.js`
- ports the lint-staged configuration from  `package.json` to `lint-staged.config.js`
- ports the prettier configuration from `.prettierrc.js` to `prettier.config.js`

ESLint is notably omitted here because it requires upgrading to v9 in order to use this config file convention. That work is addressed via #897 