### PR TITLE
fix: use correct expression type for point filter on remote detection alerts map layer

### DIFF
--- a/src/frontend/screens/MapScreen/MapLayers/RemoteDetectionAlertsLayer.tsx
+++ b/src/frontend/screens/MapScreen/MapLayers/RemoteDetectionAlertsLayer.tsx
@@ -22,7 +22,7 @@ const LABEL_FILTER = [
   ['has', 'yearDetec'],
 ];
 
-const POINT_FILTER = ['==', '$type', 'Point', 'MultiPoint'];
+const POINT_FILTER = ['in', '$type', 'Point', 'MultiPoint'];
 
 const LINESTRING_FILTER = ['in', '$type', 'LineString', 'MultiLineString'];
 


### PR DESCRIPTION
Missed this when reviewing #895 and ran into this error when starting the app after it got merged:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/166cbf10-8537-4ee7-9f2e-41059d0d54aa" />