### PR TITLE
chore: disable Mapbox telemetry immediately

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -3,6 +3,7 @@ import {createMapeoClient} from '@comapeo/ipc';
 import {AppNavigator} from './AppNavigator';
 import {MessagePortLike} from './lib/MessagePortLike';
 import {initializeNodejs} from './initializeNodejs';
+import Mapbox from '@rnmapbox/maps';
 import {PermissionsAndroid} from 'react-native';
 import {AppProviders} from './contexts/AppProviders';
 import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
@@ -37,6 +38,8 @@ Sentry.init({
   debug: sentryDebug, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   initialScope: {user: {id: getSentryUserId({now: new Date(), storage})}},
 });
+
+Mapbox.setTelemetryEnabled(false);
 
 const appDiagnosticMetrics = new AppDiagnosticMetrics();
 const deviceDiagnosticMetrics = new DeviceDiagnosticMetrics();

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -63,10 +63,6 @@ export const MapScreen = ({
     navigate('PresetChooser');
   };
 
-  React.useEffect(() => {
-    Mapbox.setTelemetryEnabled(false);
-  }, []);
-
   // This closes the track bottom sheet whenever the user is navigated away.
   // This prevents the closing animation from happening when the map screen is being reopened
   useFocusEffect(


### PR DESCRIPTION
We were disabling Mapbox telemetry in a useEffect on the map screen. Because this happens after initial initialization of the app, there is a possibility that Mapbox could send telemetry before this is disabled. This PR sets telemetry collection to false as soon as we can. There is still not a solid guarantee that Mapbox will never send telemetry before this option is set, but I think this is the best we can do without switching to Maplibre