### PR TITLE
fix: adjusts language test

### DIFF
--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -30,7 +30,11 @@ describe('Settings - Language Settings Flow', () => {
     await obsListTab.click();
 
     await expect(
-      $(byTextMatches('hace\\s+(?:[1-5]?\\d|60)\\s+(?:minutos|segundos)')),
+      $(
+        byTextMatches(
+          'hace\\s+(?:[1-5]?\\d|60)\\s+(?:minuto|minutos|segundos)',
+        ),
+      ),
     ).toBeDisplayed();
   });
 


### PR DESCRIPTION
When I made the language test, I mistakenly did not account for it having been exactly one minute since the observations had been created. 
This test adds the text minute (in spanish) to the regex so that the test won't fail for the wrong reason.

