### PR TITLE
chore(deps): install react-test-renderer as explicit dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
         "patch-package": "8.0.0",
         "prettier": "3.5.1",
         "react-native-svg-transformer": "1.5.0",
+        "react-test-renderer": "18.3.1",
         "rimraf": "5.0.5",
         "semver": "7.7.1",
         "type-fest": "4.34.1",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "patch-package": "8.0.0",
     "prettier": "3.5.1",
     "react-native-svg-transformer": "1.5.0",
+    "react-test-renderer": "18.3.1",
     "rimraf": "5.0.5",
     "semver": "7.7.1",
     "type-fest": "4.34.1",


### PR DESCRIPTION
Missed that this got removed in #971.  @testing-library/react-native requires it to be installed as a peer dep, with a version that exactly matches the version of React being used.

From https://github.com/callstack/react-native-testing-library?tab=readme-ov-file#installation:

> This library has a peerDependencies listing for react-test-renderer. Make sure that your react-test-renderer version matches exactly the react version, avoid using ^ in version number.

