### PR TITLE
chore: apply type checking on wdio config file

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,7 +1,7 @@
-/**
- * @type {import('webdriverio').Config}
- */
+// @ts-check
 
+// `capabilities` missing in `Options.Testrunner` type: https://github.com/webdriverio/webdriverio/issues/13769
+/** @type {import('@wdio/types').Options.Testrunner & { capabilities: import('@wdio/types').Capabilities }} */
 const config = {
   runner: 'local',
   user: process.env.BROWSERSTACK_USERNAME,
@@ -61,4 +61,7 @@ const config = {
   ],
   outputDir: './test-results',
 };
-exports.config = config;
+
+module.exports = {
+  config,
+};


### PR DESCRIPTION
Properly applies typechecking on the webdriver config file