### PR TITLE
chore: update sodium-native@4.3.3

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -1244,6 +1244,24 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.9.3.tgz",
+      "integrity": "sha512-0W343p8kVy9KimDMrxJtJct/ILWL8gzC0Wwg/Fn/GgQplHvrllyz4fPobUVG5+gx9BokWttzg8FYypQP7V5nrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-events": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
@@ -1260,6 +1278,23 @@
         "bare-events": "^2.0.0",
         "bare-path": "^2.0.0",
         "bare-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.10.2.tgz",
+      "integrity": "sha512-C9COe/GhWfVXKytW3DElTkiBU+Gb2OXeaVkdGdRB/lp26TVLESHkTGS876iceAGdvtPgohfp9nX8vXHGvN3++Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
       }
     },
     "node_modules/bare-os": {
@@ -1279,6 +1314,12 @@
         "bare-os": "^2.1.0"
       }
     },
+    "node_modules/bare-semver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.1.tgz",
+      "integrity": "sha512-UtggzHLiTrmFOC/ogQ+Hy7VfoKoIwrP1UFcYtTxoCUdLtsIErT8+SWtOC2DH/snT9h+xDrcBEPcwKei1mzemgg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bare-stream": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.0.tgz",
@@ -1288,6 +1329,33 @@
       "dependencies": {
         "b4a": "^1.6.6",
         "streamx": "^2.20.0"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.1.3.tgz",
+      "integrity": "sha512-c02+eKvn/4esh5E2lSYQFwHL1WoTIL3u3NeFqb9e7ahBVENXw13MWx4/4/wdPyI557GqqB2Cm0bBbOXD0I0qgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bare-url/node_modules/bare-os": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.0.tgz",
+      "integrity": "sha512-BUrFS5TqSBdA0LwHop4OjPJwisqxGy6JsWVqV6qaFoe965qqtaKfDzHY5T2YA1gUL0ZeeQeA+4BBc1FJTcHiPw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-url/node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
       }
     },
     "node_modules/base-x": {
@@ -3523,6 +3591,7 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
       "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
       "license": "MIT",
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -4238,6 +4307,19 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
     },
+    "node_modules/require-addon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.1.0.tgz",
+      "integrity": "sha512-KbXAD5q2+v1GJnkzd8zzbOxchTkStSyJZ9QwoCq3QwEXAaIlG3wDYRZGzVD357jmwaGY7hr5VaoEAL0BkF0Kvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0",
+        "bare-url": "^2.1.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4682,12 +4764,12 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
-      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
       "license": "MIT",
       "dependencies": {
-        "node-gyp-build": "^4.8.0"
+        "require-addon": "^1.1.0"
       }
     },
     "node_modules/sodium-secretstream": {


### PR DESCRIPTION
Update transitive dep sodium-native@4.3.3 to test whether it will work on mobile, prior to publishing a release of comapeo-core that updates it.