### PR TITLE
chore: remove redundant mock in useDraftObservation test

### DIFF
--- a/src/frontend/hooks/useDraftObservation.test.tsx
+++ b/src/frontend/hooks/useDraftObservation.test.tsx
@@ -1,30 +1,8 @@
-// TODO: Move this into a jest setup file
-jest.mock('expo-localization', () => ({
-  getLocales: (): Locale[] => [
-    {
-      languageTag: 'en-US',
-      languageCode: null,
-      langageCurrencyCode: null,
-      langageCurrencySymbol: null,
-      languageRegionCode: null,
-      regionCode: null,
-      currencyCode: null,
-      currencySymbol: null,
-      decimalSeparator: null,
-      digitGroupingSeparator: null,
-      textDirection: null,
-      measurementSystem: null,
-      temperatureUnit: null,
-    },
-  ],
-}));
-
 import React from 'react';
 import {act, renderHook} from '@testing-library/react-native';
 import {PhotoPromiseProvider} from '../contexts/PhotoPromiseContext/index.tsx';
 import {useDraftObservation} from './useDraftObservation.ts';
 import {usePersistedDraftObservation} from './persistedState/usePersistedDraftObservation/index.ts';
-import type {Locale} from 'expo-localization';
 import type {Preset} from '@comapeo/schema';
 import {randomBytes} from 'crypto';
 


### PR DESCRIPTION
The todo in the comment has been addressed via #1063 ([link](https://github.com/digidem/comapeo-mobile/blob/e3fe026dd626252bf28bc8b406f78990780c0ba6/src/frontend/__mocks__/expo-localization.ts)) so this is no longer needed.