### PR TITLE
fix: observations hidden behind tracks

### DIFF
--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -114,9 +114,9 @@ export const MapScreen = () => {
 
         {isFinishedLoading && (
           <>
-            <ObservationMapLayer />
             <CurrentTrackMapLayer />
             <TracksMapLayer />
+            <ObservationMapLayer />
           </>
         )}
       </Mapbox.MapView>


### PR DESCRIPTION
closes #869 

Changes the order of layers so that the tracks are laid down first and below the observations.
<image src="https://github.com/user-attachments/assets/49cf9929-9e08-42e3-94da-f1278bec1543" width="250" />
