### PR TITLE
chore: introduce usage of eslint-plugin-react-hooks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import pluginQuery from '@tanstack/eslint-plugin-query';
 import * as tsParser from '@typescript-eslint/parser';
 import pluginJest from 'eslint-plugin-jest';
 import pluginReactNative from 'eslint-plugin-react-native';
+import * as pluginReactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 import pluginTs from 'typescript-eslint';
 
@@ -62,6 +63,7 @@ const frontendConfig = pluginTs.config(
       pluginQuery.configs['flat/recommended'],
       pluginReact.configs['recommended-typescript'],
       pluginReact.configs['disable-dom'],
+      pluginReactHooks.configs['recommended-latest'],
       // https://github.com/facebook/react-native/issues/42996#issuecomment-2275994981
       {
         name: 'eslint-plugin-react-native',
@@ -83,6 +85,10 @@ const frontendConfig = pluginTs.config(
       '@eslint-react/web-api/no-leaked-resize-observer': 'off',
       // There are some cases in app code when it's needed
       '@typescript-eslint/no-require-imports': 'off',
+      // We want to strictly adhere
+      'react-hooks/exhaustive-deps': 'error',
+      // We want to strictly adhere
+      'react-hooks/rules-of-hooks': 'error',
       // Doesn't work well with custom components that wrap Text component
       'react-native/no-raw-text': 'off',
       // We only work on Android for now

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,7 @@
         "dotenv-cli": "8.0.0",
         "eslint": "9.21.0",
         "eslint-plugin-jest": "28.11.0",
+        "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-native": "5.0.0",
         "execa": "9.5.2",
         "glob": "10.3.15",
@@ -15405,6 +15406,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks-extra": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "dotenv-cli": "8.0.0",
     "eslint": "9.21.0",
     "eslint-plugin-jest": "28.11.0",
+    "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-native": "5.0.0",
     "execa": "9.5.2",
     "glob": "10.3.15",

--- a/src/frontend/contexts/MetricsContext.tsx
+++ b/src/frontend/contexts/MetricsContext.tsx
@@ -26,7 +26,7 @@ export const MetricsProvider = ({
   React.useEffect(() => {
     appMetrics.setEnabled(isEnabled);
     deviceMetrics.setEnabled(isEnabled);
-  }, [isEnabled]);
+  }, [isEnabled, appMetrics, deviceMetrics]);
 
   return (
     <MetricsContext.Provider value={{appMetrics, deviceMetrics}}>

--- a/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
+++ b/src/frontend/hooks/persistedState/usePersistedDraftObservation/index.ts
@@ -259,5 +259,5 @@ export const usePreset = () => {
   }
 };
 
-export const _usePersistedDraftObservationActions = () =>
+export const usePersistedDraftObservationActions = () =>
   usePersistedDraftObservation(state => state.actions);

--- a/src/frontend/hooks/useDraftObservation.ts
+++ b/src/frontend/hooks/useDraftObservation.ts
@@ -1,7 +1,7 @@
 import {useCallback} from 'react';
 import {usePhotoPromiseContext} from '../contexts/PhotoPromiseContext';
 import {
-  _usePersistedDraftObservationActions,
+  usePersistedDraftObservationActions,
   usePreset,
 } from './persistedState/usePersistedDraftObservation';
 import {
@@ -30,7 +30,7 @@ export const useDraftObservation = () => {
     existingObservationToDraft,
     addAudio,
     deleteAudio,
-  } = _usePersistedDraftObservationActions();
+  } = usePersistedDraftObservationActions();
 
   const addPhoto = useCallback(
     async ({capturePromise, mediaMetadata}: PhotoPromiseWithMetadata) => {


### PR DESCRIPTION
I didn't realize that `@eslint-react/eslint-plugin` doesn't have rules that overlap with the semi-"official" hooks plugin when initially updating our ESLint configuration. Ideally, you're supposed to use them in conjunction.

This PR introduces the hooks plugin which introduces rules related to adhering to the rules of hooks, and applies a couple of small fixes.