### PR TITLE
test: add basic component test for GPS pill component

### DIFF
--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -24,7 +24,7 @@ import {useMapStyleJsonUrl} from '../../hooks/server/maps';
 import {TracksMapLayer} from './MapLayers/TracksMapLayer';
 import {assert} from '../../lib/assert';
 import {RemoteDetectionAlertsMapLayer} from './MapLayers/RemoteDetectionAlertsLayer';
-import {matchPreset} from '../../lib/utils';
+import {getLocationStatus, matchPreset} from '../../lib/utils';
 import {NativeHomeTabsNavigationProps} from '../../sharedTypes/navigation';
 import {useFocusEffect} from '@react-navigation/native';
 import {GPSPill} from '../../sharedComponents/GPSPill';
@@ -53,7 +53,7 @@ export const MapScreen = ({
   const [following, setFollowing] = React.useState(true);
   const {newDraft} = useDraftObservation();
   const {navigate} = useNavigationFromHomeTabs();
-  const {locationState} = useSharedLocationContext();
+  const {locationState, fgPermissions} = useSharedLocationContext();
   const savedLocation = useLastKnownLocation();
   const coords = locationState.location && getCoords(locationState.location);
   const locationProviderStatus = useLocationProviderStatus();
@@ -165,8 +165,13 @@ export const MapScreen = ({
       <View style={styles.bottomContainer}>
         <View style={{flex: 1, alignItems: 'center'}}>
           <GPSPill
+            {...getLocationStatus({
+              providerStatus: locationProviderStatus,
+              location: fgPermissions ? locationState.location : undefined,
+            })}
+            testID="MAP.gps-pill"
+            accessibilityLabel="Open GPS Modal."
             onPress={() => navigation.navigate('GpsModal')}
-            locationProviderStatus={locationProviderStatus}
           />
         </View>
 

--- a/src/frontend/sharedComponents/GPSPill.test.tsx
+++ b/src/frontend/sharedComponents/GPSPill.test.tsx
@@ -1,0 +1,45 @@
+import {render, screen} from '@testing-library/react-native';
+
+import {GPSPill} from './GPSPill';
+
+test.skip('searching status', async () => {
+  render(<GPSPill status="searching" />);
+
+  // TODO: Check icon color
+});
+
+test('error status', async () => {
+  render(<GPSPill status="error" />);
+
+  expect(screen.getByText('--')).toBeOnTheScreen();
+
+  // TODO: Check icon color
+});
+
+test('good status', async () => {
+  render(<GPSPill status="good" accuracy={1} />);
+
+  expect(screen.getByText('± 1 m')).toBeOnTheScreen();
+
+  // TODO: Check icon color
+});
+
+test('displayed accuracy', async () => {
+  // Handles integers
+  render(<GPSPill status="good" accuracy={10} />);
+  expect(screen.getByText('± 10 m')).toBeOnTheScreen();
+
+  // Handles negative accuracy elegantly
+  render(<GPSPill status="good" accuracy={-1} />);
+  expect(screen.getByText('± 1 m')).toBeOnTheScreen();
+
+  // Handles floats
+  render(<GPSPill status="good" accuracy={0.5} />);
+  expect(screen.getByText('± 1 m')).toBeOnTheScreen();
+
+  render(<GPSPill status="good" accuracy={5.25} />);
+  expect(screen.getByText('± 5 m')).toBeOnTheScreen();
+
+  render(<GPSPill status="good" accuracy={10.75} />);
+  expect(screen.getByText('± 11 m')).toBeOnTheScreen();
+});

--- a/src/frontend/sharedComponents/GPSPill.tsx
+++ b/src/frontend/sharedComponents/GPSPill.tsx
@@ -1,33 +1,29 @@
-import React, {FC} from 'react';
 import {StyleSheet, TouchableOpacity} from 'react-native';
-import {DARK_GREY, WHITE} from '../lib/styles';
-import {GpsErrorIcon, GpsSearchingIcon, GpsGoodIcon} from './icons';
-import {useSharedLocationContext} from '../contexts/SharedLocationContext';
-import {getLocationStatus} from '../lib/utils';
-import {BodyText} from './Text/BodyText';
 import {UIActivityIndicator} from 'react-native-indicators';
-import type {LocationProviderStatus} from 'expo-location';
+
+import {DARK_GREY, WHITE} from '../lib/styles';
+import {GpsErrorIcon, GpsGoodIcon, GpsSearchingIcon} from './icons';
+import {BodyText} from './Text/BodyText';
 
 type GPSPillProps = {
+  accessibilityLabel?: string;
   onPress?: () => void;
-  locationProviderStatus?: LocationProviderStatus;
-};
+  testID?: string;
+} & (
+  | {
+      status: 'searching' | 'error';
+    }
+  | {
+      status: 'good';
+      accuracy: number;
+    }
+);
 
-export const GPSPill: FC<GPSPillProps> = ({
-  onPress,
-  locationProviderStatus,
-}) => {
-  const {locationState, fgPermissions} = useSharedLocationContext();
-
-  const locationStatus = getLocationStatus({
-    location: fgPermissions ? locationState.location : undefined,
-    providerStatus: locationProviderStatus,
-  });
-
+export const GPSPill = (props: GPSPillProps) => {
   let textValue: string | React.ReactNode;
   let IconToRender: React.FC;
 
-  switch (locationStatus.status) {
+  switch (props.status) {
     case 'error':
       textValue = '--';
       IconToRender = GpsErrorIcon;
@@ -37,7 +33,7 @@ export const GPSPill: FC<GPSPillProps> = ({
       IconToRender = GpsSearchingIcon;
       break;
     case 'good': {
-      textValue = `± ${Math.round(locationStatus.accuracy)} m`;
+      textValue = `± ${Math.abs(Math.round(props.accuracy))} m`;
       IconToRender = GpsGoodIcon;
       break;
     }
@@ -49,17 +45,13 @@ export const GPSPill: FC<GPSPillProps> = ({
 
   return (
     <TouchableOpacity
-      onPress={onPress}
+      onPress={props.onPress}
       style={styles.container}
-      testID="MAP.gps-pill"
-      accessibilityLabel="Open GPS Modal">
+      testID={props.testID}
+      accessibilityLabel={props.accessibilityLabel}>
       <IconToRender />
 
-      <BodyText
-        variant="smallMeta"
-        style={styles.text}
-        numberOfLines={1}
-        testID="MAP.gps-pill-text">
+      <BodyText variant="smallMeta" style={styles.text} numberOfLines={1}>
         {textValue}
       </BodyText>
     </TouchableOpacity>

--- a/tests/e2e/specs/main/gps.test.ts
+++ b/tests/e2e/specs/main/gps.test.ts
@@ -7,8 +7,8 @@ describe('MAIN - GPS Component Test', () => {
     const mapView = await $(byResourceId('MAIN.mapbox-map-view'));
     await expect(mapView).toBeDisplayed();
 
-    const gpsText = await $(byResourceId('MAP.gps-pill-text'));
-    await expect(gpsText).toBeDisplayed();
+    const gpsPill = await $(byResourceId('MAP.gps-pill'));
+    await expect(gpsPill).toBeDisplayed();
   });
 
   it('should verify GPS pill navigation from Home Map screen', async () => {


### PR DESCRIPTION
Stacked on #1105 

Provides an example of a isolated component unit test using React Testing Library.

Notable changes:

- Updates the `GPSPill` component to make it more testable:

  - removes the internal usage of a context in favor defining props for the relevant information
  - exposes the test ID and accessibility label as props instead of defining them internally.
      - test IDs should always be defined as props for shared components because otherwise, they're not shareable (as the IDs are supposed be unique).
      - accessibility labels are contextual so a shared component should not define it internally and exposing it as a prop allows for more flexible usage.
      
      
Still have some questions about the desired behavior of the component, mostly in the context of how it displays accuracy values.