### PR TITLE
chore: add menu as modal

### DIFF
--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -424,15 +424,7 @@ export const createDefaultScreenGroup = ({
         component={ObservationMetadata}
         options={{headerTitle: intl(ObservationMetadata.navTitle)}}
       />
-      <RootStack.Screen
-        name="Menu"
-        component={MenuScreen}
-        options={{
-          headerShown: true,
-          animation: 'slide_from_right',
-          header: () => <MenuHeader />,
-        }}
-      />
+
       <RootStack.Screen
         name="InviteCollaborators"
         component={InviteCollaboratorsScreen}
@@ -484,6 +476,15 @@ export const createDefaultScreenGroup = ({
         component={ExistingProjectWarning}
       />
       <RootStack.Screen name="LeaveProject" component={LeaveProject} />
+      <RootStack.Screen
+        name="Menu"
+        component={MenuScreen}
+        options={{
+          headerShown: true,
+          animation: 'slide_from_right',
+          header: () => <MenuHeader />,
+        }}
+      />
     </RootStack.Group>
   </>
 );


### PR DESCRIPTION
fixes a visual problem with animation of the menu. When it is under the `Rootstack.group` where `{presentation:'card'}`, it animates by moving the entire previous screen away, which is not the desired behaviour.

When it is under the `Rootstack.group` where `{presentation:'transparentModal'}`, it animates on top the the previous screen, which is the desired behaviour.
 
presentation:transparentModal (Correct)

https://github.com/user-attachments/assets/b80b334d-d02e-48d0-8594-d79f707f721e

presentation:card (incorrect)

https://github.com/user-attachments/assets/c60777fb-acfc-4e6b-9efa-499860bcd5c3

