### PR TITLE
fix: do not require passcode entry when app is backgrounded due to share dialog opening

### DIFF
--- a/src/frontend/contexts/SecurityContext.tsx
+++ b/src/frontend/contexts/SecurityContext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {AppState, AppStateStatus} from 'react-native';
 import {usePersistedPasscode} from '../hooks/persistedState/usePersistedPasscode';
+import {useIsShareDialogOpen} from '../hooks/share';
 
 type AuthState = 'unauthenticated' | 'authenticated' | 'obscured';
 
@@ -35,6 +36,8 @@ export const SecurityProvider = ({children}: {children: React.ReactNode}) => {
     passcode === null ? 'authenticated' : 'unauthenticated',
   );
 
+  const shareDialogIsOpen = useIsShareDialogOpen();
+
   const passcodeSet = passcode !== null;
   const obscureSet = obscureCode !== null;
 
@@ -42,6 +45,9 @@ export const SecurityProvider = ({children}: {children: React.ReactNode}) => {
     const appStateListener = AppState.addEventListener(
       'change',
       (nextAppState: AppStateStatus) => {
+        // If the app state changes due to opening a share dialog, do not unauthenticate
+        if (shareDialogIsOpen) return;
+
         if (passcodeSet) {
           if (
             nextAppState === 'active' ||
@@ -55,7 +61,7 @@ export const SecurityProvider = ({children}: {children: React.ReactNode}) => {
     );
 
     return () => appStateListener.remove();
-  }, [passcodeSet]);
+  }, [passcodeSet, shareDialogIsOpen]);
 
   const authenticate: SecurityContextType['authenticate'] = React.useCallback(
     (passcodeValue, validateOnly = false) => {

--- a/src/frontend/hooks/share.ts
+++ b/src/frontend/hooks/share.ts
@@ -1,0 +1,24 @@
+import {useIsMutating, useMutation} from '@tanstack/react-query';
+import Share, {type ShareOptions} from 'react-native-share';
+
+const SHARE_OPEN_MUTATION_KEY = ['share', 'open'] as const;
+
+export function useOpenShareDialog() {
+  return useMutation({
+    networkMode: 'always',
+    retry: false,
+    mutationKey: SHARE_OPEN_MUTATION_KEY,
+    mutationFn: async (options: ShareOptions) => {
+      return Share.open(options);
+    },
+  });
+}
+
+export function useIsShareDialogOpen() {
+  return (
+    useIsMutating({
+      mutationKey: SHARE_OPEN_MUTATION_KEY,
+      status: 'pending',
+    }) > 0
+  );
+}

--- a/src/frontend/screens/Audio/ExistingRecording.tsx
+++ b/src/frontend/screens/Audio/ExistingRecording.tsx
@@ -16,10 +16,10 @@ import {
 import {CloseIcon, DeleteIcon} from '../../sharedComponents/icons';
 import {WHITE, BLACK} from '../../lib/styles';
 import ErrorIcon from '../../images/Error.svg';
-import Share from 'react-native-share';
 import * as FileSystem from 'expo-file-system';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {ErrorBottomSheet} from '../../sharedComponents/ErrorBottomSheet';
+import {useOpenShareDialog} from '../../hooks/share';
 
 const m = defineMessages({
   deleteBottomSheetTitle: {
@@ -63,6 +63,8 @@ export const ExistingRecording: React.FC<ExistingRecordingProps> = ({
   const [localUri, setLocalUri] = useState<string | null>(null);
   const [shareLoading, setShareLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+
+  const openShare = useOpenShareDialog();
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
@@ -108,13 +110,13 @@ export const ExistingRecording: React.FC<ExistingRecordingProps> = ({
         fileUri = uri;
       }
 
-      await Share.open({url: fileUri, failOnCancel: false});
+      await openShare.mutateAsync({url: fileUri, failOnCancel: false});
     } catch (err) {
       setError(err as Error);
     } finally {
       setShareLoading(false);
     }
-  }, [uri, isSavedUri, localUri]);
+  }, [uri, isSavedUri, localUri, openShare]);
 
   useEffect(() => {
     return () => {

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -6,7 +6,6 @@ import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import {defineMessages, useIntl} from 'react-intl';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeleteObservation} from '../../hooks/server/observations';
-import Share from 'react-native-share';
 import {useObservationWithPreset} from '../../hooks/useObservationWithPreset.ts';
 import {formatCoords} from '../../lib/utils.ts';
 import {UIActivityIndicator} from 'react-native-indicators';
@@ -18,6 +17,7 @@ import {getValueLabel} from '../../sharedComponents/FormattedData.tsx';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
 import {isSavedPhoto} from '../../lib/attachmentTypeChecks.ts';
+import {useOpenShareDialog} from '../../hooks/share.ts';
 
 const m = defineMessages({
   delete: {
@@ -97,6 +97,7 @@ export const ButtonFields = ({
   const format = usePersistedSettings(store => store.coordinateFormat);
   const [isShareButtonLoading, setShareButtonLoading] = useState(false);
   const {projectApi} = useActiveProject();
+  const openShare = useOpenShareDialog();
 
   function handlePressDelete() {
     Alert.alert(t(m.deleteTitle), undefined, [
@@ -162,7 +163,7 @@ export const ButtonFields = ({
         completedFields.push({label: field.label, value: displayedValue});
       }
 
-      await Share.open({
+      await openShare.mutateAsync({
         subject: `${t(m.comapeoAlert)} — _*${preset ? preset.name : t(m.fallbackCategoryName)}*_ — ${formatDate(observation.createdAt, {format: 'long'})}`,
         title:
           base64Urls.length > 0 ? t(m.shareMediaTitle) : t(m.shareTextTitle),


### PR DESCRIPTION
Fixes #955 

After setting up a passcode for the app, there are two ways of testing this:

1. Create an observation. Go to the observation and press the share button.
2. Create an observation with an audio attachemnt. Go to the observation and press the audio thumbnail and then press the share button.

The passcode screen should not show up at any point when the share dialog is open.

The fix for this does require us to remember to use the `useOpenShareDialog()` from `hooks/share.ts` instead of using `react-native-share` directly. Couldn't really think of a more elegant way of approaching this and I don't think this is too bad of a caveat.

---

https://github.com/user-attachments/assets/355924e8-87b7-4700-94f0-03d612824e85