### PR TITLE
fix: allow "failed" members to be invitable

### DIFF
--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -11,6 +11,7 @@ import {DeviceCard} from '../../../../sharedComponents/DeviceCard';
 import {Text} from '../../../../sharedComponents/Text';
 import {NativeNavigationComponent} from '../../../../sharedTypes/navigation';
 import {useActiveProject} from '../../../../contexts/ActiveProjectContext';
+import {FAILED_ROLE_ID} from '../../../../sharedTypes';
 
 const m = defineMessages({
   title: {
@@ -58,12 +59,23 @@ function InvitableDevicesList() {
   const projectId = useActiveProject();
   const projectMembersQuery = useManyMembers(projectId);
 
-  const memberDeviceIds = projectMembersQuery.data.map(
-    member => member.deviceId,
-  );
-
   const invitableDevices = devices.filter(device => {
-    return !memberDeviceIds.includes(device.deviceId);
+    const existingMember = projectMembersQuery.data.find(
+      member => member.deviceId === device.deviceId,
+    );
+
+    if (!existingMember) {
+      return true;
+    }
+
+    // Devices who failed to successfully join the project
+    // should be re-invitable, as the failure is due to external conditions
+    // such as interruptions in the invite flow or device-related issues.
+    if (existingMember.role.roleId === FAILED_ROLE_ID) {
+      return true;
+    }
+
+    return false;
   });
 
   return (

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -39,4 +39,5 @@ export const COORDINATOR_ROLE_ID = 'f7c150f5a3a9a855';
 export const MEMBER_ROLE_ID = '012fd2d431c0bf60';
 export const BLOCKED_ROLE_ID = '9e6d29263cba36c9';
 export const LEFT_ROLE_ID = '8ced989b1904606b';
+export const FAILED_ROLE_ID = 'a24eaca65ab5d5d0';
 export const NO_ROLE_ID = '08e4251e36f6e7ed';


### PR DESCRIPTION
`@comapeo/core@3.1.0` introduced a new "failed" role that indicates a member's failure to properly join a project under valid circumstances, usually caused by external conditions such as device-related issues or interruptions to the invite flow. This new role was added to indicate the ability to re-invite the device with the intent of properly adding it to the project.

This PR updates the UI for device selection step when inviting a device to account for this new role such that project members with this role can be invited.