### PR TITLE
fix: Updates styling of how to join a project.

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1319,7 +1319,7 @@
     "message": "Create a Project"
   },
   "screens.Settings.CreateOrJoinProject.JoinExistingProject.goBack": {
-    "message": "Go back"
+    "message": "Go Back"
   },
   "screens.Settings.CreateOrJoinProject.JoinExistingProject.howTo": {
     "message": "How to Join a Project"

--- a/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/JoinExistingProject.tsx
@@ -1,9 +1,11 @@
 import {StyleSheet, View} from 'react-native';
-import {Text} from '../../../sharedComponents/Text';
+import {HeaderText} from '../../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../../sharedComponents/Text/BodyText';
 import {defineMessages, useIntl} from 'react-intl';
 import {Button} from '../../../sharedComponents/Button';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {AppStackParamsList} from '../../../sharedTypes/navigation';
+import {DARK_GREY, NEW_DARK_GREY, BLUE_GREY} from '../../../lib/styles';
 
 const m = defineMessages({
   howTo: {
@@ -17,7 +19,7 @@ const m = defineMessages({
   },
   goBack: {
     id: 'screens.Settings.CreateOrJoinProject.JoinExistingProject.goBack',
-    defaultMessage: 'Go back',
+    defaultMessage: 'Go Back',
   },
 });
 
@@ -27,34 +29,75 @@ export const JoinExistingProject = ({
   const {formatMessage} = useIntl();
   return (
     <View style={styles.container}>
-      <View>
-        <Text style={[styles.text, {fontSize: 20}]}>
+      <View style={styles.topSection}>
+        <View style={styles.helpIconContainer}>
+          <HeaderText variant="header1" style={styles.helpIconText}>
+            ?
+          </HeaderText>
+        </View>
+
+        <HeaderText variant="header1" style={styles.heading}>
           {formatMessage(m.howTo)}
-        </Text>
-        <Text style={[styles.text, {marginTop: 20}]}>
+        </HeaderText>
+
+        <BodyText style={styles.instructions}>
           {formatMessage(m.instructions)}
-        </Text>
+        </BodyText>
       </View>
-      <Button
-        fullWidth
-        variant="outlined"
-        onPress={() => {
-          navigation.goBack();
-        }}>
-        {formatMessage(m.goBack)}
-      </Button>
+
+      <View style={styles.footer}>
+        <Button
+          fullWidth
+          variant="outlined"
+          style={{
+            borderColor: BLUE_GREY,
+          }}
+          color="ComapeoBlue"
+          onPress={() => {
+            navigation.goBack();
+          }}>
+          {formatMessage(m.goBack)}
+        </Button>
+      </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    padding: 20,
-    paddingTop: 80,
-    justifyContent: 'space-between',
-    height: '100%',
+    flex: 1,
+    paddingHorizontal: 40,
   },
-  text: {
+  topSection: {
+    paddingTop: 80,
+    alignItems: 'center',
+    gap: 20,
+  },
+  helpIconContainer: {
+    height: 80,
+    width: 80,
+    borderRadius: 40,
+    borderWidth: 1,
+    borderColor: NEW_DARK_GREY,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  helpIconText: {
+    color: NEW_DARK_GREY,
+  },
+  heading: {
     textAlign: 'center',
+    color: DARK_GREY,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: DARK_GREY,
+    lineHeight: 24,
+    paddingTop: 20,
+  },
+  footer: {
+    marginTop: 'auto',
+    paddingBottom: 20,
+    width: '100%',
   },
 });


### PR DESCRIPTION
closes #948 

- This PR adds a help icon and corrects the styling of the how to join a project screen.
- It uses the updated Header and Body Text with the color specified in the Figma
- It spaces it to reflect what is in the FIgma
- It updates the button to be what the outlined buttons throughout the app are [supposed to look like](https://www.notion.so/digidem/Correction-Correct-style-for-secondary-buttons-10b1b08162d5801eb19be0c1f6b1be80)
- [(but which we aren't doing just yet)](https://github.com/digidem/comapeo-mobile/issues/979)

- Here is the [FIGMA (sort of](https://www.figma.com/design/iUeC0Qzhb4H0unuPfxQAsM/(Mobile)-CoMapeo?node-id=291-4476&t=jNP9tEeyOi3DuK9m-0))

- But [the Notion Doc](https://www.notion.so/digidem/Correction-Add-help-icon-10b1b08162d58088bc73f7542521740d) is more clear to me about what the changes needed to be because it includes the new button.
---

**Here is a screenshot from my pixel of what I did.**

<image src="https://github.com/user-attachments/assets/6abf43c7-22cc-46ac-9f8b-611a4d630555" width="350" />





