### PR TITLE
chore(ci): fix RC build command displayed in release PRs

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -116,7 +116,7 @@ jobs:
 
             :warning: Only add bug fixes, copy edits and translation updates during the QA process.
 
-            :test_tube: Create a new Release Candidate build by commenting on this PR with the `/buildrc` command.
+            :test_tube: Create a new Release Candidate build by commenting on this PR with the `${{ vars.BUILD_COMMENT_TRIGGER || '/build-rc' }}` command.
 
             :construction: An initial Release Candidate build will be triggered shortly, and the build URL will be posted here.
 

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -105,7 +105,7 @@ jobs:
 
             :warning: Only add bug fixes, copy edits and translation updates during the QA process.
 
-            :test_tube: Create a new Release Candidate build by commenting on this PR with the `/buildrc` command.
+            :test_tube: Create a new Release Candidate build by commenting on this PR with the `${{ vars.BUILD_COMMENT_TRIGGER || '/build-rc' }}` command.
 
             :construction: An initial Release Candidate build will be triggered shortly, and the build URL will be posted here.
 


### PR DESCRIPTION
Noticed that this [comment](https://github.com/digidem/comapeo-mobile/pull/1112#issuecomment-2825865395) didn't work and that's because the message in the PR body indicates the wrong default command 😅 i.e. should be `/build-rc`, not `/buildrc`. This updates the PR body to show the correct command (based on the repo variable `BUILD_COMMENT_TRIGGER` and falls back to `/build-rc`)

Still need to verify that this works as expected so will keep as a draft until I verify this works in the automations example repo.