### PR TITLE
fix: Removes excess shadow from observation list

### DIFF
--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -10,7 +10,7 @@ import {ObservationsListBarIcon} from '../../Navigation/Tab/TabBar/ObservationsL
 import {ObservationListHeaderLeft} from './ObservationListHeaderLeft';
 import {NativeHomeTabsNavigationProps} from '../../sharedTypes/navigation';
 import {NoProjectWarning} from './NoProjectWarning';
-import {LIGHT_GREY, WHITE} from '../../lib/styles';
+import {WHITE} from '../../lib/styles';
 import {useAllProjects} from '../../hooks/server/projects';
 import {Loading} from '../../sharedComponents/Loading';
 import {TrackListItem} from './TrackListItem';
@@ -85,10 +85,7 @@ export const ObservationsList: React.FC<
         initialNumToRender={rowsPerWindow}
         getItemLayout={getItemLayout}
         keyExtractor={keyExtractor}
-        style={[
-          styles.container,
-          {borderTopColor: LIGHT_GREY, borderTopWidth: 1},
-        ]}
+        style={styles.container}
         windowSize={3}
         removeClippedSubviews
         renderItem={({item, index}) => {
@@ -137,12 +134,6 @@ export function createNavigationOptions(
     headerLeft: ObservationListHeaderLeft,
     headerTransparent: false,
     headerTitle: formatMessage(ObservationsList.navTitle),
-    headerShadowVisible: true,
-    headerStyle: {
-      elevation: 15,
-      shadowOpacity: 0,
-      borderBottomWidth: 1,
-    },
   };
 }
 


### PR DESCRIPTION
closes #950 (see Notion issue linked in Github issue)
There were excess shadows being applied in the observation list -- some from the header style and some from the container

The design team wanted the shadow to look like the rest of the app. The rest of the app just uses the default header style that comes from react navigation elements and is never specified. The shadow is applied by default as long as the header is not transparent. 

So, I took out any defining of shadows in the Observation List and now it matches the rest of the app.

The Sync Screen. What the Shadow is supposed to be.
<image src="https://github.com/user-attachments/assets/1ded8131-5dc6-4e12-b96a-b3d363a301f5" width="250" />

The new Observation List (empty)
<image src="https://github.com/user-attachments/assets/42bd3ef2-4e5f-499b-8b6b-4a51bb19a8e7" width="250" />

The new Observation List with a list item
<image src="https://github.com/user-attachments/assets/21a29141-15c9-417a-9d92-06d4fb941f2f" width="250" />

