### PR TITLE
chore: use recommended type for wdio config

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-// `capabilities` missing in `Options.Testrunner` type: https://github.com/webdriverio/webdriverio/issues/13769
-/** @type {import('@wdio/types').Options.Testrunner & { capabilities: import('@wdio/types').Capabilities }} */
+// Type is very questionably declared in the global namespace via @wdio/types
+/** @type {WebdriverIO.Config} */
 const config = {
   runner: 'local',
   user: process.env.BROWSERSTACK_USERNAME,


### PR DESCRIPTION
I missed this [comment](https://github.com/webdriverio/webdriverio/issues/13769#issuecomment-2419619504) when initially fixing this in #964 , mostly because the type is not exported from the relevant package but rather registered in the global namespace 🤔  Very confusing and not ideal, but using it for the sake of following their recommendation.