### PR TITLE
fix: fix issues building backend when working with fresh installation

### DIFF
--- a/scripts/build-backend.mjs
+++ b/scripts/build-backend.mjs
@@ -1,17 +1,36 @@
 #!/usr/bin/env node
 
-import {parseArgs} from 'util';
+import fs from 'node:fs';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {parseArgs} from 'node:util';
 import {$} from 'execa';
-import path from 'path';
-import fs from 'fs';
+
 import {downloadPrebuilds} from './download-prebuilds.mjs';
+
+const require = createRequire(import.meta.url);
+
+const nodejsAssetsDirectory = fileURLToPath(
+  new URL('../nodejs-assets', import.meta.url),
+);
+const nodejsAssetsBackendDirectory = path.join(
+  nodejsAssetsDirectory,
+  'backend',
+);
+const nodejsAssetsProjectDirectory = path.join(
+  nodejsAssetsDirectory,
+  'nodejs-project',
+);
+
+const backendSourceDirectory = fileURLToPath(
+  new URL('../src/backend', import.meta.url),
+);
 
 const {
   values: {prod},
 } = parseArgs({
-  options: {
-    prod: {type: 'boolean'},
-  },
+  options: {prod: {type: 'boolean'}},
 });
 
 const $$ = $({stdio: 'inherit'});
@@ -19,23 +38,29 @@ const $$ = $({stdio: 'inherit'});
 console.group('[SETUP]');
 
 // Ensure we start in the right place
-process.chdir(new URL('../', import.meta.url).pathname);
+process.chdir(fileURLToPath(new URL('../', import.meta.url)));
 
 console.log('Preparing nodejs-assets directory...');
 
-fs.mkdirSync('./nodejs-assets', {recursive: true});
+fs.mkdirSync(nodejsAssetsDirectory, {recursive: true});
 
 await Promise.all([
-  $$`rm -rf ./nodejs-assets/nodejs-project`,
-  $$`rm -rf ./nodejs-assets/backend`,
+  $$`rm -rf ${nodejsAssetsProjectDirectory}`,
+  $$`rm -rf ${nodejsAssetsBackendDirectory}`,
 ]);
 
-fs.cpSync('./src/backend', './nodejs-assets/backend', {recursive: true});
-fs.mkdirSync('./nodejs-assets/nodejs-project/node_modules', {recursive: true});
-
-fs.writeFileSync('./nodejs-assets/BUILD_NATIVE_MODULES.txt', '1', {
-  encoding: 'utf-8',
+fs.cpSync(backendSourceDirectory, nodejsAssetsBackendDirectory, {
+  recursive: true,
 });
+fs.mkdirSync(path.join(nodejsAssetsProjectDirectory, 'node_modules'), {
+  recursive: true,
+});
+
+fs.writeFileSync(
+  path.join(nodejsAssetsDirectory, 'BUILD_NATIVE_MODULES.txt'),
+  '1',
+  {encoding: 'utf-8'},
+);
 console.log('Set build native modules on');
 
 console.groupEnd();
@@ -50,18 +75,18 @@ console.log('Installing deps...');
 // for generating / downloading builds of native modules.
 // We don't need to run these scripts since we pull prebuilds in a later step.
 await $$({
-  cwd: './nodejs-assets/backend',
+  cwd: nodejsAssetsBackendDirectory,
 })`npm ci --ignore-scripts`;
 
 //  Setting --ignore-scripts above means that the postinstall script will not run (needed for patch-package)
 await $$({
-  cwd: './nodejs-assets/backend',
+  cwd: nodejsAssetsBackendDirectory,
 })`npm run postinstall`;
 
 if (prod) {
-  await $$({cwd: './nodejs-assets/backend'})`npm run build -- --minify`;
+  await $$({cwd: nodejsAssetsBackendDirectory})`npm run build -- --minify`;
 } else {
-  await $$({cwd: './nodejs-assets/backend'})`npm run build`;
+  await $$({cwd: nodejsAssetsBackendDirectory})`npm run build`;
 }
 
 console.log(
@@ -81,24 +106,40 @@ const KEEP_THESE = [
 ];
 
 for (const name of KEEP_THESE) {
-  const source = path.join('./nodejs-assets/backend/', name);
+  const source = path.join(nodejsAssetsBackendDirectory, name);
   const destination = path.join(
-    './nodejs-assets/nodejs-project',
+    nodejsAssetsProjectDirectory,
     name === 'index.bundle.js' ? 'index.js' : name,
   );
 
   fs.cpSync(source, destination, {recursive: true});
 }
 
-await $$`rm -rf ./nodejs-assets/backend`;
+console.log('Downloading native prebuilds...');
 
-console.groupEnd();
+// TODO: Figure out how to know if module uses N-API at runtime
+const NATIVE_MODULES = [
+  {name: 'better-sqlite3', usesNapi: false},
+  {name: 'crc-native', usesNapi: true},
+  {name: 'fs-native-extensions', usesNapi: true},
+  {name: 'quickbit-native', usesNapi: true},
+  {name: 'simdle-native', usesNapi: true},
+  {name: 'sodium-native', usesNapi: true},
+];
 
-// ------------------------------------------------
+await downloadPrebuilds(
+  NATIVE_MODULES.map(m => {
+    const pkgJsonPath = require.resolve(`${m.name}/package.json`, {
+      paths: [nodejsAssetsBackendDirectory],
+    });
 
-console.group('[PREBUILDS]');
+    const {version} = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
 
-await downloadPrebuilds();
+    return {...m, version};
+  }),
+);
+
+await $$`rm -rf ${nodejsAssetsBackendDirectory}`;
 
 console.groupEnd();
 

--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -1,33 +1,17 @@
 #!/usr/bin/env node
 
-import {$} from 'execa';
 import fs from 'node:fs';
 import path from 'node:path';
-import {createRequire} from 'node:module';
 import {fileURLToPath} from 'node:url';
-
-const require = createRequire(import.meta.url);
+import {$} from 'execa';
 
 const TARGETS = ['android-arm', 'android-arm64', 'android-x64'];
 
-// TODO: Figure out how to know if module uses N-API at runtime
-const NATIVE_MODULES = [
-  {name: 'better-sqlite3', usesNapi: false},
-  {name: 'crc-native', usesNapi: true},
-  {name: 'fs-native-extensions', usesNapi: true},
-  {name: 'quickbit-native', usesNapi: true},
-  {name: 'simdle-native', usesNapi: true},
-  {name: 'sodium-native', usesNapi: true},
-];
-
-// Uncomment line below if you want to run this script directly
-// await downloadPrebuilds({verbose: true});
-
 /**
+ * @param {Array<{ name: string, usesNapi: boolean, version: string }>} modules
  * @param {{verbose?: boolean}} opts
  */
-export async function downloadPrebuilds({verbose} = {verbose: false}) {
-  const backendRootUrl = new URL('../src/backend/', import.meta.url);
+export async function downloadPrebuilds(modules, {verbose} = {verbose: false}) {
   const nodejsProjectUrl = new URL(
     '../nodejs-assets/nodejs-project/',
     import.meta.url,
@@ -36,11 +20,7 @@ export async function downloadPrebuilds({verbose} = {verbose: false}) {
   const {abi: NODE_ABI} = getNodeJsMobileNodeVersions();
 
   return Promise.all(
-    NATIVE_MODULES.map(async ({name, usesNapi}) => {
-      const pkgJsonPath = require.resolve(`${name}/package.json`, {
-        paths: [fileURLToPath(backendRootUrl)],
-      });
-      const {version} = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    modules.map(async ({name, usesNapi, version}) => {
       if (verbose) {
         console.log(`${name}: prebuilds start (${version})`);
       }


### PR DESCRIPTION
Follow-up to #896 , which I didn't properly test on a "fresh" installation of the repo. The problem was that the script for downloading prebuilds was deriving information about the relevant packages' versions based on the _source_ directory (`src/backend/node_modules/...`) and not the directory where the installation of project occurs (`nodejs-assets/backend/`). 

Abbreviated sequence of what was happening:

1. Copy `src/backend/` to `nodejs-assets/backend/`
2. run `npm ci` in `nodejs-assets/backend/` (populates `nodejs-assets/backend/node_modules/` as a result)
3. Bundle backend and copy relevant files to `nodejs-assets/nodejs-project/`
4. delete `nodejs-assets/backend/`
5. download prebuilds

the main issue is that step 5 ideally gets needed information from something that is erased in step 4. instead, it was pulling in information in a directory that may not exist or may be stale i.e. it would work fine if one ran `npm ci` in `src/backend/` before step 5.

this PR fixes the scripts so that step 4 and 5 are basically switched and that step 5 is sourcing information from the proper directory.  

For anyone reviewing/testing this PR, I would recommend doing the following on your machine to verify that this works:

1. Remove the nodejs assets directory (`rm -rf nodejs-assets`)
2. Remove the backend node modules directory `cd src/backend ; rm -rf node_modules`)
3. In the project root, run `npm run build:backend` - it should not have any notable errors
4. Run the scripts for starting the app as you normally would