### PR TITLE
Proposal: Update Location to utilize zustand and context

### DIFF
--- a/src/frontend/contexts/DraftObservationContext.tsx
+++ b/src/frontend/contexts/DraftObservationContext.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {StoreApi, useStore} from 'zustand';
 import CheapRuler from 'cheap-ruler';
-import * as Location from 'expo-location';
 import {
   DraftState,
   DraftObservationStore,
@@ -110,11 +109,7 @@ function useCreateDraftObservationLocationUpdator(
           if (!providerStatus?.locationServicesEnabled) return;
 
           // If manual location, do not update
-          if (
-            draftObservationStore.instance.getState().value?.metadata
-              ?.manualLocation
-          )
-            return;
+          if (currentDraft.metadata?.manualLocation) return;
 
           // if no initial position, set initial position
           if (!initialPosition) {
@@ -126,9 +121,34 @@ function useCreateDraftObservationLocationUpdator(
             });
           }
 
-          onPositionUpdate({
-            draftObservationStore,
-            location: location,
+          const isStale =
+            Date.now() - location.timestamp > STALE_LOCATION_THRESHOLD_MS;
+          if (isStale) return;
+
+          const initialAccuracy = initialPosition?.coords.accuracy;
+
+          const movedAwayThreshold = initialAccuracy
+            ? initialAccuracy * ACCURACY_MOVED_AWAY_FACTOR
+            : MOVED_AWAY_THRESHOLD_METERS;
+          const hasMovedAway =
+            initialPosition &&
+            distanceBetweenCoords(initialPosition.coords, location.coords) >
+              movedAwayThreshold;
+          if (hasMovedAway) return;
+
+          const currentDraftCoords = currentDraft.metadata?.position?.coords;
+
+          const isMoreAccurate =
+            !currentDraftCoords ||
+            !location.coords.accuracy ||
+            !currentDraftCoords.accuracy ||
+            location.coords.accuracy < currentDraftCoords.accuracy;
+
+          if (!isMoreAccurate) return;
+
+          draftObservationStore.actions.updatePosition({
+            manualLocation: false,
+            position: location,
             positionProvider: providerStatus,
           });
         });
@@ -149,50 +169,6 @@ function useCreateDraftObservationLocationUpdator(
       }
     };
   }, [draftObservationStore, locationStore]);
-}
-
-function onPositionUpdate({
-  location,
-  positionProvider,
-  draftObservationStore,
-}: {
-  location: Location.LocationObject;
-  positionProvider: Location.LocationProviderStatus;
-  draftObservationStore: DraftObservationStore;
-}) {
-  const {value: currentDraft, initialPosition} =
-    draftObservationStore.instance.getState();
-
-  if (!currentDraft) return;
-
-  const isStale = Date.now() - location.timestamp > STALE_LOCATION_THRESHOLD_MS;
-  if (isStale) return;
-
-  const initialAccuracy = initialPosition?.coords.accuracy;
-  const movedAwayThreshold = initialAccuracy
-    ? initialAccuracy * ACCURACY_MOVED_AWAY_FACTOR
-    : MOVED_AWAY_THRESHOLD_METERS;
-  const hasMovedAway =
-    initialPosition &&
-    distanceBetweenCoords(initialPosition.coords, location.coords) >
-      movedAwayThreshold;
-  if (hasMovedAway) return;
-
-  const currentDraftCoords = currentDraft.metadata?.position?.coords;
-
-  const isMoreAccurate =
-    !currentDraftCoords ||
-    !location.coords.accuracy ||
-    !currentDraftCoords.accuracy ||
-    location.coords.accuracy < currentDraftCoords.accuracy;
-
-  if (!isMoreAccurate) return;
-
-  draftObservationStore.actions.updatePosition({
-    manualLocation: false,
-    position: location,
-    positionProvider,
-  });
 }
 
 function isNewlyCreatedDraft(storeState: DraftState) {

--- a/src/frontend/contexts/DraftObservationContext.tsx
+++ b/src/frontend/contexts/DraftObservationContext.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
 
-import {useStore} from 'zustand';
+import {StoreApi, useStore} from 'zustand';
 import CheapRuler from 'cheap-ruler';
 import * as Location from 'expo-location';
-import {AppState, type AppStateStatus} from 'react-native';
 import {
   DraftState,
   DraftObservationStore,
   convertPosition,
 } from './PersistedStores/DraftObservationStore.ts';
+import {useLocationContext} from './LocationContext.tsx';
+import {LocationState} from './PersistedStores/LocationStore.ts';
 
 export function useDraftObservationState(): DraftState;
 export function useDraftObservationState<T>(
@@ -34,12 +35,17 @@ type DraftObservationProviderProps = {
   draftObservationStore: DraftObservationStore;
 };
 
-/** `draftObservationStore` should be initialized outside of react life cycle */
+/** `draftObservationStore` should be initialized outside of react life cycle there will be a stable value */
+// eslint-disable-next-line @eslint-react/no-unstable-context-value
 export const DraftObservationProvider = ({
   children,
   draftObservationStore,
 }: DraftObservationProviderProps) => {
-  createDraftObservationLocationUpdator(draftObservationStore);
+  const locationStore = useLocationContext();
+  useCreateDraftObservationLocationUpdator(
+    draftObservationStore,
+    locationStore,
+  );
   return (
     <DraftObservationContext.Provider value={draftObservationStore}>
       {children}
@@ -56,10 +62,6 @@ function useDraftObservationContext() {
   return value;
 }
 
-const LOCATION_OPTIONS: Location.LocationOptions = {
-  accuracy: Location.Accuracy.Highest,
-  timeInterval: 1000,
-};
 /** We don't update the position of an observation with the location from the
  * device location provider if the location is older than this threshold */
 const STALE_LOCATION_THRESHOLD_MS = 1000;
@@ -74,94 +76,123 @@ const MOVED_AWAY_THRESHOLD_METERS = 100;
  * update is 15m away. */
 const ACCURACY_MOVED_AWAY_FACTOR = 1.5;
 
-async function createDraftObservationLocationUpdator({
-  instance,
-  actions: {updatePosition},
-}: DraftObservationStore) {
-  let {granted: locationPermissionGranted} =
-    await Location.getForegroundPermissionsAsync();
-  let locationSubscriptionPromise: Promise<Location.LocationSubscription> | null =
-    null;
-  let appState: AppStateStatus = AppState.currentState;
-  let isNewlyCreatedDraftInStore = isNewlyCreatedDraft(instance.getState());
+function useCreateDraftObservationLocationUpdator(
+  draftObservationStore: DraftObservationStore,
+  locationStore: StoreApi<LocationState>,
+) {
+  React.useEffect(() => {
+    let locationSubscription: (() => void) | null = null;
+    let storeStateSubscription: (() => void) | null = null;
 
-  AppState.addEventListener('change', async nextAppState => {
-    appState = nextAppState;
-    if (appState === 'active' && !locationPermissionGranted) {
-      locationPermissionGranted = (
-        await Location.getForegroundPermissionsAsync()
-      ).granted;
-    }
-    watchPositionIfNeeded();
-  });
+    if (storeStateSubscription) return;
 
-  instance.subscribe(storeState => {
-    isNewlyCreatedDraftInStore = isNewlyCreatedDraft(storeState);
-    watchPositionIfNeeded();
-  });
+    draftObservationStore.instance.subscribe(storeState => {
+      const isNewlyCreatedDraftInStore = isNewlyCreatedDraft(storeState);
+      if (isNewlyCreatedDraftInStore && !locationSubscription) {
+        locationSubscription = locationStore.subscribe(locationState => {
+          const {value: currentDraft, initialPosition} =
+            draftObservationStore.instance.getState();
 
-  async function watchPositionIfNeeded() {
-    const shouldBeWatchingPosition =
-      appState === 'active' &&
-      isNewlyCreatedDraftInStore &&
-      locationPermissionGranted;
+          if (!currentDraft) {
+            // should not get here, re: isNewlyCreatedDraftInStore above
+            return;
+          }
 
-    if (shouldBeWatchingPosition && !locationSubscriptionPromise) {
-      locationSubscriptionPromise = Location.watchPositionAsync(
-        LOCATION_OPTIONS,
-        onPositionUpdate,
-      );
-    } else if (!shouldBeWatchingPosition && locationSubscriptionPromise) {
-      // Avoid a race condition by nulling the state before awaiting the promise
-      const locationSubscriptionPromiseCopy = locationSubscriptionPromise;
-      locationSubscriptionPromise = null;
-      const subscription = await locationSubscriptionPromiseCopy;
-      subscription.remove();
-    }
-  }
+          const location = locationState.location;
 
-  function onPositionUpdate(location: Location.LocationObject) {
-    const {value: currentDraft, initialPosition} = instance.getState();
-    if (!currentDraft) return;
+          if (!location) return;
+          // if the permission is not granted, there should be no new location. Therefore this location being returned here is stale
+          if (locationState.locationPermission !== 'granted') return;
 
-    const isManualLocation = !!currentDraft.metadata?.manualLocation;
-    if (isManualLocation) return;
+          const providerStatus = locationState.providerStatus;
 
-    const isStale =
-      Date.now() - location.timestamp > STALE_LOCATION_THRESHOLD_MS;
-    if (isStale) return;
+          // if location services is not enabled, the location is stale
+          if (!providerStatus?.locationServicesEnabled) return;
 
-    instance.setState(prev => {
-      if (prev.initialPosition || !prev.value) return prev;
-      return {...prev, initialPosition: convertPosition(location)};
+          // If manual location, do not update
+          if (
+            draftObservationStore.instance.getState().value?.metadata
+              ?.manualLocation
+          )
+            return;
+
+          // if no initial position, set initial position
+          if (!initialPosition) {
+            draftObservationStore.instance.setState(prev => {
+              {
+                if (!prev.value) return prev;
+                return {...prev, initialPosition: convertPosition(location)};
+              }
+            });
+          }
+
+          onPositionUpdate({
+            draftObservationStore,
+            location: location,
+            positionProvider: providerStatus,
+          });
+        });
+      } else if (!isNewlyCreatedDraftInStore && locationSubscription) {
+        locationSubscription();
+        locationSubscription = null;
+      }
     });
 
-    const initialAccuracy = initialPosition?.coords.accuracy;
-    const movedAwayThreshold = initialAccuracy
-      ? initialAccuracy * ACCURACY_MOVED_AWAY_FACTOR
-      : MOVED_AWAY_THRESHOLD_METERS;
-    const hasMovedAway =
-      initialPosition &&
-      distanceBetweenCoords(initialPosition.coords, location.coords) >
-        movedAwayThreshold;
-    if (hasMovedAway) return;
+    return () => {
+      if (storeStateSubscription) {
+        storeStateSubscription();
+        storeStateSubscription = null;
+      }
+      if (locationSubscription) {
+        locationSubscription();
+        locationSubscription = null;
+      }
+    };
+  }, [draftObservationStore, locationStore]);
+}
 
-    const currentDraftCoords = currentDraft.metadata?.position?.coords;
+function onPositionUpdate({
+  location,
+  positionProvider,
+  draftObservationStore,
+}: {
+  location: Location.LocationObject;
+  positionProvider: Location.LocationProviderStatus;
+  draftObservationStore: DraftObservationStore;
+}) {
+  const {value: currentDraft, initialPosition} =
+    draftObservationStore.instance.getState();
 
-    const isMoreAccurate =
-      !currentDraftCoords ||
-      !location.coords.accuracy ||
-      !currentDraftCoords.accuracy ||
-      location.coords.accuracy < currentDraftCoords.accuracy;
+  if (!currentDraft) return;
 
-    if (!isMoreAccurate) return;
+  const isStale = Date.now() - location.timestamp > STALE_LOCATION_THRESHOLD_MS;
+  if (isStale) return;
 
-    updatePosition({
-      manualLocation: false,
-      position: location,
-      // TODO: Also add positionProvider. Probably needs access to the locationProvider store.
-    });
-  }
+  const initialAccuracy = initialPosition?.coords.accuracy;
+  const movedAwayThreshold = initialAccuracy
+    ? initialAccuracy * ACCURACY_MOVED_AWAY_FACTOR
+    : MOVED_AWAY_THRESHOLD_METERS;
+  const hasMovedAway =
+    initialPosition &&
+    distanceBetweenCoords(initialPosition.coords, location.coords) >
+      movedAwayThreshold;
+  if (hasMovedAway) return;
+
+  const currentDraftCoords = currentDraft.metadata?.position?.coords;
+
+  const isMoreAccurate =
+    !currentDraftCoords ||
+    !location.coords.accuracy ||
+    !currentDraftCoords.accuracy ||
+    location.coords.accuracy < currentDraftCoords.accuracy;
+
+  if (!isMoreAccurate) return;
+
+  draftObservationStore.actions.updatePosition({
+    manualLocation: false,
+    position: location,
+    positionProvider,
+  });
 }
 
 function isNewlyCreatedDraft(storeState: DraftState) {

--- a/src/frontend/contexts/LocationContext.tsx
+++ b/src/frontend/contexts/LocationContext.tsx
@@ -1,0 +1,162 @@
+import {
+  watchPositionAsync,
+  Accuracy,
+  PermissionStatus,
+  LocationSubscription,
+  getProviderStatusAsync,
+  getForegroundPermissionsAsync,
+} from 'expo-location';
+import React, {createContext, useContext} from 'react';
+import {
+  createLocationStore,
+  LocationState,
+} from './PersistedStores/LocationStore';
+import {getCoords} from '../hooks/useLocation';
+import CheapRuler from 'cheap-ruler';
+import {useQueryClient} from '@tanstack/react-query';
+import {AppState, AppStateStatus} from 'react-native';
+import {useStore} from 'zustand';
+import * as Sentry from '@sentry/react-native';
+
+export function useLocationState(): LocationState;
+export function useLocationState<T>(selector: (state: LocationState) => T): T;
+export function useLocationState<T>(selector?: (state: LocationState) => T) {
+  const store = useLocationContext();
+  return useStore(store, selector!);
+}
+
+const LocationContext = createContext<ReturnType<
+  typeof createLocationStore
+> | null>(null);
+
+const POLL_PROVIDER_STATUS_INTERVAL = 10;
+
+export function LocationProvider({
+  children,
+  locationPermission,
+}: {
+  children: React.ReactNode;
+  locationPermission: PermissionStatus;
+}) {
+  const [store] = React.useState(() => createLocationStore(locationPermission));
+
+  const queryClient = useQueryClient();
+
+  // These useEffects update the store but do not cause re-renders as the store itself is stable
+  // zustand's useStore deal with the react state.
+  React.useEffect(() => {
+    let subscription: LocationSubscription | null = null;
+    watchPositionAsync(
+      {
+        accuracy: Accuracy.BestForNavigation,
+      },
+      location => {
+        store.setState(prev => ({...prev, location}));
+        const lastThrottledLocation = store.getState().throttledLocation;
+        if (!lastThrottledLocation) {
+          store.setState(prev => ({
+            ...prev,
+            throttledLocation: location,
+          }));
+          return;
+        }
+
+        const timeElapsed =
+          location.timestamp - lastThrottledLocation.timestamp;
+
+        if (timeElapsed < 1000) return;
+
+        const coords = getCoords(location);
+        const lastCoords = getCoords(lastThrottledLocation);
+        const ruler = new CheapRuler(lastCoords[1], 'meters');
+        const distance = ruler.distance(coords, lastCoords);
+
+        if (distance > 5) {
+          store.setState(prev => ({
+            ...prev,
+            throttledLocation: location,
+          }));
+          return;
+        }
+      },
+    )
+      .then(sub => (subscription = sub))
+      .catch(error => {
+        console.error('Failed to start location tracking:', error);
+      });
+
+    return () => {
+      if (subscription) {
+        subscription.remove();
+      }
+    };
+  }, [store]);
+
+  React.useEffect(() => {
+    let ignore = false;
+    async function checkProviderStatus() {
+      getProviderStatusAsync()
+        .then(status => {
+          if (ignore) return;
+          if (!status.locationServicesEnabled)
+            queryClient.invalidateQueries({queryKey: ['lastLocation']});
+          store.setState(store => ({...store, providerStatus: status}));
+        })
+        // Shouldn't happen because we check permissions.granted above, but just in case
+        .catch(err => {
+          Sentry.captureException(err);
+        });
+    }
+    checkProviderStatus();
+    const intervalId = setInterval(
+      checkProviderStatus,
+      POLL_PROVIDER_STATUS_INTERVAL,
+    );
+    return () => {
+      clearInterval(intervalId);
+      ignore = true;
+    };
+  }, [store, queryClient]);
+
+  React.useEffect(() => {
+    let isCancelled = false;
+    const handleAppStateChange = async (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'active') {
+        const newPermissionStatus = (await getForegroundPermissionsAsync())
+          .status;
+        if (isCancelled) return;
+        const prevPermission = store.getState().locationPermission;
+        if (prevPermission !== newPermissionStatus) {
+          store.setState(state => ({
+            ...state,
+            locationPermission: newPermissionStatus,
+          }));
+        }
+      }
+    };
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange,
+    );
+
+    return () => {
+      isCancelled = true;
+      subscription.remove();
+    };
+  }, [store]);
+
+  return (
+    <LocationContext.Provider value={store}>
+      {children}
+    </LocationContext.Provider>
+  );
+}
+
+export function useLocationContext() {
+  const context = useContext(LocationContext);
+  if (context === null) {
+    throw new Error('Location Context not intialized');
+  }
+  return context;
+}

--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -252,7 +252,7 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
           manualLocation: false;
           position: LocationObject;
           // TODO: Optional for now until we integrate this into the draft observation location updater
-          positionProvider?: LocationProviderStatus;
+          positionProvider: LocationProviderStatus;
         }
       | {
           manualLocation: true;

--- a/src/frontend/contexts/PersistedStores/LocationStore.ts
+++ b/src/frontend/contexts/PersistedStores/LocationStore.ts
@@ -1,0 +1,26 @@
+import {
+  LocationObject,
+  PermissionStatus,
+  LocationProviderStatus,
+} from 'expo-location';
+import {createStore} from 'zustand';
+
+export type LocationState = {
+  location: LocationObject | undefined;
+  throttledLocation: LocationObject | undefined;
+  locationPermission: PermissionStatus;
+  providerStatus: LocationProviderStatus | undefined;
+};
+
+export function createLocationStore(initialStatus: PermissionStatus) {
+  const instance = createStore<LocationState>()(() => {
+    return {
+      location: undefined,
+      throttledLocation: undefined,
+      locationPermission: initialStatus,
+      providerStatus: undefined,
+    };
+  });
+
+  return instance;
+}


### PR DESCRIPTION
# Proposal PR: Centralizing Location Management in Zustand

This is a proposal PR. The implementation details are less important at this stage—I am primarily looking for feedback on the architecture.

## Main Proposal

Move `location`, `locationProviderStatus`, and `locationPermissions` into a Zustand store and [propagate those values via a context](https://tkdodo.eu/blog/zustand-and-react-context)](https://tkdodo.eu/blog/zustand-and-react-context).

## Previous Implementation & Rationale

### How `useLocation` Currently Works
- `useLocation` subscribes to location changes and updates React state.
- Each use of `useLocation` creates a new subscription.
- Example: The map screen and the GPS pill (in the header) both use `useLocation`, leading to two separate subscriptions when the map is open.

### Why We Took This Approach
- **High-frequency updates:** GPS data updates multiple times per second, even when stationary.
- **Battery performance concerns:** Frequent updates were causing excessive re-renders, particularly in the map screen.
- **Throttling strategy:**
  - The map screen receives a throttled location to reduce re-renders.
  - The GPS pill and observation location use the most precise location.
  - Even though these use the same subscription, we needed to throttle it for the map but not for the other components. We decided to use seperate subscriptions for each for that reason
- **Context concerns:**
  - Initially avoided using Context because it would require wrapping the entire navigator meaning the subscription would always be running even if subcription weren't being used

### `locationProviderStatus`
- Tracks whether the user has disabled location services.
- Initially considered Context but rejected due to persistent background subscriptions.

### `locationPermissions`
- Currently a mix of Expo’s `useLocationPermission` hook and Android’s permissions API.
- `useLocationPermission` is not fully reactive (doesn't detect permission revocations from system settings).

## What Has Changed

- **Subscriptions are always running anyway.**
  - Due to React Navigation’s behavior, the first screen in a stack remains mounted.
  - Since the first screen is the **map**, we are already running both the location and provider status subscriptions.
  - Additionally, the GPS pill has its own subscription, leading to duplication.
- **Proposal:** Centralize the subscriptions into a Zustand store.
  - Run them once instead of multiple times.
  - Use Zustand to ensure only consuming components re-render instead of the entire app.

## Proposed Solution

1. **Use Zustand for State Management:**
   - Centralize `location`, `locationProviderStatus`, and `locationPermissions`.
   - Prevent redundant subscriptions by managing state in a single place.
2. **Control Subscriptions with Context:**
   - Use a React context to start/stop subscriptions via lifecycle methods.
   - This avoids memory leaks, which could occur if subscriptions were directly managed in Zustand outside React’s lifecycle.
3. **Optimize Location Updates:**
   - Maintain two separate location values:
     - **Throttled location** for the map (reduces re-renders).
     - **Precise location** for GPS pill and observations.
   - Both values derive from the same subscription but update separate properties in the Zustand store.
4. **Unify Permission Handling:**
   - Subscribe to app state changes (already done in the map screen) to detect permission changes.
   - Store the permission status in Zustand for a simpler, centralized approach.

## Benefits

- **Single source of truth:** Eliminates redundant subscriptions.
- **Better performance:** Only relevant components update, preventing unnecessary re-renders.
- **Cleaner code:** Simplifies permission handling and avoids multiple subscription mechanisms.
- **Easier debugging & maintenance:** Centralized state management improves clarity.

@cimigree and @achou11 I will set up a meeting for us to talk about this further. But feel free to add comments here before hand