### PR TITLE
chore: adds E2E tests for observations and settings

### DIFF
--- a/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
@@ -72,8 +72,6 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
     openOnMount: false,
   });
 
-  const {navigate} = navigation;
-
   const {formatMessage: t} = useIntl();
 
   // These next three function forces the user to go back to the setting page instead of the "EnterPassToTurnOff" screen
@@ -108,7 +106,7 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
 
   function unsetAppPasscode() {
     setPasscode(null);
-    navigate('Security');
+    navigation.popTo('Security');
   }
 
   return (
@@ -140,11 +138,11 @@ export const TurnOffPasscode: NativeNavigationComponent<'DisablePasscode'> = ({
         </ListItem>
         <ListDivider />
 
-        {/* User is not able to see this option unlesss they already have a pass */}
+        {/* User is not able to see this option unless they already have a pass */}
         {authValuesSet.passcodeSet && (
           <ListItem
             onPress={() => {
-              navigate('SetPasscode');
+              navigation.navigate('SetPasscode');
             }}
             style={{marginTop: 20}}>
             <ListItemText

--- a/tests/e2e/specs/flow.test.ts
+++ b/tests/e2e/specs/flow.test.ts
@@ -11,4 +11,7 @@ describe('CoMapeo E2E Flow', function () {
   require('./main/side-drawer-menu-proj.test');
   require('./main/gps.test');
   require('./main/map.test');
+  require('./observations/create-observation.test');
+  require('./observations/add-details.test');
+  require('./observations/view-observations.test');
 });

--- a/tests/e2e/specs/flow.test.ts
+++ b/tests/e2e/specs/flow.test.ts
@@ -17,4 +17,6 @@ describe('CoMapeo E2E Flow', function () {
   require('./settings/coordinates.test');
   require('./settings/language.test');
   require('./settings/about-comapeo.test');
+  require('./passcode/set-passcode.test');
+  require('./passcode/check-passcode-requirements.test');
 });

--- a/tests/e2e/specs/flow.test.ts
+++ b/tests/e2e/specs/flow.test.ts
@@ -14,4 +14,7 @@ describe('CoMapeo E2E Flow', function () {
   require('./observations/create-observation.test');
   require('./observations/add-details.test');
   require('./observations/view-observations.test');
+  require('./settings/coordinates.test');
+  require('./settings/language.test');
+  require('./settings/about-comapeo.test');
 });

--- a/tests/e2e/specs/observations/add-details.test.ts
+++ b/tests/e2e/specs/observations/add-details.test.ts
@@ -4,7 +4,7 @@ import {byResourceId, byTextMatches} from '../../utils/selectors';
 
 describe('Add Details Flow', () => {
   it('should create a new observation with Gathering Site category and open Details screen', async () => {
-    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
     const gatherSite = await $(byTextMatches('Gathering Site'));
@@ -27,7 +27,7 @@ describe('Add Details Flow', () => {
     expect(isFocused).toBe('true');
   });
 
-  it('should return to New Observation screen via back arrow, then re-open Details', async () => {
+  it('should return to create new Observation screen via back arrow, then re-open Details', async () => {
     const backArrow = await $(byResourceId('MAIN.header-back-btn'));
     await backArrow.click();
     await expect($(byTextMatches('New Observation'))).toBeDisplayed();

--- a/tests/e2e/specs/observations/add-details.test.ts
+++ b/tests/e2e/specs/observations/add-details.test.ts
@@ -1,0 +1,55 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byResourceId, byTextMatches} from '../../utils/selectors';
+
+describe('Add Details Flow', () => {
+  it('should create a new observation with Gathering Site category and open Details screen', async () => {
+    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    await addObsBtn.click();
+
+    const gatherSite = await $(byTextMatches('Gathering Site'));
+    await gatherSite.click();
+
+    const addDetailsBtn = await $(byResourceId('OBS.add-details-btn'));
+    await addDetailsBtn.click();
+
+    await expect($(byResourceId('OBS.add-details-scrn'))).toBeDisplayed();
+
+    const backArrow = await $(byResourceId('MAIN.header-back-btn'));
+    await expect(backArrow).toBeDisplayed();
+
+    await expect($(byTextMatches('Question [0-9] of [0-9]'))).toBeDisplayed();
+    await expect($(byTextMatches('(Next|Done)'))).toBeDisplayed();
+    await expect($(byTextMatches('What is gathered here?'))).toBeDisplayed();
+
+    const detailsInp = await $(byResourceId('OBS.details-inp'));
+    const isFocused = await detailsInp.getAttribute('focused');
+    expect(isFocused).toBe('true');
+  });
+
+  it('should return to New Observation screen via back arrow, then re-open Details', async () => {
+    const backArrow = await $(byResourceId('MAIN.header-back-btn'));
+    await backArrow.click();
+    await expect($(byTextMatches('New Observation'))).toBeDisplayed();
+
+    const addDetailsBtn = await $(byResourceId('OBS.add-details-btn'));
+    await addDetailsBtn.click();
+
+    const detailsInp = await $(byResourceId('OBS.details-inp'));
+    await detailsInp.click();
+    await detailsInp.setValue('Some details');
+
+    const doneBtn = await $(byTextMatches('Done'));
+    await doneBtn.click();
+  });
+
+  it('should confirm we are back on the New Observation screen, then save & go back', async () => {
+    await expect($(byTextMatches('New Observation'))).toBeDisplayed();
+
+    const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
+    await saveBtn.click();
+
+    const mainBack = await $(byResourceId('MAIN.header-back-btn'));
+    await mainBack.click();
+  });
+});

--- a/tests/e2e/specs/observations/create-observation.test.ts
+++ b/tests/e2e/specs/observations/create-observation.test.ts
@@ -4,8 +4,8 @@ import {byResourceId, byTextMatches} from '../../utils/selectors';
 import {tapAboveElement} from '../../utils/touchActions';
 
 describe('Create Observation Flow', () => {
-  it('should set location and open add-observation screen', async () => {
-    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+  it('should set location and open create observation screen', async () => {
+    const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
     await expect($(byTextMatches('Choose what is happening'))).toBeDisplayed();
     await expect($(byTextMatches('Airstrip'))).toBeDisplayed();
@@ -32,7 +32,7 @@ describe('Create Observation Flow', () => {
   });
 
   it('should pick House category and display New Observation screen', async () => {
-    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
     const houseCategory = await $(byTextMatches('House'));

--- a/tests/e2e/specs/observations/create-observation.test.ts
+++ b/tests/e2e/specs/observations/create-observation.test.ts
@@ -49,7 +49,7 @@ describe('Create Observation Flow', () => {
     await expect($(byTextMatches('UTM 44N 218632 21930'))).toBeDisplayed();
 
     await expect($(byResourceId('OBS.House-icon'))).toBeDisplayed();
-    await expect($(byTextMatches('House'))).toBeDisplayed();
+    await expect(houseCategory).toBeDisplayed();
   });
 
   it('should change category to Threat and add a description', async () => {

--- a/tests/e2e/specs/observations/create-observation.test.ts
+++ b/tests/e2e/specs/observations/create-observation.test.ts
@@ -1,0 +1,99 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byResourceId, byTextMatches} from '../../utils/selectors';
+import {tapAboveElement} from '../../utils/touchActions';
+
+describe('Create Observation Flow', () => {
+  it('should set location and open add-observation screen', async () => {
+    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    await addObsBtn.click();
+    await expect($(byTextMatches('Choose what is happening'))).toBeDisplayed();
+    await expect($(byTextMatches('Airstrip'))).toBeDisplayed();
+  });
+
+  it('should discard observation and return to the map screen', async () => {
+    const closeIcon = await $(byResourceId('close-icon'));
+    await closeIcon.click();
+
+    const discardObs = await $(byTextMatches('Discard Observation'));
+    await expect(discardObs).toBeDisplayed();
+
+    const continueEditing = await $(byTextMatches('Continue editing'));
+    await continueEditing.click();
+    await discardObs.waitForDisplayed({
+      reverse: true,
+      timeout: 1500,
+    });
+
+    await closeIcon.click();
+    await discardObs.click();
+
+    await expect($(byResourceId('MAIN.mapbox-map-view'))).toBeDisplayed();
+  });
+
+  it('should pick House category and display New Observation screen', async () => {
+    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    await addObsBtn.click();
+
+    const houseCategory = await $(byTextMatches('House'));
+    await houseCategory.click();
+
+    await expect($(byTextMatches('New Observation'))).toBeDisplayed();
+    await expect($(byResourceId('close-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.edit-save-btn'))).toBeDisplayed();
+    await expect($(byTextMatches('Change'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.add-photo-btn'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.add-details-btn'))).toBeDisplayed();
+    await expect($(byTextMatches('What is happening here?'))).toBeDisplayed();
+
+    await expect($(byTextMatches('UTM 44N 218632 21930'))).toBeDisplayed();
+
+    await expect($(byResourceId('OBS.House-icon'))).toBeDisplayed();
+    await expect($(byTextMatches('House'))).toBeDisplayed();
+  });
+
+  it('should change category to Threat and add a description', async () => {
+    const changeBtn = await $(byTextMatches('Change'));
+    await changeBtn.click();
+    await expect($(byResourceId('MAIN.categories-scrn'))).toBeDisplayed();
+
+    const threatOption = await $(byTextMatches('Threat'));
+    await threatOption.scrollIntoView();
+    await threatOption.click();
+
+    const descriptionInput = await $(byResourceId('OBS.description-inp'));
+    await descriptionInput.click();
+    await descriptionInput.setValue('Sample description');
+
+    await expect($(byResourceId('OBS.add-photo-btn-keyboard'))).toBeDisplayed();
+
+    const showOptionsElem = $(byTextMatches('Show Options'));
+    await tapAboveElement(showOptionsElem, 150);
+    await $(byResourceId('OBS.add-photo-btn-keyboard')).waitForDisplayed({
+      reverse: true,
+      timeout: 1500,
+    });
+  });
+
+  it('should open camera, cancel, then save observation', async () => {
+    const addPhotoBtn = await $(byResourceId('OBS.add-photo-btn'));
+    await addPhotoBtn.click();
+    await expect($(byResourceId('MAIN.camera-scrn'))).toBeDisplayed();
+
+    const cancelCamera = await $(byTextMatches('Cancel'));
+    await cancelCamera.click();
+    await expect($(byTextMatches('New Observation'))).toBeDisplayed();
+
+    const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
+    await saveBtn.click();
+
+    try {
+      const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+      if (await backBtn.isDisplayed()) {
+        await backBtn.click();
+      }
+    } catch (e) {
+      console.info('Back button not visible, continuing...');
+    }
+  });
+});

--- a/tests/e2e/specs/observations/view-observations.test.ts
+++ b/tests/e2e/specs/observations/view-observations.test.ts
@@ -4,7 +4,7 @@ import {byResourceId, byTextMatches} from '../../utils/selectors';
 
 describe('View Observations Flow', () => {
   it('should create observation with "Lake" category', async () => {
-    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
     const lakeCategory = await $(byTextMatches('Lake'));
@@ -24,7 +24,7 @@ describe('View Observations Flow', () => {
   });
 
   it('should create observation with "Clay" category', async () => {
-    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
     const clayCategory = await $(byTextMatches('Clay'));
@@ -46,16 +46,16 @@ describe('View Observations Flow', () => {
   });
 
   it('should open Observations list and verify it is displayed', async () => {
-    const obsListTab = await $(byResourceId('tabBarButtonObservationsList'));
+    const obsListTab = await $('~Go to ObservationsList');
     await obsListTab.click();
     await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
   });
 
   it('should toggle camera tab and back to confirm correct place', async () => {
-    const cameraTab = await $(byResourceId('tabBarButtonCamera'));
+    const cameraTab = await $('~Go to Camera');
     await cameraTab.click();
 
-    const obsListTab = await $(byResourceId('tabBarButtonObservationsList'));
+    const obsListTab = await $('~Go to ObservationsList');
     await obsListTab.click();
 
     await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();

--- a/tests/e2e/specs/observations/view-observations.test.ts
+++ b/tests/e2e/specs/observations/view-observations.test.ts
@@ -1,0 +1,98 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byResourceId, byTextMatches} from '../../utils/selectors';
+
+describe('View Observations Flow', () => {
+  it('should create observation with "Lake" category', async () => {
+    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    await addObsBtn.click();
+
+    const lakeCategory = await $(byTextMatches('Lake'));
+    await lakeCategory.click();
+
+    await driver.pause(1000);
+    const noGpsElems = await $$(byTextMatches('No GPS signal'));
+    if ((await noGpsElems.length) > 0 && (await noGpsElems[0].isDisplayed())) {
+      const textSave = await $(byTextMatches('SAVE'));
+      await textSave.click();
+    } else {
+      const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
+      await saveBtn.click();
+    }
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+  });
+
+  it('should create observation with "Clay" category', async () => {
+    const addObsBtn = await $(byResourceId('MAIN.add-observation-btn'));
+    await addObsBtn.click();
+
+    const clayCategory = await $(byTextMatches('Clay'));
+    await clayCategory.click();
+
+    await driver.pause(1000);
+
+    const noGpsElems = await $$(byTextMatches('No GPS signal'));
+    if ((await noGpsElems.length) > 0 && (await noGpsElems[0].isDisplayed())) {
+      const textSave = await $(byTextMatches('SAVE'));
+      await textSave.click();
+    } else {
+      const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
+      await saveBtn.click();
+    }
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+  });
+
+  it('should open Observations list and verify it is displayed', async () => {
+    const obsListTab = await $(byResourceId('tabBarButtonObservationsList'));
+    await obsListTab.click();
+    await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
+  });
+
+  it('should toggle camera tab and back to confirm correct place', async () => {
+    const cameraTab = await $(byResourceId('tabBarButtonCamera'));
+    await cameraTab.click();
+
+    const obsListTab = await $(byResourceId('tabBarButtonObservationsList'));
+    await obsListTab.click();
+
+    await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
+  });
+
+  it('should confirm newly-created observations appear in the list', async () => {
+    await expect($(byTextMatches('Lake'))).toBeDisplayed();
+    await expect($(byTextMatches('Clay'))).toBeDisplayed();
+    await expect($(byTextMatches('Gathering Site'))).toBeDisplayed();
+    await expect($(byTextMatches('Threat'))).toBeDisplayed();
+
+    await expect($(byResourceId('OBS.Clay-list-icon'))).toBeDisplayed();
+    await expect(
+      $(byResourceId('OBS.Gathering Site-list-icon')),
+    ).toBeDisplayed();
+    await expect($(byResourceId('OBS.Threat-list-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.Lake-list-icon'))).toBeDisplayed();
+  });
+
+  it('should open "Clay" observation, check details, and go back to map', async () => {
+    const clayItem = await $(byTextMatches('Clay'));
+    await clayItem.click();
+
+    await expect($(byTextMatches('Clay'))).toBeDisplayed();
+
+    // Check date format: e.g. "Oct 25, 2024"
+    const dateRegex =
+      '^[A-Z][a-z]{2} (0?[1-9]|[12][0-9]|3[01]), (20[2-9][4-9]|2[1-9][0-9]{2})';
+    await expect($(byTextMatches(dateRegex))).toBeDisplayed();
+
+    await expect($(byResourceId('OBS.Clay-view-icon'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+    await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
+
+    await backBtn.click();
+    await expect($(byResourceId('MAIN.mapbox-map-view'))).toBeDisplayed();
+  });
+});

--- a/tests/e2e/specs/passcode/check-passcode-requirements.test.ts
+++ b/tests/e2e/specs/passcode/check-passcode-requirements.test.ts
@@ -15,11 +15,10 @@ describe('Check Passcode Requirements Flow', () => {
   });
 
   it('should press Home, then return to see passcode screen again', async () => {
-    // should put app in the background
-    // keycode 3 is home button
+    // presses the home button
     await driver.pressKeyCode(3);
-    // if I figure out how, this should involve opening another app in between
-    await driver.pause(2000);
+    // activates the calendar app
+    await driver.pressKeyCode(208);
     await driver.activateApp('com.comapeo.rc');
 
     await expect($(byTextMatches('Enter your passcode'))).toBeDisplayed();
@@ -30,9 +29,9 @@ describe('Check Passcode Requirements Flow', () => {
     await passcodeField.setValue('54321');
 
     await expect($(byTextMatches('Incorrect passcode'))).toBeDisplayed();
-    // if I figure out how, this should be turn phone on and off instead
-    await driver.terminateApp('com.comapeo.rc');
-    await driver.activateApp('com.comapeo.rc');
+    // power button (off then on)
+    await driver.pressKeyCode(26);
+    await driver.pressKeyCode(26);
 
     await expect($(byTextMatches('Enter your passcode'))).toBeDisplayed();
 

--- a/tests/e2e/specs/passcode/check-passcode-requirements.test.ts
+++ b/tests/e2e/specs/passcode/check-passcode-requirements.test.ts
@@ -1,0 +1,41 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byTextMatches, byResourceId} from '../../utils/selectors';
+import {output} from '../../utils/naming';
+
+describe('Check Passcode Requirements Flow', () => {
+  it('should relaunch app and see Passcode entry screen', async () => {
+    await driver.terminateApp('com.comapeo.rc');
+    await driver.activateApp('com.comapeo.rc');
+
+    await expect($(byTextMatches('Enter your passcode'))).toBeDisplayed();
+    await expect($(byResourceId('SETTINGS.auth-passcode-inp'))).toBeDisplayed();
+
+    await expect(driver.isKeyboardShown());
+  });
+
+  it('should press Home, then return to see passcode screen again', async () => {
+    // should put app in the background
+    // keycode 3 is home button
+    await driver.pressKeyCode(3);
+    // if I figure out how, this should involve opening another app in between
+    await driver.pause(2000);
+    await driver.activateApp('com.comapeo.rc');
+
+    await expect($(byTextMatches('Enter your passcode'))).toBeDisplayed();
+  });
+
+  it('should handle wrong passcode, then close and reopen app, see passcode again, then correct passcode', async () => {
+    const passcodeField = await $(byResourceId('SETTINGS.auth-passcode-inp'));
+    await passcodeField.setValue('54321');
+
+    await expect($(byTextMatches('Incorrect passcode'))).toBeDisplayed();
+    // if I figure out how, this should be turn phone on and off instead
+    await driver.terminateApp('com.comapeo.rc');
+    await driver.activateApp('com.comapeo.rc');
+
+    await expect($(byTextMatches('Enter your passcode'))).toBeDisplayed();
+
+    await passcodeField.setValue(output.passcode);
+  });
+});

--- a/tests/e2e/specs/passcode/post-passcode-setup.test.ts
+++ b/tests/e2e/specs/passcode/post-passcode-setup.test.ts
@@ -1,0 +1,122 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byTextMatches, byText, byResourceId} from '../../utils/selectors';
+import {output} from '../../utils/naming';
+
+describe('Post Passcode Setup Flow', () => {
+  it('should navigate to Security and see "Enter Passcode" if passcode is set', async () => {
+    const drawerIcon = await $('~Open Navigation Drawer');
+    await drawerIcon.click();
+
+    const appSettingsOption = await $('~Go to App Settings');
+    await appSettingsOption.click();
+
+    const securityOption = await $(byTextMatches('Security'));
+    await securityOption.click();
+
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await expect($(byText('Passcode is set'))).toBeDisplayed();
+    await appPasscodeText.click();
+
+    await expect($(byTextMatches('Enter Passcode'))).toBeDisplayed();
+    await expect($(byResourceId('SETTINGS.passcode-inp'))).toBeDisplayed();
+
+    await expect(driver.isKeyboardShown());
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+    await expect(securityOption).toBeDisplayed();
+  });
+
+  it('should cancel passcode entry, then try with wrong passcode, then correct passcode', async () => {
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+
+    const cancelBtn = await $(byTextMatches('Cancel'));
+    await cancelBtn.click();
+
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+
+    await appPasscodeText.click();
+
+    const passcodeField = await $(byResourceId('SETTINGS.passcode-inp'));
+    await passcodeField.setValue(output.newpasscode);
+    await expect($(byText('Incorrect Passcode'))).toBeDisplayed();
+
+    await passcodeField.setValue(output.passcode);
+
+    await expect(appPasscodeText).toBeDisplayed();
+  });
+
+  it('should see "Use App Passcode" is checked, see "Change App Passcode," and cancel out', async () => {
+    await expect(
+      $(byTextMatches('App passcode adds an additional layer')),
+    ).toBeDisplayed();
+
+    await expect($(byResourceId('SETTINGS.passcode-checked'))).toBeDisplayed();
+
+    const changeBtn = await $(byText('Change App Passcode'));
+
+    await expect(changeBtn).toBeDisplayed();
+
+    await changeBtn.click();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    await expect(changeBtn).toBeDisplayed();
+    await changeBtn.click();
+
+    const cancelBtn = await $(byTextMatches('Cancel'));
+    await cancelBtn.click();
+
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+  });
+
+  it('should re-enter passcode, change it, confirm new passcode, then uncheck passcode usage', async () => {
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+
+    const passcodeField = await $(byResourceId('SETTINGS.passcode-inp'));
+    await passcodeField.setValue(output.passcode);
+    await expect($(byTextMatches('App Passcode'))).toBeDisplayed();
+
+    const changeBtn = await $(byTextMatches('Change App Passcode'));
+    await changeBtn.click();
+
+    await passcodeField.setValue(output.newpasscode);
+    const nextBtn = await $(byTextMatches('Next'));
+    await nextBtn.click();
+    23;
+    await passcodeField.setValue(output.newpasscode);
+    await nextBtn.click();
+
+    const saveBtn = await $(byTextMatches('Save App Passcode'));
+    await saveBtn.click();
+
+    await appPasscodeText.click();
+    await passcodeField.setValue(output.newpasscode);
+
+    const passcodeCheckbox = await $(byResourceId('SETTINGS.passcode-checked'));
+    await passcodeCheckbox.click();
+
+    await expect($(byTextMatches('Turn Off App Passcode?'))).toBeDisplayed();
+
+    const cancelTurnOff = await $(byTextMatches('Cancel'));
+    await cancelTurnOff.click();
+
+    await expect(
+      $(byTextMatches('Turn Off App Passcode?')),
+    ).not.toBeDisplayed();
+
+    await passcodeCheckbox.click();
+    const turnOffBtn = await $(byTextMatches('Turn Off'));
+    await turnOffBtn.click();
+
+    await expect($(byTextMatches('Passcode not set'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+    await backBtn.click();
+  });
+});

--- a/tests/e2e/specs/passcode/set-passcode.test.ts
+++ b/tests/e2e/specs/passcode/set-passcode.test.ts
@@ -1,0 +1,163 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byTextMatches, byResourceId} from '../../utils/selectors';
+import {output} from '../../utils/naming';
+
+describe('Set Passcode Flow', () => {
+  it('should navigate to Security screen from drawer', async () => {
+    const drawerIcon = await $('~Open Navigation Drawer');
+    await drawerIcon.click();
+
+    const appSettingsOption = await $('~Go to App Settings');
+    await appSettingsOption.click();
+
+    const securityOption = await $(byTextMatches('Security'));
+    await securityOption.click();
+
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+    await expect($(byTextMatches('App Passcode'))).toBeDisplayed();
+    await expect($(byTextMatches('Passcode not set'))).toBeDisplayed();
+  });
+
+  it('should open and back out of "What is App Passcode?" screen', async () => {
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+
+    await expect($(byTextMatches('What is App Passcode?'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+  });
+
+  it('should open passcode descriptor, back out of Set Passcode screen, then open it again', async () => {
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+
+    await expect(
+      $(byTextMatches('additional layer of security')),
+    ).toBeDisplayed();
+    const continueBtn = await $(byTextMatches('Continue'));
+    await expect(continueBtn).toBeDisplayed();
+
+    await continueBtn.click();
+
+    await expect($(byTextMatches('Set App Passcode'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+    await expect($(byTextMatches('What is App Passcode?'))).toBeDisplayed();
+
+    await continueBtn.click();
+  });
+
+  it('should cancel passcode setup and reopen it', async () => {
+    const cancelBtn = await $(byTextMatches('Cancel'));
+    await cancelBtn.click();
+
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+
+    const continueBtn = await $(byTextMatches('Continue'));
+    await continueBtn.click();
+
+    await expect($(byResourceId('SETTINGS.passcode-inp'))).toBeDisplayed();
+  });
+
+  it('should verify keyboard, handle passcode errors, then get to Re-enter screen', async () => {
+    await expect(driver.isKeyboardShown());
+
+    const nextBtn = await $(byTextMatches('Next'));
+    await nextBtn.click();
+    await expect(
+      $(byTextMatches('Password must be 5 numbers')),
+    ).toBeDisplayed();
+
+    const passcodeInp = await $(byResourceId('SETTINGS.passcode-inp'));
+    await passcodeInp.setValue('22');
+    await nextBtn.click();
+    await expect(
+      $(byTextMatches('Password must be 5 numbers')),
+    ).toBeDisplayed();
+
+    await passcodeInp.setValue('00000');
+    await nextBtn.click();
+    await expect(
+      $(byTextMatches('Cannot be used as a Passcode')),
+    ).toBeDisplayed();
+
+    await passcodeInp.setValue(output.passcode);
+    await nextBtn.click();
+
+    await expect($(byTextMatches('Re-enter Passcode'))).toBeDisplayed();
+  });
+
+  it('should handle going back from re-enter, open it again, mismatch passcode, then see bottom sheet', async () => {
+    let backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+    await expect($(byTextMatches('What is App Passcode?'))).toBeDisplayed();
+
+    const continueBtn = await $(byTextMatches('Continue'));
+    await continueBtn.click();
+
+    const passcodeInput = await $(byResourceId('SETTINGS.passcode-inp'));
+    await passcodeInput.setValue(output.passcode);
+    const nextBtn = await $(byTextMatches('Next'));
+    await nextBtn.click();
+
+    const cancelBtn = await $(byTextMatches('Cancel'));
+    await cancelBtn.click();
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+    await continueBtn.click();
+
+    await passcodeInput.setValue(output.passcode);
+    await nextBtn.click();
+
+    await expect(driver.isKeyboardShown());
+
+    await passcodeInput.setValue('54321');
+    await nextBtn.click();
+    await expect($(byTextMatches('Password does not match'))).toBeDisplayed();
+
+    await passcodeInput.setValue(output.passcode);
+    await nextBtn.click();
+    await expect(
+      $(byTextMatches('App Passcodes can never be recovered')),
+    ).toBeDisplayed();
+    await expect($(byTextMatches(output.passcode))).toBeDisplayed();
+
+    await cancelBtn.click();
+    await expect($(byTextMatches('Security'))).toBeDisplayed();
+  });
+
+  it('should finalize passcode setup, see "Passcode is set," then go back', async () => {
+    const appPasscodeText = await $(byTextMatches('App Passcode'));
+    await appPasscodeText.click();
+
+    const continueBtn = await $(byTextMatches('Continue'));
+    await continueBtn.click();
+
+    const passcodeInput = await $(byResourceId('SETTINGS.passcode-inp'));
+    await passcodeInput.setValue(output.passcode);
+
+    const nextBtn = await $(byTextMatches('Next'));
+    await nextBtn.click();
+
+    await passcodeInput.setValue(output.passcode);
+    await nextBtn.click();
+
+    const saveBtn = await $(byTextMatches('Save App Passcode'));
+    await saveBtn.click();
+
+    await expect($(byTextMatches('Passcode is set'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+  });
+});

--- a/tests/e2e/specs/settings/about-comapeo.test.ts
+++ b/tests/e2e/specs/settings/about-comapeo.test.ts
@@ -1,0 +1,31 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byResourceId, byTextMatches} from '../../utils/selectors';
+
+describe('About CoMapeo Flow', () => {
+  it('should open About CoMapeo from the drawer', async () => {
+    const drawerIcon = await $('~Open Navigation Drawer');
+    await drawerIcon.click();
+
+    const aboutComapeoOption = await $('~Go to About CoMapeo Screen');
+    await aboutComapeoOption.click();
+  });
+
+  it('should display version/build/variant and phone info', async () => {
+    await expect($(byTextMatches('About CoMapeo'))).toBeDisplayed();
+
+    await expect($(byTextMatches('CoMapeo version'))).toBeDisplayed();
+    await expect($(byTextMatches('CoMapeo build'))).toBeDisplayed();
+    await expect($(byTextMatches('CoMapeo variant'))).toBeDisplayed();
+    await expect($(byTextMatches('Android version'))).toBeDisplayed();
+    await expect($(byTextMatches('Android build number'))).toBeDisplayed();
+    await expect($(byTextMatches('Phone model'))).toBeDisplayed();
+  });
+
+  it('should navigate back to map screen', async () => {
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    await expect($(byResourceId('MAIN.mapbox-map-view'))).toBeDisplayed();
+  });
+});

--- a/tests/e2e/specs/settings/coordinates.test.ts
+++ b/tests/e2e/specs/settings/coordinates.test.ts
@@ -1,0 +1,37 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byResourceId, byTextMatches} from '../../utils/selectors';
+
+describe('Coordinates Settings Flow', () => {
+  it('should open the App Settings from the drawer', async () => {
+    const drawerIcon = await $('~Open Navigation Drawer');
+    await drawerIcon.click();
+
+    const appSettingsOption = await $('~Go to App Settings');
+    await appSettingsOption.click();
+  });
+
+  it('should open Coordinate System screen', async () => {
+    const coordinateSystemOption = await $(byTextMatches('Coordinate System'));
+    await coordinateSystemOption.click();
+
+    await expect($(byTextMatches('Decimal Degrees'))).toBeDisplayed();
+    await expect($(byTextMatches('Degrees/Minutes/Seconds'))).toBeDisplayed();
+    await expect(
+      $(byTextMatches('Universal Transverse Mercator')),
+    ).toBeDisplayed();
+  });
+
+  it('should select D/M/S, then back to Settings and back to map', async () => {
+    const dmsOption = await $(byTextMatches('Degrees/Minutes/Seconds'));
+    await dmsOption.click();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    await expect($(byTextMatches('App Settings'))).toBeDisplayed();
+
+    await backBtn.click();
+    await expect($(byResourceId('MAIN.mapbox-map-view'))).toBeDisplayed();
+  });
+});

--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -1,0 +1,51 @@
+import {expect} from '@wdio/globals';
+import {describe, it} from 'mocha';
+import {byResourceId, byTextMatches} from '../../utils/selectors';
+
+describe('Language Settings Flow', () => {
+  it('should open the Language list from App Settings', async () => {
+    const drawerIcon = await $('~Open Navigation Drawer');
+    await drawerIcon.click();
+
+    const appSettingsOption = await $('~Go to App Settings');
+    await appSettingsOption.click();
+
+    const languageOption = await $(byTextMatches('Language'));
+    await languageOption.click();
+  });
+
+  it('should scroll to Spanish, select it, and confirm language change', async () => {
+    const spanishElem = await $(byTextMatches('Spanish'));
+    await $(byTextMatches('Spanish')).scrollIntoView();
+    await spanishElem.click();
+
+    await expect($(byTextMatches('Idioma'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    const obsListTab = await $('~Go to ObservationsList');
+    await obsListTab.click();
+
+    await expect($(byTextMatches('Observaciones'))).toBeDisplayed();
+  });
+
+  it('should switch back to English and confirm language revert', async () => {
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    const drawerIcon = await $('~Open Navigation Drawer');
+    await drawerIcon.click();
+
+    const settingsInSpanish = await $(byTextMatches('Ajustes de la'));
+    await settingsInSpanish.click();
+
+    const idiomaOption = await $(byTextMatches('Idioma'));
+    await idiomaOption.click();
+
+    const englishElem = await $(byTextMatches('English'));
+    await englishElem.click();
+
+    await backBtn.click();
+  });
+});

--- a/tests/e2e/utils/touchActions.ts
+++ b/tests/e2e/utils/touchActions.ts
@@ -1,0 +1,32 @@
+import type {ChainablePromiseElement} from 'webdriverio';
+
+export async function tapAboveElement(
+  chainableElem: ChainablePromiseElement,
+  offset = 50,
+) {
+  const el = await chainableElem;
+  const elementId = await el.elementId;
+  const rect = await driver.getElementRect(elementId);
+  const xCoord = Math.round(rect.x + rect.width / 2);
+  const yCoord = Math.round(rect.y - offset);
+
+  await driver.performActions([
+    {
+      type: 'pointer',
+      id: 'finger1',
+      parameters: {pointerType: 'touch'},
+      actions: [
+        {
+          type: 'pointerMove',
+          origin: 'viewport',
+          x: xCoord,
+          y: yCoord,
+          duration: 100,
+        },
+        {type: 'pointerDown', button: 0},
+        {type: 'pointerUp', button: 0},
+      ],
+    },
+  ]);
+  await driver.releaseActions();
+}


### PR DESCRIPTION
closes #957 

Finishes off converting the current Maestro tests to Appium tests to run on Browserstack.
Adds eight new tests and calls them from the "flow" file.
Adds tests to create observations, add details, and check the observation lists.
Adds tests for various parts of the settings screens
Adds tests for using the passcode

I needed to also update the navigation when turning off the passcode based on [changes made necessary by the last upgrade](https://reactnavigation.org/docs/upgrading-from-6.x/#the-navigate-method-no-longer-goes-back-use-popto-instead). I missed this necessary fix when I did the upgrade last month.

The documentation for these tests lives in the docs/EndToEndTests folder