### PR TITLE
fix: changes order of observation buttons.

### DIFF
--- a/src/frontend/sharedComponents/ActionsRow/index.tsx
+++ b/src/frontend/sharedComponents/ActionsRow/index.tsx
@@ -68,21 +68,21 @@ export function ActionsRow({fieldRefs}: {fieldRefs?: Preset['fieldRefs']}) {
 
   const bottomSheetItems = [
     {
-      icon: <AudioIcon width={30} height={30} />,
-      label: t(m.audioButton),
-      onPress: handleAudioPress,
-      testID: 'OBS.add-audio-btn',
-    },
-    {
       icon: <PhotoIcon width={30} height={30} />,
       label: t(m.photoButton),
       onPress: handleCameraPress,
       testID: 'OBS.add-photo-btn',
     },
+    {
+      icon: <AudioIcon width={30} height={30} />,
+      label: t(m.audioButton),
+      onPress: handleAudioPress,
+      testID: 'OBS.add-audio-btn',
+    },
   ];
 
   if (fieldRefs?.length) {
-    bottomSheetItems.push({
+    bottomSheetItems.unshift({
       icon: <DetailsIcon width={30} height={30} />,
       label: t(m.detailsButton),
       onPress: handleDetailsPress,


### PR DESCRIPTION
closes #952 
Changes the order of buttons to +details | +photo | +Audio for when creating an observation and editing an observation

**Adding**
<image src="https://github.com/user-attachments/assets/a0a4d923-b0d0-41e7-b991-b3d3b0410969" width="250" />

**Editing**
<image src="https://github.com/user-attachments/assets/bffb7d2b-407f-495e-8074-9f4b66e19fcd" width="250" />

