### PR TITLE
fix: disallow space only device names

### DIFF
--- a/src/frontend/screens/Onboarding/DeviceNaming.tsx
+++ b/src/frontend/screens/Onboarding/DeviceNaming.tsx
@@ -36,7 +36,6 @@ export const DeviceNaming = ({
 }: NativeStackScreenProps<OnboardingParamsList, 'DeviceNaming'>) => {
   const [name, setName] = React.useState('');
   const [errorTimeout, setErrorTimeout] = useTemporaryError();
-  const invalidName = name.length === 0 || name.length > 60;
   const {formatMessage: t} = useIntl();
 
   function setNameWithValidation(nameValue: string) {
@@ -48,12 +47,13 @@ export const DeviceNaming = ({
   }
 
   function handleAddNamePress() {
-    if (invalidName) {
+    const trimmedName = name.trim();
+    if (trimmedName.length === 0 || trimmedName.length > 60) {
       setErrorTimeout();
       return;
     }
 
-    navigation.navigate('Success', {deviceName: name});
+    navigation.navigate('Success', {deviceName: trimmedName});
   }
   return (
     <KeyboardAvoidingView style={{width: '100%', height: '100%'}}>

--- a/tests/e2e/specs/onboarding/device-naming.test.ts
+++ b/tests/e2e/specs/onboarding/device-naming.test.ts
@@ -20,8 +20,17 @@ describe('Device Naming Test', () => {
 
     const successMessage = await $(byTextMatches('Success'));
     await driver.waitUntil(async () => !(await successMessage.isExisting()), {
-      timeout: 5000,
+      timeout: 2000,
       timeoutMsg: 'The success message did not appear within timeout',
+    });
+
+    await deviceNameInput.setValue('    ');
+    await addNameButton.click();
+
+    await driver.waitUntil(async () => !(await successMessage.isExisting()), {
+      timeout: 2000,
+      timeoutMsg:
+        'Success message should not appear when input is only spaces.',
     });
 
     await deviceNameInput.setValue(output.names.device);


### PR DESCRIPTION
Fixes #973  
Makes sure need to enter some kind of text for device name by using trim()

The Edit Device Name did not need to be adjusted as it already does not allow just a blank space name.