### PR TITLE
fix: disable expo updates (fix Android 7 crash)

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "assetBundlePatterns": ["**/*"],
+    "updates": {
+      "enabled": false
+    },
     "plugins": [
       "expo-localization",
       "expo-secure-store",

--- a/eas.json
+++ b/eas.json
@@ -26,7 +26,6 @@
     "release-candidate": {
       "extends": "base",
       "distribution": "internal",
-      "channel": "preview",
       "env": {
         "APP_VARIANT": "releaseCandidate",
         "EXPO_PUBLIC_FEATURE_TEST_DATA_UI": "true"
@@ -35,7 +34,6 @@
     "production": {
       "extends": "base",
       "distribution": "store",
-      "channel": "production",
       "env": {
         "APP_VARIANT": "production"
       },
@@ -44,7 +42,6 @@
     "pre-release": {
       "extends": "base",
       "distribution": "internal",
-      "channel": "preview",
       "env": {
         "APP_VARIANT": "preRelease"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "expo-status-bar": "2.0.1",
         "expo-system-ui": "4.0.7",
         "expo-task-manager": "12.0.5",
-        "expo-updates": "0.26.13",
         "filter-obj": "6.1.0",
         "geojson": "0.5.0",
         "geojson-geometries-lookup": "0.5.0",
@@ -16843,12 +16842,6 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-eas-client": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.13.2.tgz",
-      "integrity": "sha512-2RAAGtkO9vseoJZuW4mhJkiNQ6+FfLrX66OTMq4Qj9mRKZV2Uq/ZquxUGIeJyYqBy4vNYeKbuPd2oJtsV9LBGQ==",
-      "license": "MIT"
-    },
     "node_modules/expo-file-system": {
       "version": "18.0.7",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.7.tgz",
@@ -17116,12 +17109,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-structured-headers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.0.0.tgz",
-      "integrity": "sha512-uPiwZjWq3AdFGgY52+I2nGPrNa6izxAglymPXHUZLekZW290GqIUOk7MBNDD4sg4JwUbSi3gdxEurpEvuq+FSg==",
-      "license": "MIT"
-    },
     "node_modules/expo-system-ui": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/expo-system-ui/-/expo-system-ui-4.0.7.tgz",
@@ -17155,35 +17142,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-updates": {
-      "version": "0.26.13",
-      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.26.13.tgz",
-      "integrity": "sha512-rNJQ5eCGOGy6Ewxop1Fz3Kh5HXxSoIH480qrbJYqUDrql2J4Fp7cnv36B+Kwz+r+47gwGm1VgzwUbA2PctQc+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/code-signing-certificates": "0.0.5",
-        "@expo/config": "~10.0.8",
-        "@expo/config-plugins": "~9.0.14",
-        "@expo/spawn-async": "^1.7.2",
-        "arg": "4.1.0",
-        "chalk": "^4.1.2",
-        "expo-eas-client": "~0.13.2",
-        "expo-manifests": "~0.15.5",
-        "expo-structured-headers": "~4.0.0",
-        "expo-updates-interface": "~1.0.0",
-        "fast-glob": "^3.3.2",
-        "fbemitter": "^3.0.0",
-        "ignore": "^5.3.1",
-        "resolve-from": "^5.0.0"
-      },
-      "bin": {
-        "expo-updates": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
-      }
-    },
     "node_modules/expo-updates-interface": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.0.0.tgz",
@@ -17192,11 +17150,6 @@
       "peerDependencies": {
         "expo": "*"
       }
-    },
-    "node_modules/expo-updates/node_modules/arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
     },
     "node_modules/expo/node_modules/@expo/fingerprint": {
       "version": "0.11.7",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "expo-status-bar": "2.0.1",
     "expo-system-ui": "4.0.7",
     "expo-task-manager": "12.0.5",
-    "expo-updates": "0.26.13",
     "filter-obj": "6.1.0",
     "geojson": "0.5.0",
     "geojson-geometries-lookup": "0.5.0",


### PR DESCRIPTION
Expo updates is crashing Android 7 devices in the latest version (https://github.com/digidem/comapeo-mobile/issues/983)

Expo updates allow over-the-air updates of bundled JS code. We currently do not use this feature, but it is enabled by default (https://docs.expo.dev/versions/latest/config/app/#enabled). Disabling the option should have no consequences for the app, it avoid unnecessary network traffic, and reduces the bundle size.