### PR TITLE
feat: block invites if user taking tracks

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -47,7 +47,7 @@
     "message": "Stop Tracks"
   },
   "Modal.GPSEnable.trackingDescription": {
-    "message": "You’ve been recording for"
+    "message": "You’ve been recording for {time}"
   },
   "Navigation.Menu.Settings": {
     "message": "Settings"
@@ -1730,7 +1730,7 @@
     "message": "Cancel"
   },
   "screens.TrackRecordingActive.recordingTracks": {
-    "message": "Recording Tracks"
+    "message": "Recording Tracks!"
   },
   "screens.TrackRecordingActive.stopTracks": {
     "message": "Stop Tracks"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1726,6 +1726,18 @@
     "description": "Preset title for new track screen",
     "message": "Track"
   },
+  "screens.TrackRecordingActive.cancel": {
+    "message": "Cancel"
+  },
+  "screens.TrackRecordingActive.recordingTracks": {
+    "message": "Recording Tracks"
+  },
+  "screens.TrackRecordingActive.stopTracks": {
+    "message": "Stop Tracks"
+  },
+  "screens.TrackRecordingActive.warningMessage": {
+    "message": "You’re currently recording a track. To join project, stop recording"
+  },
   "shareComponent.KeyboardAccessory.showOptions": {
     "description": "title for observation options",
     "message": "Show Options"

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -104,6 +104,7 @@ import {LeaveProject} from '../../screens/Invites/LeaveProject.tsx';
 import {MenuScreen} from '../../screens/MenuScreen';
 import {InviteCollaboratorsScreen} from '../../screens/Settings/ProjectSettings/YourTeam/InviteCollaborators.tsx';
 import {MenuHeader} from '../../sharedComponents/MenuHeader.tsx';
+import {TrackRecordingActive} from '../../screens/TrackRecordingActive.tsx';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -484,6 +485,10 @@ export const createDefaultScreenGroup = ({
         component={ExistingProjectWarning}
       />
       <RootStack.Screen name="LeaveProject" component={LeaveProject} />
+      <RootStack.Screen
+        name="TrackRecordingActive"
+        component={TrackRecordingActive}
+      />
     </RootStack.Group>
   </>
 );

--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -31,6 +31,7 @@ export const INVITE_SCREEN_NAME: (keyof AppStackParamsList)[] = [
   'InviteSuccessfullyAccepted',
   'LeaveProject',
   'ExistingProjectWarning',
+  'TrackRecordingActive',
 ];
 
 // Replicates the root query key from comapeo/core-react v3.3.0

--- a/src/frontend/hooks/useTracking.ts
+++ b/src/frontend/hooks/useTracking.ts
@@ -6,6 +6,7 @@ import {
 } from '../contexts/TrackStoreContext.tsx';
 import {LOCATION_TASK_NAME} from '../sharedTypes/location.ts';
 import {useNavigation} from '@react-navigation/native';
+import * as Sentry from '@sentry/react-native';
 
 export function useTracking() {
   const {setTracking, clearCurrentTrack} = useTrackActions();
@@ -22,9 +23,10 @@ export function useTracking() {
     Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
       accuracy: Location.Accuracy.Highest,
       activityType: Location.LocationActivityType.Fitness,
-    }).catch(() => {
+    }).catch(err => {
+      Sentry.captureException(err);
       setTracking(false);
-      // @ts-expect-error - this is typing issue, we are using the not strongly typed hook as this can technically be used in any screen. But regardless of the screen, we want to show the error bottom sheet
+      // @ts-expect-error - this is a typing issue, we are using the non-strongly typed hook as this can technically be used in any screen. But regardless of the screen, we want to show the error bottom sheet.
       navigation.navigate('ErrorBottomSheet');
     });
   }, [isTracking, setTracking, navigation]);
@@ -32,9 +34,11 @@ export function useTracking() {
    * Cancels location tracking and stops background updates.
    * @returns {boolean} True if location history has more than one entry (track should be kept), false otherwise.
    */
-  const cancelTrackingAndReturnIfTracksSaved = useCallback(() => {
+  const cancelTracking = useCallback(() => {
     setTracking(false);
-    Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
+    Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME).catch(err => {
+      Sentry.captureException(err);
+    });
     const hasTrackWithMoreThan1Point = locationHistory.length > 1;
 
     if (!hasTrackWithMoreThan1Point) {
@@ -44,5 +48,9 @@ export function useTracking() {
     return hasTrackWithMoreThan1Point;
   }, [setTracking, clearCurrentTrack, locationHistory]);
 
-  return {isTracking, startTracking, cancelTrackingAndReturnIfTracksSaved};
+  return {
+    isTracking,
+    startTracking,
+    cancelTracking,
+  };
 }

--- a/src/frontend/hooks/useTracking.ts
+++ b/src/frontend/hooks/useTracking.ts
@@ -5,34 +5,44 @@ import {
   useTrackState,
 } from '../contexts/TrackStoreContext.tsx';
 import {LOCATION_TASK_NAME} from '../sharedTypes/location.ts';
+import {useNavigation} from '@react-navigation/native';
 
 export function useTracking() {
-  const [loading, setLoading] = useState(false);
-  const {setTracking} = useTrackActions();
+  const {setTracking, clearCurrentTrack} = useTrackActions();
+  const navigation = useNavigation();
   const isTracking = useTrackState(state => state.isTracking);
+  const locationHistory = useTrackState(state => state.locationHistory);
 
-  const startTracking = useCallback(async () => {
+  const startTracking = useCallback(() => {
     if (isTracking) {
       console.warn('Start tracking attempt while tracking already enabled');
-      setLoading(false);
       return;
     }
-
-    setLoading(true);
-
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+    setTracking(true);
+    Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
       accuracy: Location.Accuracy.Highest,
       activityType: Location.LocationActivityType.Fitness,
+    }).catch(error => {
+      setTracking(false);
+      // @ts-expect-error - this is typing issue, we are using the not strongly typed hook as this can technically be used in any screen. But regardless of the screen, we want to show the error bottom sheet
+      navigation.navigate('ErrorBottomSheet');
     });
-
-    setTracking(true);
-    setLoading(false);
   }, [isTracking, setTracking]);
-
-  const cancelTracking = useCallback(async () => {
-    await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
+  /**
+   * Cancels location tracking and stops background updates.
+   * @returns {boolean} True if location history has more than one entry (track should be kept), false otherwise.
+   */
+  const cancelTrackingAndReturnIfTracksSaved = useCallback(() => {
     setTracking(false);
+    Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
+    const hasTrackWithMoreThan1Point = locationHistory.length > 1;
+
+    if (!hasTrackWithMoreThan1Point) {
+      clearCurrentTrack();
+    }
+
+    return hasTrackWithMoreThan1Point;
   }, [setTracking]);
 
-  return {isTracking, startTracking, cancelTracking, loading};
+  return {isTracking, startTracking, cancelTrackingAndReturnIfTracksSaved};
 }

--- a/src/frontend/hooks/useTracking.ts
+++ b/src/frontend/hooks/useTracking.ts
@@ -1,5 +1,5 @@
 import * as Location from 'expo-location';
-import {useCallback, useState} from 'react';
+import {useCallback} from 'react';
 import {
   useTrackActions,
   useTrackState,
@@ -22,12 +22,12 @@ export function useTracking() {
     Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
       accuracy: Location.Accuracy.Highest,
       activityType: Location.LocationActivityType.Fitness,
-    }).catch(error => {
+    }).catch(() => {
       setTracking(false);
       // @ts-expect-error - this is typing issue, we are using the not strongly typed hook as this can technically be used in any screen. But regardless of the screen, we want to show the error bottom sheet
       navigation.navigate('ErrorBottomSheet');
     });
-  }, [isTracking, setTracking]);
+  }, [isTracking, setTracking, navigation]);
   /**
    * Cancels location tracking and stops background updates.
    * @returns {boolean} True if location history has more than one entry (track should be kept), false otherwise.
@@ -42,7 +42,7 @@ export function useTracking() {
     }
 
     return hasTrackWithMoreThan1Point;
-  }, [setTracking]);
+  }, [setTracking, clearCurrentTrack, locationHistory]);
 
   return {isTracking, startTracking, cancelTrackingAndReturnIfTracksSaved};
 }

--- a/src/frontend/screens/Invites/InviteReceived.tsx
+++ b/src/frontend/screens/Invites/InviteReceived.tsx
@@ -16,7 +16,6 @@ import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreCont
 import * as Sentry from '@sentry/react-native';
 import {useListenToInviteCancel} from '../../hooks/useListenToInviteCancel';
 import {BLACK, NEW_DARK_GREY, VERY_LIGHT_GREY} from '../../lib/styles';
-import {useTrackActions, useTrackState} from '../../contexts/TrackStoreContext';
 import {useTracking} from '../../hooks/useTracking';
 
 const m = defineMessages({

--- a/src/frontend/screens/Invites/InviteReceived.tsx
+++ b/src/frontend/screens/Invites/InviteReceived.tsx
@@ -16,6 +16,8 @@ import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreCont
 import * as Sentry from '@sentry/react-native';
 import {useListenToInviteCancel} from '../../hooks/useListenToInviteCancel';
 import {BLACK, NEW_DARK_GREY, VERY_LIGHT_GREY} from '../../lib/styles';
+import {useTrackActions, useTrackState} from '../../contexts/TrackStoreContext';
+import {useTracking} from '../../hooks/useTracking';
 
 const m = defineMessages({
   joinProject: {
@@ -60,10 +62,16 @@ export const InviteReceived = ({
   const rejectInvite = useRejectInvite();
   const {setActiveProjectId} = useActiveProjectIdActions();
   const projects = useManyProjects();
+  const {isTracking} = useTracking();
 
   useListenToInviteCancel(inviteId);
 
   function accept() {
+    if (isTracking) {
+      navigation.navigate('TrackRecordingActive');
+      return;
+    }
+
     if (projects.data.length > 1) {
       navigation.replace('ExistingProjectWarning', {
         inviteId,

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/StartStopTrack.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/StartStopTrack.tsx
@@ -33,13 +33,12 @@ const m = defineMessages({
 
 export const StartStopTrack = () => {
   const {formatMessage} = useIntl();
-  const {isTracking, cancelTrackingAndReturnIfTracksSaved, startTracking} =
-    useTracking();
+  const {isTracking, cancelTracking, startTracking} = useTracking();
   const {timer} = useTrackTimerContext();
   const navigation = useNavigationFromHomeTabs();
 
   function endTracking() {
-    const hasTracksSaved = cancelTrackingAndReturnIfTracksSaved();
+    const hasTracksSaved = cancelTracking();
 
     if (hasTracksSaved) {
       navigation.navigate('SaveTrack');

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/StartStopTrack.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/StartStopTrack.tsx
@@ -90,7 +90,4 @@ const styles = StyleSheet.create({
     borderRadius: 99,
     backgroundColor: '#59A553',
   },
-  timer: {
-    marginLeft: 5,
-  },
 });

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/StartStopTrack.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/StartStopTrack.tsx
@@ -1,18 +1,16 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {StyleSheet, View} from 'react-native';
-
-import {
-  useTrackActions,
-  useTrackState,
-} from '../../../contexts/TrackStoreContext.tsx';
 import {useTrackTimerContext} from '../../../contexts/TrackTimerContext.tsx';
 import {useNavigationFromHomeTabs} from '../../../hooks/useNavigationWithTypes.ts';
 import {useTracking} from '../../../hooks/useTracking.ts';
 import StartTrackingIcon from '../../../images/StartTracking.svg';
 import StopTrackingIcon from '../../../images/StopTracking.svg';
-import {Button} from '../../../sharedComponents/Button.tsx';
-import {Text} from '../../../sharedComponents/Text.tsx';
+import {
+  DestructiveButton,
+  PrimaryButton,
+} from '../../../sharedComponents/Buttons.tsx';
+import {HeaderText} from '../../../sharedComponents/Text/HeaderText.tsx';
 
 const m = defineMessages({
   defaultButtonText: {
@@ -29,68 +27,48 @@ const m = defineMessages({
   },
   trackingDescription: {
     id: 'Modal.GPSEnable.trackingDescription',
-    defaultMessage: 'You’ve been recording for',
+    defaultMessage: 'You’ve been recording for {time}',
   },
 });
 
 export const StartStopTrack = () => {
   const {formatMessage} = useIntl();
-  const {isTracking, cancelTracking, startTracking, loading} = useTracking();
-  const locationHistory = useTrackState(state => state.locationHistory);
-  const {clearCurrentTrack} = useTrackActions();
+  const {isTracking, cancelTrackingAndReturnIfTracksSaved, startTracking} =
+    useTracking();
   const {timer} = useTrackTimerContext();
   const navigation = useNavigationFromHomeTabs();
 
-  const handleTracking = useCallback(() => {
-    if (!isTracking) {
-      startTracking();
-      return;
-    }
+  function endTracking() {
+    const hasTracksSaved = cancelTrackingAndReturnIfTracksSaved();
 
-    cancelTracking();
-
-    if (locationHistory.length <= 1) {
-      clearCurrentTrack();
-      navigation.setParams({trackingOpen: false});
-    } else {
+    if (hasTracksSaved) {
       navigation.navigate('SaveTrack');
     }
-  }, [
-    cancelTracking,
-    clearCurrentTrack,
-    locationHistory,
-    isTracking,
-    startTracking,
-    navigation,
-  ]);
-
-  const getButtonTitle = () => {
-    if (loading) return m.loadingButtonText;
-    if (isTracking) return m.stopButtonText;
-    return m.defaultButtonText;
-  };
+  }
 
   return (
-    <View>
-      <Button
-        fullWidth
-        disabled={loading}
-        onPress={handleTracking}
-        style={{backgroundColor: isTracking ? '#D92222' : '#0066FF'}}>
-        <View style={styles.buttonWrapper}>
-          {isTracking ? <StopTrackingIcon /> : <StartTrackingIcon />}
-          <Text style={styles.buttonText}>
-            {formatMessage(getButtonTitle())}
-          </Text>
-        </View>
-      </Button>
+    <View style={{alignItems: 'center', flex: 1}}>
+      {!isTracking ? (
+        <PrimaryButton
+          fullSize={true}
+          text={formatMessage(m.defaultButtonText)}
+          onPress={startTracking}
+          renderIcon={() => <StartTrackingIcon />}
+        />
+      ) : (
+        <DestructiveButton
+          text={formatMessage(m.stopButtonText)}
+          fullSize={true}
+          renderIcon={() => <StopTrackingIcon />}
+          onPress={endTracking}
+        />
+      )}
       {isTracking && (
         <View style={styles.runtimeWrapper}>
           <View style={styles.indicator} />
-          <Text style={styles.text}>
-            {formatMessage(m.trackingDescription)}
-          </Text>
-          <Text style={styles.timer}>{timer}</Text>
+          <HeaderText style={{textAlign: 'center'}} variant="header5">
+            {formatMessage(m.trackingDescription, {time: timer})}
+          </HeaderText>
         </View>
       )}
     </View>
@@ -98,24 +76,12 @@ export const StartStopTrack = () => {
 };
 
 const styles = StyleSheet.create({
-  buttonWrapper: {
-    flexDirection: 'row',
-    display: 'flex',
-    alignItems: 'center',
-    width: '100%',
-  },
-  buttonText: {
-    fontWeight: '500',
-    color: '#fff',
-    width: '100%',
-    flex: 1,
-    textAlign: 'center',
-  },
   runtimeWrapper: {
     paddingTop: 20,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    flex: 1,
   },
   indicator: {
     marginRight: 5,
@@ -124,12 +90,7 @@ const styles = StyleSheet.create({
     borderRadius: 99,
     backgroundColor: '#59A553',
   },
-  text: {
-    fontSize: 16,
-  },
   timer: {
     marginLeft: 5,
-    fontWeight: 'bold',
-    fontSize: 16,
   },
 });

--- a/src/frontend/screens/SaveTrack/SaveTrackButton.tsx
+++ b/src/frontend/screens/SaveTrack/SaveTrackButton.tsx
@@ -40,12 +40,7 @@ export const SaveTrackButton: FC = () => {
       {
         onSuccess: () => {
           clearCurrentTrack();
-          navigation.dispatch(
-            CommonActions.reset({
-              index: 0,
-              routes: [{name: 'Home', params: {screen: 'Map'}}],
-            }),
-          );
+          navigation.goBack();
         },
       },
     );

--- a/src/frontend/screens/SaveTrack/SaveTrackButton.tsx
+++ b/src/frontend/screens/SaveTrack/SaveTrackButton.tsx
@@ -1,4 +1,3 @@
-import {CommonActions} from '@react-navigation/native';
 import React, {FC} from 'react';
 import {Image, Pressable, StyleSheet} from 'react-native';
 

--- a/src/frontend/screens/TrackRecordingActive.tsx
+++ b/src/frontend/screens/TrackRecordingActive.tsx
@@ -5,11 +5,12 @@ import {defineMessages, useIntl} from 'react-intl';
 import {BodyText} from '../sharedComponents/Text/BodyText';
 import {DestructiveButton, SecondaryButton} from '../sharedComponents/Buttons';
 import {NativeRootNavigationProps} from '../sharedTypes/navigation';
+import Error from '../images/Error.svg';
 
 const m = defineMessages({
   recordingTracks: {
     id: 'screens.TrackRecordingActive.recordingTracks',
-    defaultMessage: 'Recording Tracks',
+    defaultMessage: 'Recording Tracks!',
   },
   warningMessage: {
     id: 'screens.TrackRecordingActive.warningMessage',
@@ -32,18 +33,29 @@ export const TrackRecordingActive = ({
   const {formatMessage} = useIntl();
   return (
     <BottomSheetWrapper>
-      <View>
-        <HeaderText>{formatMessage(m.recordingTracks)}</HeaderText>
-        <BodyText>{formatMessage(m.warningMessage)}</BodyText>
+      <View style={{alignItems: 'center'}}>
+        <Error />
+        <HeaderText
+          style={{textAlign: 'center', marginTop: 20}}
+          variant="header2">
+          {formatMessage(m.recordingTracks)}
+        </HeaderText>
+        <BodyText style={{textAlign: 'center', marginTop: 20}}>
+          {formatMessage(m.warningMessage)}
+        </BodyText>
       </View>
       <DestructiveButton
         fullSize={true}
-        onPress={() => {}}
+        onPress={() => {
+          navigation.navigate('SaveTrack');
+        }}
+        style={{marginTop: 20, alignSelf: 'center'}}
         text={formatMessage(m.stopTracks)}
       />
       <SecondaryButton
         fullSize={true}
         onPress={() => navigation.goBack()}
+        style={{marginTop: 20, alignSelf: 'center'}}
         text={formatMessage(m.cancel)}
       />
     </BottomSheetWrapper>

--- a/src/frontend/screens/TrackRecordingActive.tsx
+++ b/src/frontend/screens/TrackRecordingActive.tsx
@@ -32,10 +32,10 @@ export const TrackRecordingActive = ({
   navigation,
 }: NativeRootNavigationProps<'TrackRecordingActive'>) => {
   const {formatMessage} = useIntl();
-  const {cancelTrackingAndReturnIfTracksSaved} = useTracking();
+  const {cancelTracking} = useTracking();
 
   function handleStopTracks() {
-    const hasTracksSaved = cancelTrackingAndReturnIfTracksSaved();
+    const hasTracksSaved = cancelTracking();
 
     if (hasTracksSaved) {
       navigation.replace('SaveTrack');

--- a/src/frontend/screens/TrackRecordingActive.tsx
+++ b/src/frontend/screens/TrackRecordingActive.tsx
@@ -1,0 +1,51 @@
+import {View} from 'react-native';
+import {BottomSheetWrapper} from '../sharedComponents/BottomSheetWrapper';
+import {HeaderText} from '../sharedComponents/Text/HeaderText';
+import {defineMessages, useIntl} from 'react-intl';
+import {BodyText} from '../sharedComponents/Text/BodyText';
+import {DestructiveButton, SecondaryButton} from '../sharedComponents/Buttons';
+import {NativeRootNavigationProps} from '../sharedTypes/navigation';
+
+const m = defineMessages({
+  recordingTracks: {
+    id: 'screens.TrackRecordingActive.recordingTracks',
+    defaultMessage: 'Recording Tracks',
+  },
+  warningMessage: {
+    id: 'screens.TrackRecordingActive.warningMessage',
+    defaultMessage:
+      'You’re currently recording a track. To join project, stop recording',
+  },
+  stopTracks: {
+    id: 'screens.TrackRecordingActive.stopTracks',
+    defaultMessage: 'Stop Tracks',
+  },
+  cancel: {
+    id: 'screens.TrackRecordingActive.cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+export const TrackRecordingActive = ({
+  navigation,
+}: NativeRootNavigationProps<'TrackRecordingActive'>) => {
+  const {formatMessage} = useIntl();
+  return (
+    <BottomSheetWrapper>
+      <View>
+        <HeaderText>{formatMessage(m.recordingTracks)}</HeaderText>
+        <BodyText>{formatMessage(m.warningMessage)}</BodyText>
+      </View>
+      <DestructiveButton
+        fullSize={true}
+        onPress={() => {}}
+        text={formatMessage(m.stopTracks)}
+      />
+      <SecondaryButton
+        fullSize={true}
+        onPress={() => navigation.goBack()}
+        text={formatMessage(m.cancel)}
+      />
+    </BottomSheetWrapper>
+  );
+};

--- a/src/frontend/screens/TrackRecordingActive.tsx
+++ b/src/frontend/screens/TrackRecordingActive.tsx
@@ -6,6 +6,7 @@ import {BodyText} from '../sharedComponents/Text/BodyText';
 import {DestructiveButton, SecondaryButton} from '../sharedComponents/Buttons';
 import {NativeRootNavigationProps} from '../sharedTypes/navigation';
 import Error from '../images/Error.svg';
+import {useTracking} from '../hooks/useTracking';
 
 const m = defineMessages({
   recordingTracks: {
@@ -31,6 +32,19 @@ export const TrackRecordingActive = ({
   navigation,
 }: NativeRootNavigationProps<'TrackRecordingActive'>) => {
   const {formatMessage} = useIntl();
+  const {cancelTrackingAndReturnIfTracksSaved} = useTracking();
+
+  function handleStopTracks() {
+    const hasTracksSaved = cancelTrackingAndReturnIfTracksSaved();
+
+    if (hasTracksSaved) {
+      navigation.replace('SaveTrack');
+      return;
+    }
+
+    navigation.goBack();
+  }
+
   return (
     <BottomSheetWrapper>
       <View style={{alignItems: 'center'}}>
@@ -46,9 +60,7 @@ export const TrackRecordingActive = ({
       </View>
       <DestructiveButton
         fullSize={true}
-        onPress={() => {
-          navigation.navigate('SaveTrack');
-        }}
+        onPress={handleStopTracks}
         style={{marginTop: 20, alignSelf: 'center'}}
         text={formatMessage(m.stopTracks)}
       />

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -125,6 +125,7 @@ export type RootStackParamsList = {
   };
   Menu: undefined;
   InviteCollaborators: undefined;
+  TrackRecordingActive: undefined;
 };
 
 export type OnboardingParamsList = {


### PR DESCRIPTION
closes #1089 

https://github.com/user-attachments/assets/e76dbd89-ab53-4b89-ad06-7cc88435a42d

I simplified the useTracks hook in the process:
1. There was some leaky implementation. We only save a track if there is more than 1 location saved. Previously the hook was not responsible for this check, and would only save or cancel a track. This meant that the consuming component was checking for the location via the `useTrackState`. The useTracks() is partly an abstraction of useTrackState. So we were using 2 hook unnecessarily. I updated the hook so that useTracks does check for the location. Now when tracks is stopped, it simply return a boolean whether there is more than 1 location in persisted state.
2. Removed the loading state from the hook. The loading state is unncessary as we don't need to block any interactions while we are turning on tracks. It is turned on and runs in the background. If there is an error, we show an error sheet but a loading state is unnecessary for that. Also when turning off the tracking, the user does not need to wait for track to turn off. It can happen in the background while they are saving the track.