### PR TITLE
fix: audio error - does not throw when time runs out

### DIFF
--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -15,7 +15,7 @@ import {UIActivityIndicator} from 'react-native-indicators';
 import {millisecondsToMMSS} from '../../../lib/millisecondsToFormattedTime';
 
 // 5 minutes
-const MAX_RECORDING_DURATION_MS = 5000;
+const MAX_RECORDING_DURATION_MS = 30000;
 const PRIMARY_CONTROL_DIAMETER = 96;
 
 const m = defineMessages({

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -15,7 +15,7 @@ import {UIActivityIndicator} from 'react-native-indicators';
 import {millisecondsToMMSS} from '../../../lib/millisecondsToFormattedTime';
 
 // 5 minutes
-const MAX_RECORDING_DURATION_MS = 300000;
+const MAX_RECORDING_DURATION_MS = 5000;
 const PRIMARY_CONTROL_DIAMETER = 96;
 
 const m = defineMessages({
@@ -66,10 +66,10 @@ export function AudioRecording({
 
   // stop recording at 5 minutes
   React.useEffect(() => {
-    if (timeElapsed >= MAX_RECORDING_DURATION_MS) {
+    if (timeElapsed >= MAX_RECORDING_DURATION_MS && isRecording) {
       finishRecording();
     }
-  }, [timeElapsed, finishRecording]);
+  }, [timeElapsed, finishRecording, isRecording]);
 
   return (
     <>

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -15,7 +15,7 @@ import {UIActivityIndicator} from 'react-native-indicators';
 import {millisecondsToMMSS} from '../../../lib/millisecondsToFormattedTime';
 
 // 5 minutes
-const MAX_RECORDING_DURATION_MS = 30000;
+const MAX_RECORDING_DURATION_MS = 300000;
 const PRIMARY_CONTROL_DIAMETER = 96;
 
 const m = defineMessages({


### PR DESCRIPTION
closes #1137 

The issue was being caused by useEffect which stopped the recording at 5 mins. The useEffect would check to see if the timeElapsed was equal to or greater than 5 mins. If it was 5 mins, it would call `finishRecording`, which would cause another re-render. This would cause the useEffect to be run again, and since the `timeElapsed` was greater that 5 mins, it would call `finishRecording()` again. But since there was no active recording, as finish recording had been already called once before, it would throw an error.

This fix adds a check to only call `finishRecording` if the recording is active.

To test, you can change [this number](https://github.com/digidem/comapeo-mobile/blob/489519d907500918678618e892552c53cef1ff09/src/frontend/screens/Audio/AudioRecording/index.tsx#L18) to a smaller number so you do not need to wait 5 mins.
