### PR TITLE
Shows react native alert after a config file is successfully imported.

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1315,6 +1315,9 @@
   "screens.Settings.Config.navTitle": {
     "message": "Configuration"
   },
+  "screens.Settings.Config.okButton": {
+    "message": "OK"
+  },
   "screens.Settings.Config.projectName": {
     "message": "Project Name:"
   },
@@ -1368,6 +1371,9 @@
   },
   "screens.Settings.CreateOrJoinProject.joinProject": {
     "message": "Join a Project"
+  },
+  "screens.Settings.CreateOrJoinProject.okButton": {
+    "message": "OK"
   },
   "screens.Settings.CreateOrJoinProject.projectDescription": {
     "message": "A project is a secure container for your data. Only devices you invite can enter and share data with you. Create or Join a project in order to share data with other devices. This action will delete observations you have collected so far. Consider sharing {icon} important observations to your email before proceeding."

--- a/messages/en.json
+++ b/messages/en.json
@@ -1306,6 +1306,9 @@
   "screens.Settings.Config.importConfig": {
     "message": "Import Config"
   },
+  "screens.Settings.Config.importSuccessTitle": {
+    "message": "Successfully imported config:"
+  },
   "screens.Settings.Config.name": {
     "message": "Config Name:"
   },
@@ -1356,6 +1359,9 @@
   },
   "screens.Settings.CreateOrJoinProject.importConfigFileError": {
     "message": "File name should end with .comapeocat"
+  },
+  "screens.Settings.CreateOrJoinProject.importSuccessTitle": {
+    "message": "Successfully imported config:"
   },
   "screens.Settings.CreateOrJoinProject.joinExisting": {
     "message": "Join an existing CoMapeo Project"

--- a/src/frontend/screens/Settings/Config.tsx
+++ b/src/frontend/screens/Settings/Config.tsx
@@ -1,7 +1,7 @@
 import * as FileSystem from 'expo-file-system';
 import * as React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
-import {StyleSheet, View} from 'react-native';
+import {Alert, StyleSheet, View} from 'react-native';
 import {Text} from '../../sharedComponents/Text';
 import {useSelectFile} from '../../hooks/files';
 import {
@@ -39,6 +39,10 @@ const m = defineMessages({
   importConfig: {
     id: 'screens.Settings.Config.importConfig',
     defaultMessage: 'Import Config',
+  },
+  configImportTitle: {
+    id: 'screens.Settings.Config.importSuccessTitle',
+    defaultMessage: 'Successfully imported config:',
   },
 });
 
@@ -91,6 +95,11 @@ export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
                 FileSystem.deleteAsync(selected.uri, {idempotent: true}).catch(
                   noop,
                 );
+              },
+              onSuccess: () => {
+                Alert.alert(formatMessage(m.configImportTitle), selected.name, [
+                  {text: 'OK'},
+                ]);
               },
             },
           );

--- a/src/frontend/screens/Settings/Config.tsx
+++ b/src/frontend/screens/Settings/Config.tsx
@@ -44,6 +44,10 @@ const m = defineMessages({
     id: 'screens.Settings.Config.importSuccessTitle',
     defaultMessage: 'Successfully imported config:',
   },
+  okButton: {
+    id: 'screens.Settings.Config.okButton',
+    defaultMessage: 'OK',
+  },
 });
 
 export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
@@ -98,7 +102,7 @@ export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
               },
               onSuccess: () => {
                 Alert.alert(formatMessage(m.configImportTitle), selected.name, [
-                  {text: 'OK'},
+                  {text: formatMessage(m.okButton)},
                 ]);
               },
             },

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -3,7 +3,13 @@ import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import {useForm} from 'react-hook-form';
 import {defineMessages, useIntl} from 'react-intl';
-import {Keyboard, KeyboardAvoidingView, StyleSheet, View} from 'react-native';
+import {
+  Alert,
+  Keyboard,
+  KeyboardAvoidingView,
+  StyleSheet,
+  View,
+} from 'react-native';
 import {
   TouchableOpacity,
   TouchableWithoutFeedback,
@@ -47,6 +53,10 @@ const m = defineMessages({
   importConfigFileError: {
     id: 'screens.Settings.CreateOrJoinProject.importConfigFileError',
     defaultMessage: 'File name should end with .comapeocat',
+  },
+  configImportTitle: {
+    id: 'screens.Settings.CreateOrJoinProject.importSuccessTitle',
+    defaultMessage: 'Successfully imported config:',
   },
 });
 
@@ -136,6 +146,7 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
         onSuccess: selected => {
           if (!selected) return;
           setConfigFileResult({type: 'success', file: selected});
+          Alert.alert(t(m.configImportTitle), selected.name, [{text: 'OK'}]);
         },
         onError: err => {
           setConfigFileResult({type: 'error', error: err});

--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateProject/index.tsx
@@ -58,6 +58,10 @@ const m = defineMessages({
     id: 'screens.Settings.CreateOrJoinProject.importSuccessTitle',
     defaultMessage: 'Successfully imported config:',
   },
+  okButton: {
+    id: 'screens.Settings.CreateOrJoinProject.okButton',
+    defaultMessage: 'OK',
+  },
 });
 
 type ConfigFileImportResult =
@@ -146,7 +150,9 @@ export const CreateProject: NativeNavigationComponent<'CreateProject'> = ({
         onSuccess: selected => {
           if (!selected) return;
           setConfigFileResult({type: 'success', file: selected});
-          Alert.alert(t(m.configImportTitle), selected.name, [{text: 'OK'}]);
+          Alert.alert(t(m.configImportTitle), selected.name, [
+            {text: t(m.okButton)},
+          ]);
         },
         onError: err => {
           setConfigFileResult({type: 'error', error: err});


### PR DESCRIPTION
**closes #951**

- Shows a native Android Alert when config import succeeds.  
- Text matches Notion/Figma specs. Color cannot be customized (no purple “OK”).  
- The “OK” button simply closes the alert, per requirements.

**Screenshots**:  
!<image src="https://github.com/user-attachments/assets/8a522783-d03e-4413-a37b-776f7ee31103" width="300" />
!<image src="https://github.com/user-attachments/assets/1df74f0b-55a4-45ef-b6f5-3e713f3300bf" width="300" /> 

**References**:  
- [Notion doc](https://www.notion.so/digidem/Correction-Import-Config-No-success-screen-when-importing-e965894a8eb24be5bff38148b0cf7130)
- [Figma](https://www.figma.com/design/fk0kK8cdXX1Vs9JCWRSdVh/In-Progress?node-id=122-171&t=pXsQyiQSowKGLXPM-0)