### PR TITLE
fix: Changes order of buttons

### DIFF
--- a/src/frontend/sharedComponents/ActionRow.tsx
+++ b/src/frontend/sharedComponents/ActionRow.tsx
@@ -88,21 +88,21 @@ export const ActionsRow = ({fieldRefs}: ActionButtonsProps) => {
 
   const bottomSheetItems = [
     {
-      icon: <AudioIcon width={30} height={30} />,
-      label: t(m.audioButton),
-      onPress: handleAudioPress,
-      testID: 'OBS.add-audio-btn',
-    },
-    {
       icon: <PhotoIcon width={30} height={30} />,
       label: t(m.photoButton),
       onPress: handleCameraPress,
       testID: 'OBS.add-photo-btn',
     },
+    {
+      icon: <AudioIcon width={30} height={30} />,
+      label: t(m.audioButton),
+      onPress: handleAudioPress,
+      testID: 'OBS.add-audio-btn',
+    },
   ];
 
   if (fieldRefs?.length) {
-    bottomSheetItems.push({
+    bottomSheetItems.unshift({
       icon: <DetailsIcon width={30} height={30} />,
       label: t(m.detailsButton),
       onPress: handleDetailsPress,


### PR DESCRIPTION
closes #952 
Changes the order of buttons to +details | +photo | +Audio for when creating an observation and editing an observation

<image src="https://github.com/user-attachments/assets/086ec821-ab6e-438e-9c1e-97ed922c46e0" width="250" />
