### PR TITLE
chore: use coordinate format functions from `lib/coordinateFormat` instead of `lib/utils`

### DIFF
--- a/src/frontend/lib/utils.test.ts
+++ b/src/frontend/lib/utils.test.ts
@@ -1,7 +1,0 @@
-import {convertToUTM} from './utils';
-
-describe('convertToUTM', () => {
-  it('converts latitude + longitude to UTM format', () => {
-    expect(convertToUTM({lat: 12, lon: -34})).toBe('UTM 25P 391136 1326751');
-  });
-});

--- a/src/frontend/lib/utils.ts
+++ b/src/frontend/lib/utils.ts
@@ -1,10 +1,8 @@
 // import { Alert } from "react-native";
-import {fromLatLon} from 'utm';
 import {Preset, Observation, Track} from '@comapeo/schema';
 import {LocationObject, LocationProviderStatus} from 'expo-location';
 import {FeatureCollection, LineString} from 'geojson';
 
-import {type CoordinateFormat} from '../lib/coordinateFormat';
 import {LocationHistoryPoint} from '../sharedTypes/location';
 
 // import type {
@@ -92,98 +90,6 @@ export function getLocationStatus({
 //     fields: filterFalsy(fieldDefs),
 //   };
 // }
-
-// // Coordinates conversions
-export function toDegreesMinutesAndSeconds(coordinate: number) {
-  const absolute = Math.abs(coordinate);
-  const degrees = Math.floor(absolute);
-  const minutesNotTruncated = (absolute - degrees) * 60;
-  const minutes = Math.floor(minutesNotTruncated);
-  const seconds = (minutesNotTruncated - minutes) * 60;
-  return {
-    degrees,
-    minutes,
-    seconds,
-  };
-}
-
-export function convertDmsToDd({
-  degrees,
-  minutes,
-  seconds,
-}: {
-  degrees: number;
-  minutes: number;
-  seconds: number;
-}) {
-  return degrees + minutes / 60 + seconds / 3600;
-}
-
-// Style from National Geographic style guide
-// https://sites.google.com/a/ngs.org/ngs-style-manual/home/L/latitude-and-longitude
-function convertToDMS({lat, lon}: {lat: number; lon: number}) {
-  const latitude = formatDms(toDegreesMinutesAndSeconds(lat));
-  const latitudeCardinal = lat >= 0 ? 'N' : 'S';
-
-  const longitude = formatDms(toDegreesMinutesAndSeconds(lon));
-  const longitudeCardinal = lon >= 0 ? 'E' : 'W';
-  return `${latitude} ${latitudeCardinal}, ${longitude} ${longitudeCardinal}`;
-}
-
-export function convertToUTM({lat, lon}: {lat: number; lon: number}) {
-  try {
-    const {easting, northing, zoneNum, zoneLetter} = fromLatLon(lat, lon);
-    return `UTM ${zoneNum}${zoneLetter} ${easting.toFixed()} ${northing.toFixed()}`;
-  } catch {
-    // Some coordinates (e.g. < 80S or 84N) cannot be formatted as UTM
-    return `${lat >= 0 ? '+' : ''}${lat.toFixed(6)}°, ${
-      lon >= 0 ? '+' : ''
-    }${lon.toFixed(6)}°`;
-  }
-}
-
-// Style from National Geographic style guide
-// https://sites.google.com/a/ngs.org/ngs-style-manual/home/L/latitude-and-longitude
-function formatDD({lat, lon}: {lat: number; lon: number}) {
-  const formattedLat = Math.abs(lat).toFixed(6);
-  const formattedLon = Math.abs(lon).toFixed(6);
-  const latCardinal = lat >= 0 ? 'N' : 'S';
-  const lonCardinal = lon >= 0 ? 'E' : 'W';
-  return `${formattedLat}° ${latCardinal}, ${formattedLon}° ${lonCardinal}`;
-}
-
-function formatDms({
-  degrees,
-  minutes,
-  seconds,
-}: {
-  degrees: number;
-  minutes: number;
-  seconds: number;
-}) {
-  return `${degrees}° ${minutes}' ${seconds.toFixed(3)}"`;
-}
-
-export function formatCoords({
-  lon,
-  lat,
-  format = 'utm',
-}: {
-  lon: number;
-  lat: number;
-  format?: CoordinateFormat;
-}): string {
-  switch (format) {
-    case 'dd':
-      return formatDD({lat, lon});
-    case 'utm':
-      return convertToUTM({lat, lon});
-    case 'dms':
-      return convertToDMS({lat, lon});
-    default:
-      return convertToUTM({lat, lon});
-  }
-}
 
 // export function getProp(tags: any, fieldKey: Key, defaultValue: any) {
 //   // TODO: support deeply nested tags.

--- a/src/frontend/screens/ManualGpsScreen/DmsForm/index.tsx
+++ b/src/frontend/screens/ManualGpsScreen/DmsForm/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {View} from 'react-native';
 import {FormattedMessage, defineMessages, useIntl} from 'react-intl';
 
-import {convertDmsToDd} from '../../../lib/utils';
+import {convertDmsToDd} from '../../../lib/coordinateFormat';
 import {
   CoordinateField,
   FormProps,

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -7,7 +7,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeleteObservation} from '../../hooks/server/observations';
 import {useObservationWithPreset} from '../../hooks/useObservationWithPreset.ts';
-import {formatCoords} from '../../lib/utils.ts';
+import {formatCoords} from '../../lib/coordinateFormat.ts';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {convertUrlToBase64} from '../../utils/base64.ts';
 import * as Sentry from '@sentry/react-native';

--- a/src/frontend/screens/Settings/AppSettings/CoordinateFormat.tsx
+++ b/src/frontend/screens/Settings/AppSettings/CoordinateFormat.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {ScrollView} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 
-import {formatCoords} from '../../../lib/utils';
+import {formatCoords} from '../../../lib/coordinateFormat';
 import {SelectOne} from '../../../sharedComponents/SelectOne';
 import {type CoordinateFormat as CoordinateFormatType} from '../../../lib/coordinateFormat';
 import type {NativeNavigationComponent} from '../../../sharedTypes/navigation';

--- a/src/frontend/sharedComponents/FormattedData.tsx
+++ b/src/frontend/sharedComponents/FormattedData.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-intl';
 import {Field, Preset} from '@comapeo/schema';
 
-import {formatCoords} from '../lib/utils';
+import {formatCoords} from '../lib/coordinateFormat';
 import {DateDistance} from './DateDistance';
 import {type CoordinateFormat} from '../lib/coordinateFormat';
 


### PR DESCRIPTION
Meant to do this in #1060 but forgot to port over the relevant changes before merging (dangers of copy+paste from previous attempts 😅 )

This PR doesn't add tests for the relevant functions as described in #1062 since I want this to be a quick follow-up