### PR TITLE
chore(ci): run e2e tests for PRs targeting release branches

### DIFF
--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - 'release/**'
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
Runs the end-to-end test for PRs that target release branches, most notably RC PRs that are created as part of our release automation workflows.