### PR TITLE
Fix: secondary button color

### DIFF
--- a/src/frontend/screens/HowToLeaveProject.tsx
+++ b/src/frontend/screens/HowToLeaveProject.tsx
@@ -57,6 +57,7 @@ export const HowToLeaveProject = ({
         <Button
           fullWidth
           variant="outlined"
+          color="ComapeoBlue"
           onPress={() => {
             navigation.goBack();
           }}>

--- a/src/frontend/screens/ObservationsList/ObservationsEmptyView.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationsEmptyView.tsx
@@ -52,7 +52,11 @@ const ObservationEmptyView = ({onPressBack}: Props) => {
         </Text>
       </View>
       <View style={styles.backButton}>
-        <Button onPress={onPressBack} variant="outlined" color="dark">
+        <Button
+          onPress={onPressBack}
+          variant="outlined"
+          color="ComapeoBlue"
+          fullWidth>
           {t(m.backButton)}
         </Button>
       </View>
@@ -104,5 +108,7 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    paddingLeft: 20,
+    paddingRight: 20,
   },
 });

--- a/src/frontend/screens/Onboarding/DataPrivacy.tsx
+++ b/src/frontend/screens/Onboarding/DataPrivacy.tsx
@@ -77,7 +77,7 @@ export const DataPrivacy = ({
         <Button
           fullWidth
           variant="outlined"
-          color="dark"
+          color="ComapeoBlue"
           onPress={() => {
             navigation.navigate('OnboardingPrivacyPolicy');
           }}

--- a/src/frontend/screens/Onboarding/DataPrivacy.tsx
+++ b/src/frontend/screens/Onboarding/DataPrivacy.tsx
@@ -135,7 +135,7 @@ const styles = StyleSheet.create({
     color: NEW_DARK_GREY,
   },
   buttonContainer: {
-    width: '90%',
+    width: '100%',
     alignItems: 'center',
     gap: GAP,
   },

--- a/src/frontend/screens/Settings/Config.tsx
+++ b/src/frontend/screens/Settings/Config.tsx
@@ -5,7 +5,7 @@ import {Text} from '../../sharedComponents/Text';
 import {useGetOwnRole, useProjectSettings} from '../../hooks/server/projects';
 import {Loading} from '../../sharedComponents/Loading';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
-import {COMAPEO_BLUE, MEDIUM_GREY} from '../../lib/styles';
+import {MEDIUM_GREY} from '../../lib/styles';
 import {Button} from '../../sharedComponents/Button';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {ErrorBottomSheet} from '../../sharedComponents/ErrorBottomSheet';
@@ -96,10 +96,9 @@ export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
           style={{marginTop: 20}}
           fullWidth
           variant="outlined"
+          color="ComapeoBlue"
           onPress={importConfigFile}>
-          <Text style={{color: COMAPEO_BLUE}}>
-            {formatMessage(m.importConfig)}
-          </Text>
+          {formatMessage(m.importConfig)}
         </Button>
       ) : null}
       <ErrorBottomSheet

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/ProjectCreated.tsx
@@ -81,7 +81,11 @@ export const ProjectCreated = ({
         </Text>
       </View>
       <View style={{width: '100%'}}>
-        <Button fullWidth variant="outlined" onPress={handleGoToInviteScreen}>
+        <Button
+          fullWidth
+          variant="outlined"
+          color="ComapeoBlue"
+          onPress={handleGoToInviteScreen}>
           {t(m.inviteDevice)}
         </Button>
         <Button style={{marginTop: 20}} fullWidth onPress={handleGoToMap}>

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -192,6 +192,7 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
                   <Button
                     fullWidth
                     variant="outlined"
+                    color="ComapeoBlue"
                     onPress={() => {
                       importConfigFile();
                     }}>

--- a/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
@@ -38,6 +38,7 @@ export const JoinExistingProject = ({
       <Button
         fullWidth
         variant="outlined"
+        color="ComapeoBlue"
         onPress={() => {
           navigation.goBack();
         }}>

--- a/src/frontend/screens/Settings/MapManagement/ChooseMapFile.tsx
+++ b/src/frontend/screens/Settings/MapManagement/ChooseMapFile.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {StyleSheet, View} from 'react-native';
 
-import {NEW_DARK_GREY, RED} from '../../../lib/styles';
+import {COMAPEO_BLUE, NEW_DARK_GREY, RED} from '../../../lib/styles';
 import {Button} from '../../../sharedComponents/Button';
 import {DownloadIcon} from '../../../sharedComponents/icons';
 import {HeaderText} from '../../../sharedComponents/Text/HeaderText';
@@ -26,7 +26,7 @@ export function ChooseMapFile({onChooseFile}: {onChooseFile: () => void}) {
     <View style={styles.container}>
       <Button fullWidth variant="outlined" onPress={onChooseFile}>
         <View style={styles.buttonContentContainer}>
-          <DownloadIcon size={24} />
+          <DownloadIcon size={24} color={COMAPEO_BLUE} />
           <View>
             <HeaderText variant="header5" style={styles.buttonTextBase}>
               {t(m.chooseFile)}
@@ -56,6 +56,7 @@ const styles = StyleSheet.create({
   },
   buttonTextBase: {
     letterSpacing: 0.5,
+    color: COMAPEO_BLUE,
   },
   asteriskText: {
     color: RED,

--- a/src/frontend/screens/Settings/ProjectSettings/MediaSyncSettings/SyncEverythingBottomSheet.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/MediaSyncSettings/SyncEverythingBottomSheet.tsx
@@ -46,6 +46,7 @@ export const SyncEverythingBottomSheet = () => {
         <Button
           fullWidth
           variant="outlined"
+          color="ComapeoBlue"
           style={{marginTop: 30}}
           onPress={() => goBack()}>
           {formatMessage(m.cancel)}

--- a/src/frontend/screens/Settings/ProjectSettings/MediaSyncSettings/SyncPreviewsBottomSheet.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/MediaSyncSettings/SyncPreviewsBottomSheet.tsx
@@ -53,6 +53,7 @@ export const SyncPreviewsBottomSheet = () => {
         <Button
           fullWidth
           variant="outlined"
+          color="ComapeoBlue"
           style={{marginTop: 30}}
           onPress={() => goBack()}>
           {formatMessage(m.cancel)}

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOff.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOff.tsx
@@ -68,6 +68,8 @@ export const RemoteArchiveOff: NativeNavigationComponent<
       ) : isCoordinator ? (
         <Button
           variant="outlined"
+          color="ComapeoBlue"
+          fullWidth
           style={{marginTop: 20}}
           onPress={() => {
             navigate('AddRemoteArchive');

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/SuccessfullyAddedArchive.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/SuccessfullyAddedArchive.tsx
@@ -37,6 +37,7 @@ export const SuccessfullyAddedArchive = ({
         <Button
           fullWidth
           variant="outlined"
+          color="ComapeoBlue"
           onPress={() => {
             navigation.navigate('RemoteArchiveOn');
           }}>

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
@@ -60,6 +60,7 @@ export const InviteAccepted = ({
         <Button
           fullWidth
           variant="outlined"
+          color="ComapeoBlue"
           onPress={() => {
             navigation.popTo('SelectDevice');
           }}>

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/index.tsx
@@ -10,7 +10,7 @@ import type {NativeNavigationComponent} from '../../../../sharedTypes/navigation
 import {ScrollView, StyleSheet, View} from 'react-native';
 import {Button} from '../../../../sharedComponents/Button';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
-import {BLACK} from '../../../../lib/styles';
+import {BLACK, COMAPEO_BLUE} from '../../../../lib/styles';
 import {DeviceCard} from '../../../../sharedComponents/DeviceCard';
 import {
   useProjectMembers,
@@ -116,12 +116,14 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
               alignItems: 'center',
             }}>
             <MaterialIcon
-              color={BLACK}
+              color={COMAPEO_BLUE}
               size={32}
               name="person-add"
               style={{marginRight: 10}}
             />
-            <HeaderText variant="header5">{t(m.inviteDevice)}</HeaderText>
+            <HeaderText variant="header5" style={{color: COMAPEO_BLUE}}>
+              {t(m.inviteDevice)}
+            </HeaderText>
           </View>
         </Button>
       )}

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -216,8 +216,10 @@ export const ProjectSyncDisplay = ({
             projectApi.$sync.stop();
           }}>
           <View style={styles.buttonContentContainer}>
-            <StopIcon size={20} color={BLACK} />
-            <HeaderText variant="header5">{t(m.stop)}</HeaderText>
+            <StopIcon size={20} color={COMAPEO_BLUE} />
+            <HeaderText variant="header5" style={{color: COMAPEO_BLUE}}>
+              {t(m.stop)}
+            </HeaderText>
           </View>
         </Button>
       );

--- a/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
+++ b/src/frontend/screens/Sync/ProjectSyncDisplay.tsx
@@ -12,7 +12,6 @@ import {useDataSyncProgress} from '../../hooks/useSyncState';
 import ObservationsProjectImage from '../../images/ObservationsProject.svg';
 import {ExhaustivenessError} from '../../lib/ExhaustivenessError';
 import {
-  BLACK,
   COMAPEO_BLUE,
   DARK_GREEN,
   DARK_GREY,
@@ -243,8 +242,10 @@ export const ProjectSyncDisplay = ({
             projectApi.$sync.stop();
           }}>
           <View style={styles.buttonContentContainer}>
-            <StopIcon size={20} color={BLACK} />
-            <HeaderText variant="header5">{t(m.stop)}</HeaderText>
+            <StopIcon size={20} color={COMAPEO_BLUE} />
+            <HeaderText variant="header5" style={{color: COMAPEO_BLUE}}>
+              {t(m.stop)}
+            </HeaderText>
           </View>
         </Button>
       );
@@ -272,8 +273,10 @@ export const ProjectSyncDisplay = ({
             projectApi.$sync.stop();
           }}>
           <View style={styles.buttonContentContainer}>
-            <StopIcon size={20} color={BLACK} />
-            <HeaderText variant="header5">{t(m.stop)}</HeaderText>
+            <StopIcon size={20} color={COMAPEO_BLUE} />
+            <HeaderText variant="header5" style={{color: COMAPEO_BLUE}}>
+              {t(m.stop)}
+            </HeaderText>
           </View>
         </Button>
       );
@@ -299,8 +302,10 @@ export const ProjectSyncDisplay = ({
             projectApi.$sync.stop();
           }}>
           <View style={styles.buttonContentContainer}>
-            <StopIcon size={20} color={BLACK} />
-            <HeaderText variant="header5">{t(m.stop)}</HeaderText>
+            <StopIcon size={20} color={COMAPEO_BLUE} />
+            <HeaderText variant="header5" style={{color: COMAPEO_BLUE}}>
+              {t(m.stop)}
+            </HeaderText>
           </View>
         </Button>
       ) : (

--- a/src/frontend/sharedComponents/Button.tsx
+++ b/src/frontend/sharedComponents/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {GestureResponderEvent, StyleSheet, View, ViewStyle} from 'react-native';
 
-import {BLACK, COMAPEO_BLUE, VERY_LIGHT_BLUE} from '../lib/styles';
+import {BLACK, BLUE_GREY, COMAPEO_BLUE, VERY_LIGHT_BLUE} from '../lib/styles';
 import {TouchableNativeFeedback} from 'react-native-gesture-handler';
 
 import {ViewStyleProp} from '../sharedTypes';
@@ -140,7 +140,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#0066FF',
   },
   buttonOutlined: {
-    borderColor: '#EEEEEE',
+    borderColor: BLUE_GREY,
     borderWidth: 1.5,
   },
   touchableMedium: {


### PR DESCRIPTION
closes #947 
See notion document for guidelines.
But, in sum, 

> Clarifications: A secondary button is any outlined button. 

> Our secondary button should look like this with these colors:
> 
> - Button Text Color: #0066FF
> - Button Border Color: CCCCD6
> - Button Stroke Width: 1.5
> - Button Fill: White
> - Button Font: Rubik Medium 16pt
> - Button Width: Buttons should be 280px width

So I updated all of the outlined buttons to fit these specifications. I changed the border color as specified. As far as the text,  I did so by passing the color string unless the header text had been added separately, in which case, I added the color to the header text (and the icon).
Passing the string seemed to be in keeping with the expectations of the button component, so that is what I did, rather than setting a default color on outlined buttons in the Button file. But I am not wedded to that idea and would be happy to hear feedback on that choice.
Particular attention was paid to the buttons mentioned in the Notion document. Widths were fixed in those cases as well.

Some screen shots:
<image src="https://github.com/user-attachments/assets/b310e3ee-dcac-487f-8e6c-a2f4e352c8f1" width="250" />
<image src="https://github.com/user-attachments/assets/bfae96d1-4848-4cf9-bfb8-4b7718ec3c88" width="250" />
<image src="https://github.com/user-attachments/assets/5eb6ea67-b381-4ce7-a781-b0b895445c64" width="250"/>
<image src="https://github.com/user-attachments/assets/a440787e-d309-4d60-966c-9e447790d3d8" width="250" />

