### PR TITLE
chore: clean up translations build script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,6 @@
         "prettier": "3.5.1",
         "react-native-svg-transformer": "1.5.0",
         "react-test-renderer": "18.3.1",
-        "rimraf": "5.0.5",
         "semver": "7.7.1",
         "type-fest": "4.34.1",
         "typescript": "5.7.3",
@@ -28264,25 +28263,6 @@
       "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rpc-reflector": {
       "version": "1.3.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,6 @@
         "eslint-plugin-react-native": "5.0.0",
         "eslint-plugin-testing-library": "7.1.1",
         "execa": "9.5.2",
-        "glob": "10.3.15",
         "globals": "16.0.0",
         "husky": "9.1.7",
         "jest": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "eslint-plugin-react-native": "5.0.0",
     "eslint-plugin-testing-library": "7.1.1",
     "execa": "9.5.2",
-    "glob": "10.3.15",
     "globals": "16.0.0",
     "husky": "9.1.7",
     "jest": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "prettier": "3.5.1",
     "react-native-svg-transformer": "1.5.0",
     "react-test-renderer": "18.3.1",
-    "rimraf": "5.0.5",
     "semver": "7.7.1",
     "type-fest": "4.34.1",
     "typescript": "5.7.3",

--- a/scripts/build-translations.mjs
+++ b/scripts/build-translations.mjs
@@ -4,7 +4,6 @@ import path from 'node:path';
 import fs from 'node:fs';
 import {readFile, writeFile} from 'node:fs/promises';
 import {glob} from 'glob';
-import {rimraf} from 'rimraf';
 
 import LANGUAGE_NAME_TRANSLATIONS from '../src/frontend/languages.json' with {type: 'json'};
 
@@ -19,14 +18,8 @@ const TRANSLATIONS_OUTPUT_PATH = path.join(
 await run();
 
 async function run() {
-  // We want to preserve the translations/ directory
-  await rimraf(`${TRANSLATIONS_DIR_PATH}/*`, {glob: true, preserveRoot: true});
-
-  try {
-    fs.mkdirSync(TRANSLATIONS_DIR_PATH);
-  } catch {
-    // Translations directory already exists
-  }
+  fs.rmSync(TRANSLATIONS_DIR_PATH, {force: true, recursive: true});
+  fs.mkdirSync(TRANSLATIONS_DIR_PATH);
 
   const messages = await loadMessages();
   const translations = convertMessagesToTranslations(messages);

--- a/scripts/build-translations.mjs
+++ b/scripts/build-translations.mjs
@@ -3,7 +3,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import {readFile, writeFile} from 'node:fs/promises';
-import {glob} from 'glob';
 
 import LANGUAGE_NAME_TRANSLATIONS from '../src/frontend/languages.json' with {type: 'json'};
 
@@ -38,13 +37,15 @@ async function run() {
  * @returns {Promise<{ [lang: string]: unknown }>}
  */
 async function loadMessages() {
-  const files = await glob(`${PROJECT_ROOT_DIR_PATH}/messages/**/*.json`);
+  const files = fs.readdirSync(path.join(PROJECT_ROOT_DIR_PATH, 'messages'), {
+    withFileTypes: true,
+  });
 
   /** @type {Array<[string, any]>} */
   const loadedMessages = await Promise.all(
     files.map(async file => {
-      const lang = path.parse(file).name;
-      const msgs = JSON.parse(await readFile(file));
+      const lang = path.parse(file.name).name;
+      const msgs = JSON.parse(await readFile(path.join(file.path, file.name)));
       return [lang, msgs];
     }),
   );


### PR DESCRIPTION
Relies on built-in Node APIs to handle functionality done by our usage of `rimraf` and `glob`, which allows us to remove them as direct dev deps