### PR TITLE
fix: show previews

### DIFF
--- a/src/frontend/screens/PhotoPreviewModal.tsx
+++ b/src/frontend/screens/PhotoPreviewModal.tsx
@@ -79,7 +79,8 @@ export const PhotoPreviewModal: FC<
         <PhotoUnpreparedView
           onPress={() => setShowHeader(!showHeader)}
           photo={photo}
-          variant={'original'}
+          // This needs to be "preview" otherwise the photo will not be shown when the user is only syncing previews
+          variant={'preview'}
         />
       ) : (
         <PhotoPreparedView


### PR DESCRIPTION
closes #934 

Previously we were always trying to show the 'Original' photo, even if it was not available. Technically if the photo is not available a url is still being returned, im not sure if that is the intended behaviour. I would argue that is is not desired behaviour and that it should throw an error instead, but if its not a trivial fix the front end can deal with it.

I could see a world in which we check whether "sync previews only" is set, and return the "original" vs the "preview". I don't know if that is necessary as it complicates the code, and we cannot do anything with the current photo. For example we cannot zoom into the photo, so showing the preview vs the original has no real functionality benefit