### PR TITLE
chore: clean up createPersistedState file

### DIFF
--- a/src/frontend/hooks/persistedState/createPersistedState.ts
+++ b/src/frontend/hooks/persistedState/createPersistedState.ts
@@ -1,4 +1,4 @@
-import {StateCreator, create, createStore} from 'zustand';
+import {StateCreator, create} from 'zustand';
 import {
   StateStorage,
   persist,
@@ -9,14 +9,8 @@ import {MMKV} from 'react-native-mmkv';
 
 export const storage = new MMKV();
 
-type PersistedStoreKey =
-  | 'MapeoLocale'
-  | '@MapeoDraft'
-  | 'MapeoTrack'
-  | 'Passcode'
-  | 'ActiveProjectId'
-  | 'Settings'
-  | 'MetricDiagnosticsPermission';
+type PersistedStoreKey = '@MapeoDraft';
+
 export const MMKVZustandStorage: StateStorage = {
   setItem: (name, value) => {
     return storage.set(name, value);
@@ -34,23 +28,14 @@ type MigrationOpt<T> =
   | {version: number; migrateFn: PersistOptions<T, T>['migrate']}
   | {version: number};
 
+/**
+ * @deprecated Persisted Zustand state should follow the conventions used in `contexts/*StoreContext.tsx`
+ */
 export function createPersistedState<T>(
   ...args: Parameters<typeof createPersistMiddleware<T>>
 ) {
   const store = create<T>()(createPersistMiddleware(...args));
 
-  store.setState(state => ({
-    ...state,
-    ...args[0],
-  }));
-
-  return store;
-}
-
-export function createPersistedStore<T>(
-  ...args: Parameters<typeof createPersistMiddleware<T>>
-) {
-  const store = createStore<T>()(createPersistMiddleware(...args));
   store.setState(state => ({
     ...state,
     ...args[0],


### PR DESCRIPTION
Ideally this whole file ceases to exist given our shift in how we set up persisted zustand state. Can't do that just yet since `usePersistedDraftObservation` relies on this file too much to make it trivial to remove.

This PR does the following:

- Removes the exported `createPersistedStore()` function. Nothing's using this anymore.

- Adds a deprecation notice for the `createPersistedState()` function. Only the old draft observation hook is using this and I don't expect anything to accidentally use this, but doing just for clarity.