### PR TITLE
fix: after invite navigation

### DIFF
--- a/src/frontend/lib/resetToYourTeam.ts
+++ b/src/frontend/lib/resetToYourTeam.ts
@@ -1,0 +1,13 @@
+import {CommonActions, NavigationProp} from '@react-navigation/native';
+import type {AppStackParamsList} from '../sharedTypes/navigation';
+
+export function resetToYourTeam(
+  navigation: NavigationProp<AppStackParamsList>,
+) {
+  navigation.dispatch(
+    CommonActions.reset({
+      index: 2,
+      routes: [{name: 'Home'}, {name: 'ProjectSettings'}, {name: 'YourTeam'}],
+    }),
+  );
+}

--- a/src/frontend/lib/resetToYourTeam.ts
+++ b/src/frontend/lib/resetToYourTeam.ts
@@ -1,10 +1,11 @@
 import {CommonActions, NavigationProp} from '@react-navigation/native';
 import type {AppStackParamsList} from '../sharedTypes/navigation';
 
-export function resetToYourTeam(
-  navigation: NavigationProp<AppStackParamsList>,
-) {
-  navigation.dispatch(
+type Navigation = NavigationProp<AppStackParamsList>;
+type Dispatch = Navigation['dispatch'];
+
+export function resetToYourTeam(dispatch: Dispatch) {
+  dispatch(
     CommonActions.reset({
       index: 2,
       routes: [{name: 'Home'}, {name: 'ProjectSettings'}, {name: 'YourTeam'}],

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
@@ -31,6 +31,7 @@ export const InviteAccepted = ({
 }: NativeRootNavigationProps<'InviteAccepted'>) => {
   const {formatMessage: t} = useIntl();
   const {role, ...deviceInfo} = route.params;
+  const {onClose} = route.params;
 
   useFocusEffect(
     React.useCallback(() => {
@@ -65,12 +66,7 @@ export const InviteAccepted = ({
           }}>
           {t(m.addAnotherDevice)}
         </Button>
-        <Button
-          style={{marginTop: 10}}
-          fullWidth
-          onPress={() => {
-            navigation.popTo('YourTeam');
-          }}>
+        <Button style={{marginTop: 10}} fullWidth onPress={onClose}>
           {t(m.close)}
         </Button>
       </View>

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
@@ -72,7 +72,7 @@ export const InviteAccepted = ({
           style={{marginTop: 10}}
           fullSize
           text={t(m.close)}
-          onPress={() => resetToYourTeam(navigation)}
+          onPress={() => resetToYourTeam(navigation.dispatch)}
         />
       </View>
     </View>

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {DeviceNameWithIcon} from '../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../sharedComponents/RoleWithIcon';
-import {Button} from '../../../../sharedComponents/Button';
 import {
   SecondaryButton,
   PrimaryButton,

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteAccepted.tsx
@@ -6,9 +6,14 @@ import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {DeviceNameWithIcon} from '../../../../sharedComponents/DeviceNameWithIcon';
 import {RoleWithIcon} from '../../../../sharedComponents/RoleWithIcon';
 import {Button} from '../../../../sharedComponents/Button';
+import {
+  SecondaryButton,
+  PrimaryButton,
+} from '../../../../sharedComponents/Buttons';
 import {useFocusEffect} from '@react-navigation/native';
 import {COORDINATOR_ROLE_ID} from '../../../../sharedTypes';
 import {HeaderText} from '../../../../sharedComponents/Text/HeaderText';
+import {resetToYourTeam} from '../../../../lib/resetToYourTeam';
 
 const m = defineMessages({
   inviteAccepted: {
@@ -31,7 +36,6 @@ export const InviteAccepted = ({
 }: NativeRootNavigationProps<'InviteAccepted'>) => {
   const {formatMessage: t} = useIntl();
   const {role, ...deviceInfo} = route.params;
-  const {onClose} = route.params;
 
   useFocusEffect(
     React.useCallback(() => {
@@ -57,18 +61,20 @@ export const InviteAccepted = ({
           role={role === COORDINATOR_ROLE_ID ? 'coordinator' : 'participant'}
         />
       </View>
-      <View style={{width: '100%'}}>
-        <Button
-          fullWidth
-          variant="outlined"
+      <View style={{alignItems: 'center'}}>
+        <SecondaryButton
+          fullSize
+          text={t(m.addAnotherDevice)}
           onPress={() => {
             navigation.popTo('SelectDevice');
-          }}>
-          {t(m.addAnotherDevice)}
-        </Button>
-        <Button style={{marginTop: 10}} fullWidth onPress={onClose}>
-          {t(m.close)}
-        </Button>
+          }}
+        />
+        <PrimaryButton
+          style={{marginTop: 10}}
+          fullSize
+          text={t(m.close)}
+          onPress={() => resetToYourTeam(navigation)}
+        />
       </View>
     </View>
   );

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
@@ -25,11 +25,11 @@ const m = defineMessages({
 });
 
 export const InviteDeclined = ({
-  navigation,
   route,
 }: NativeRootNavigationProps<'InviteDeclined'>) => {
   const {formatMessage} = useIntl();
   const {name, deviceType, deviceId} = route.params;
+  const {onClose} = route.params;
 
   useFocusEffect(
     React.useCallback(() => {
@@ -59,12 +59,7 @@ export const InviteDeclined = ({
           style={{marginTop: 20}}
         />
       </View>
-      <Button
-        style={{marginTop: 10}}
-        fullWidth
-        onPress={() => {
-          navigation.popTo('YourTeam');
-        }}>
+      <Button style={{marginTop: 10}} fullWidth onPress={onClose}>
         {formatMessage(m.close)}
       </Button>
     </View>

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
@@ -7,6 +7,8 @@ import {Text} from '../../../../sharedComponents/Text';
 import {DeviceNameWithIcon} from '../../../../sharedComponents/DeviceNameWithIcon';
 import {NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
 import {useFocusEffect} from '@react-navigation/native';
+import {resetToYourTeam} from '../../../../lib/resetToYourTeam';
+import {PrimaryButton} from '../../../../sharedComponents/Buttons';
 
 const m = defineMessages({
   inviteDeclined: {
@@ -25,11 +27,11 @@ const m = defineMessages({
 });
 
 export const InviteDeclined = ({
+  navigation,
   route,
 }: NativeRootNavigationProps<'InviteDeclined'>) => {
   const {formatMessage} = useIntl();
   const {name, deviceType, deviceId} = route.params;
-  const {onClose} = route.params;
 
   useFocusEffect(
     React.useCallback(() => {
@@ -59,9 +61,12 @@ export const InviteDeclined = ({
           style={{marginTop: 20}}
         />
       </View>
-      <Button style={{marginTop: 10}} fullWidth onPress={onClose}>
-        {formatMessage(m.close)}
-      </Button>
+      <PrimaryButton
+        style={{marginTop: 10}}
+        fullSize
+        text={formatMessage(m.close)}
+        onPress={() => resetToYourTeam(navigation)}
+      />
     </View>
   );
 };

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {BackHandler, StyleSheet, View} from 'react-native';
-import {Button} from '../../../../sharedComponents/Button';
 import ErrorIcon from '../../../../images/Error.svg';
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../../../../sharedComponents/Text';

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/InviteDeclined.tsx
@@ -64,7 +64,7 @@ export const InviteDeclined = ({
         style={{marginTop: 10}}
         fullSize
         text={formatMessage(m.close)}
-        onPress={() => resetToYourTeam(navigation)}
+        onPress={() => resetToYourTeam(navigation.dispatch)}
       />
     </View>
   );

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
@@ -56,7 +56,7 @@ export const UnableToCancelInvite = ({
         style={{marginTop: 10}}
         fullSize
         text={formatMessage(m.close)}
-        onPress={() => resetToYourTeam(navigation)}
+        onPress={() => resetToYourTeam(navigation.dispatch)}
       />
     </View>
   );

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
@@ -9,6 +9,8 @@ import {RoleWithIcon} from '../../../../../sharedComponents/RoleWithIcon';
 import {COORDINATOR_ROLE_ID} from '../../../../../sharedTypes';
 import {useProjectSettings} from '../../../../../hooks/server/projects';
 import {NativeRootNavigationProps} from '../../../../../sharedTypes/navigation';
+import {resetToYourTeam} from '../../../../../lib/resetToYourTeam';
+import {PrimaryButton} from '../../../../../sharedComponents/Buttons';
 
 const m = defineMessages({
   unableToCancel: {
@@ -26,12 +28,12 @@ const m = defineMessages({
 });
 
 export const UnableToCancelInvite = ({
+  navigation,
   route,
 }: NativeRootNavigationProps<'UnableToCancelInvite'>) => {
   const {formatMessage} = useIntl();
   const {role, ...deviceInfo} = route.params;
   const {data} = useProjectSettings();
-  const {onClose} = route.params;
 
   return (
     <View style={styles.container}>
@@ -51,9 +53,12 @@ export const UnableToCancelInvite = ({
           role={role === COORDINATOR_ROLE_ID ? 'coordinator' : 'participant'}
         />
       </View>
-      <Button style={{marginTop: 10}} fullWidth onPress={onClose}>
-        {formatMessage(m.close)}
-      </Button>
+      <PrimaryButton
+        style={{marginTop: 10}}
+        fullSize
+        text={formatMessage(m.close)}
+        onPress={() => resetToYourTeam(navigation)}
+      />
     </View>
   );
 };

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
-import {Button} from '../../../../../sharedComponents/Button';
 import ErrorIcon from '../../../../../images/Error.svg';
 import {defineMessages, useIntl} from 'react-intl';
 import {Text} from '../../../../../sharedComponents/Text';

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/UnableToCancelInvite.tsx
@@ -26,12 +26,12 @@ const m = defineMessages({
 });
 
 export const UnableToCancelInvite = ({
-  navigation,
   route,
 }: NativeRootNavigationProps<'UnableToCancelInvite'>) => {
   const {formatMessage} = useIntl();
   const {role, ...deviceInfo} = route.params;
   const {data} = useProjectSettings();
+  const {onClose} = route.params;
 
   return (
     <View style={styles.container}>
@@ -51,12 +51,7 @@ export const UnableToCancelInvite = ({
           role={role === COORDINATOR_ROLE_ID ? 'coordinator' : 'participant'}
         />
       </View>
-      <Button
-        style={{marginTop: 10}}
-        fullWidth
-        onPress={() => {
-          navigation.popTo('YourTeam');
-        }}>
+      <Button style={{marginTop: 10}} fullWidth onPress={onClose}>
         {formatMessage(m.close)}
       </Button>
     </View>

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
@@ -64,7 +64,7 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
       {deviceId},
       {
         onSuccess: () => {
-          resetToYourTeam(navigation);
+          resetToYourTeam(navigation.dispatch);
         },
         onError: err => {
           Sentry.captureException(err);

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import {NativeNavigationComponent} from '../../../../../sharedTypes/navigation';
+import {
+  AppStackParamsList,
+  NativeNavigationComponent,
+} from '../../../../../sharedTypes/navigation';
 import {defineMessages} from 'react-intl';
 import {ReviewInvitation} from './ReviewInvitation';
 import {WaitingForInviteAccept} from './WaitingForInviteAccept';
 import {useSendInvite, useRequestCancelInvite} from '@comapeo/core-react';
 import {useActiveProject} from '../../../../../contexts/ActiveProjectContext';
 import * as Sentry from '@sentry/react-native';
+import {CommonActions, NavigationProp} from '@react-navigation/native';
 
 const m = defineMessages({
   title: {
@@ -37,16 +41,25 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
             val === 'ACCEPT' &&
             requestCancelInviteMutation.status === 'pending'
           ) {
-            navigation.navigate('UnableToCancelInvite', {...route.params});
+            navigation.navigate('InviteDeclined', {
+              ...route.params,
+              onClose: () => resetToYourTeam(navigation),
+            });
             return;
           }
           if (val === 'ACCEPT') {
-            navigation.navigate('InviteAccepted', route.params);
+            navigation.navigate('InviteAccepted', {
+              ...route.params,
+              onClose: () => resetToYourTeam(navigation),
+            });
             return;
           }
 
           if (val === 'REJECT') {
-            navigation.navigate('InviteDeclined', route.params);
+            navigation.navigate('InviteDeclined', {
+              ...route.params,
+              onClose: () => resetToYourTeam(navigation),
+            });
             return;
           }
         },
@@ -63,7 +76,7 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
       {deviceId},
       {
         onSuccess: () => {
-          navigation.popTo('YourTeam');
+          resetToYourTeam(navigation);
         },
         onError: err => {
           Sentry.captureException(err);
@@ -88,5 +101,14 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
     </>
   );
 };
+
+function resetToYourTeam(navigation: NavigationProp<AppStackParamsList>) {
+  navigation.dispatch(
+    CommonActions.reset({
+      index: 2,
+      routes: [{name: 'Home'}, {name: 'ProjectSettings'}, {name: 'YourTeam'}],
+    }),
+  );
+}
 
 ReviewAndInvite.navTitle = m.title;

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import {
-  AppStackParamsList,
-  NativeNavigationComponent,
-} from '../../../../../sharedTypes/navigation';
+import {NativeNavigationComponent} from '../../../../../sharedTypes/navigation';
 import {defineMessages} from 'react-intl';
 import {ReviewInvitation} from './ReviewInvitation';
 import {WaitingForInviteAccept} from './WaitingForInviteAccept';

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/ReviewAndInvite/index.tsx
@@ -9,7 +9,7 @@ import {WaitingForInviteAccept} from './WaitingForInviteAccept';
 import {useSendInvite, useRequestCancelInvite} from '@comapeo/core-react';
 import {useActiveProject} from '../../../../../contexts/ActiveProjectContext';
 import * as Sentry from '@sentry/react-native';
-import {CommonActions, NavigationProp} from '@react-navigation/native';
+import {resetToYourTeam} from '../../../../../lib/resetToYourTeam';
 
 const m = defineMessages({
   title: {
@@ -41,25 +41,16 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
             val === 'ACCEPT' &&
             requestCancelInviteMutation.status === 'pending'
           ) {
-            navigation.navigate('InviteDeclined', {
-              ...route.params,
-              onClose: () => resetToYourTeam(navigation),
-            });
+            navigation.navigate('UnableToCancelInvite', {...route.params});
             return;
           }
           if (val === 'ACCEPT') {
-            navigation.navigate('InviteAccepted', {
-              ...route.params,
-              onClose: () => resetToYourTeam(navigation),
-            });
+            navigation.navigate('InviteAccepted', route.params);
             return;
           }
 
           if (val === 'REJECT') {
-            navigation.navigate('InviteDeclined', {
-              ...route.params,
-              onClose: () => resetToYourTeam(navigation),
-            });
+            navigation.navigate('InviteDeclined', route.params);
             return;
           }
         },
@@ -101,14 +92,5 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
     </>
   );
 };
-
-function resetToYourTeam(navigation: NavigationProp<AppStackParamsList>) {
-  navigation.dispatch(
-    CommonActions.reset({
-      index: 2,
-      routes: [{name: 'Home'}, {name: 'ProjectSettings'}, {name: 'YourTeam'}],
-    }),
-  );
-}
 
 ReviewAndInvite.navTitle = m.title;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -18,15 +18,11 @@ export interface TabBarIconProps {
   color: string;
 }
 
-export type InviteParams = {
+export type InviteProps = {
   name: string;
   deviceType: DeviceType;
   deviceId: string;
   role: DeviceRoleForNewInvite;
-};
-
-export type InviteWithOnClose = InviteParams & {
-  onClose: () => void;
 };
 
 export type HomeTabsParamsList = {
@@ -81,10 +77,10 @@ export type RootStackParamsList = {
   YourTeam: undefined;
   SelectDevice: undefined;
   SelectInviteeRole: {name: string; deviceType: DeviceType; deviceId: string};
-  ReviewAndInvite: InviteParams;
-  InviteAccepted: InviteWithOnClose;
-  InviteDeclined: InviteWithOnClose;
-  UnableToCancelInvite: InviteWithOnClose;
+  ReviewAndInvite: InviteProps;
+  InviteAccepted: InviteProps;
+  InviteDeclined: InviteProps;
+  UnableToCancelInvite: InviteProps;
   DeviceNameDisplay: undefined;
   DeviceNameEdit: undefined;
   SaveTrack: undefined;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -18,11 +18,14 @@ export interface TabBarIconProps {
   color: string;
 }
 
-export type InviteProps = {
+export type InviteParams = {
   name: string;
   deviceType: DeviceType;
   deviceId: string;
   role: DeviceRoleForNewInvite;
+};
+
+export type InviteWithOnClose = InviteParams & {
   onClose: () => void;
 };
 
@@ -78,10 +81,10 @@ export type RootStackParamsList = {
   YourTeam: undefined;
   SelectDevice: undefined;
   SelectInviteeRole: {name: string; deviceType: DeviceType; deviceId: string};
-  ReviewAndInvite: InviteProps;
-  InviteAccepted: InviteProps;
-  InviteDeclined: InviteProps;
-  UnableToCancelInvite: InviteProps;
+  ReviewAndInvite: InviteParams;
+  InviteAccepted: InviteWithOnClose;
+  InviteDeclined: InviteWithOnClose;
+  UnableToCancelInvite: InviteWithOnClose;
   DeviceNameDisplay: undefined;
   DeviceNameEdit: undefined;
   SaveTrack: undefined;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -23,6 +23,7 @@ export type InviteProps = {
   deviceType: DeviceType;
   deviceId: string;
   role: DeviceRoleForNewInvite;
+  onClose: () => void;
 };
 
 export type HomeTabsParamsList = {


### PR DESCRIPTION
closes #1124 

**The problem**
After accepting or declining a device invite, tapping "Close" would return to the YourTeam screen, but the invite flow was still in the navigation stack. Pressing the back button would take the user back into the invite flow, which was confusing.

**The fix**
Added a shared resetToYourTeam function to replace the navigation stack with:
Home → ProjectSettings → YourTeam
Passed this function into InviteAccepted, InviteDeclined, and UnableToCancelInvite as an onClose param.
Used it in the cancelInvite flow as well.

**Result**
Now when the user taps "Close," they return to YourTeam, and the back button works as expected without going back into the invite screens.

