### PR TITLE
fix: clean up app metrics interval

### DIFF
--- a/src/frontend/metrics/AppDiagnosticMetrics.ts
+++ b/src/frontend/metrics/AppDiagnosticMetrics.ts
@@ -139,7 +139,8 @@ export class AppDiagnosticMetrics {
     // beginning of the next day. However, timeouts are a bit unreliable (for
     // example, if the app goes into the background), so we just check
     // periodically. This also simplifies the code a bit.
-    setInterval(this.#update, CHECK_INTERVAL);
+    const checkInterval = setInterval(this.#update, CHECK_INTERVAL);
+    subscriptionCleanupFns.push(() => clearInterval(checkInterval));
 
     this.#subscriptionCleanupFns = subscriptionCleanupFns;
   }


### PR DESCRIPTION
Towards #910 (but useful on its own)

The app diagnostic metrics class starts an interval but never cleans it up. This has two problems:

1. If you enable, disable, and re-enable app metrics, two timers will be started. Disabling and re-enabling will start a third timer, and so on. Other code protects against catastrophic issues here, but this is a memory leak.

2. When we add Jest tests (see #910), failure to clean this up will prevent the test from finishing. Not yet an issue, but soon to be.

(I believe this was my mistake, introduced way back in c6db215964e474ca868998ab608ad79118229e4b.)