### PR TITLE
fix: workaround for file lock errors crashing app

### DIFF
--- a/src/backend/patches/README.md
+++ b/src/backend/patches/README.md
@@ -7,3 +7,9 @@ These patches use [patch-package](https://github.com/ds300/patch-package) to upd
 ### [Fix shim insertion](./@rollup+plugin-esm-shim+0.1.4+001+fix-shim-insertion.patch)
 
 This is a workaround for [a bug in the plugin](https://github.com/rollup/plugins/issues/1709).
+
+## `random-access-file`
+
+### [Ignore EINVAL errors](./random-access-file+4.0.7.patch)
+
+This is a workaround for [file lock errors on certain Android devices](https://github.com/digidem/comapeo-core/issues/995). The workaround means that the failure to gain a lock is silently ignored, which may lead to data corruption if more than one process tries to access the file, which should not happen in normal operation.

--- a/src/backend/patches/random-access-file+4.0.7.patch
+++ b/src/backend/patches/random-access-file+4.0.7.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/random-access-file/index.js b/node_modules/random-access-file/index.js
+index 4824381..004f9c4 100644
+--- a/node_modules/random-access-file/index.js
++++ b/node_modules/random-access-file/index.js
+@@ -101,8 +101,16 @@ module.exports = class RandomAccessFile extends RandomAccessStorage {
+       // Should we aquire a read lock?
+       const shared = self.mode === RDONLY
+ 
+-      if (fsext.tryLock(self.fd, { shared })) onlock(null)
+-      else onlock(createLockError(self.filename))
++      try {
++        const didLock = fsext.tryLock(self.fd, { shared })
++        if (didLock) return onlock(null)
++        else onlock(createLockError(self.filename))
++      } catch (e) {
++        // Workaround for errors getting lock on certain Android devices
++        // See https://github.com/digidem/comapeo-core/issues/995
++        if (e.code === 'EINVAL') return onlock(null)
++        onlock(e)
++      }
+     }
+ 
+     function onlock (err) {


### PR DESCRIPTION
This is a workaround for https://github.com/digidem/comapeo-core/issues/995. For affected devices, it means that the hypercore storage files are not actually locked (the attempt to lock the file is silently ignored). The files in question are the `oplog` files for each Hypercore. This should not be an issue in normal operation, because there should not be any other process which is trying to read or write to these files while CoMapeo is running.

Fixes #982 