### PR TITLE
fix: add back settings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -232,6 +232,15 @@
   "Screens.ProjectSettings.projectCollaborators": {
     "message": "Project Collaborators"
   },
+  "Screens.ProjectSettings.remoteArchiveDesc": {
+    "message": "Share with a secure, encypted server. URL required to access."
+  },
+  "Screens.ProjectSettings.remoteArchiveOff": {
+    "message": "Remote Archive | OFF"
+  },
+  "Screens.ProjectSettings.remoteArchiveOn": {
+    "message": "Remote Archive | ON"
+  },
   "Screens.ProjectSettings.soloDescription": {
     "message": "You’re mapping on your own."
   },
@@ -240,6 +249,9 @@
   },
   "Screens.ProjectSettings.updateCategories": {
     "message": "Update Set"
+  },
+  "Screens.ProjectSettings.viewDetails": {
+    "message": "View Details"
   },
   "Screens.ProjectSettings.viewTeam": {
     "message": "View Team"
@@ -252,6 +264,9 @@
   },
   "Screens.Settings.AppSettings.coordinateSystemDesc": {
     "message": "UTM,Lat/Lon,DMS"
+  },
+  "Screens.Settings.AppSettings.deviceName": {
+    "message": "Device Name"
   },
   "Screens.Settings.AppSettings.language": {
     "message": "Language"

--- a/src/frontend/screens/MenuScreen.tsx
+++ b/src/frontend/screens/MenuScreen.tsx
@@ -144,7 +144,7 @@ export function MenuScreen() {
         <View style={styles.bottomItemsContainer}>
           <MainMenuItemWrapper
             onPress={() => navigation.navigate('Sync')}
-            accessibilityLabel="Go to Exchange Screen">
+            accessibilityLabel="Go to exchange screen.">
             <Exchange width={20} height={20} color={NEW_DARK_GREY} />
             <View style={{paddingLeft: 12}}>
               <BodyText variant="medium">{formatMessage(m.exchange)}</BodyText>
@@ -152,7 +152,7 @@ export function MenuScreen() {
           </MainMenuItemWrapper>
           <MainMenuItemWrapper
             onPress={() => navigation.navigate('AppSettings')}
-            accessibilityLabel="Go to App Settings">
+            accessibilityLabel="Go to app settings screen.">
             <IonIcon name="settings-outline" size={20} color={NEW_DARK_GREY} />
             <View style={{paddingLeft: 12}}>
               <BodyText variant="medium">
@@ -162,7 +162,7 @@ export function MenuScreen() {
           </MainMenuItemWrapper>
           <MainMenuItemWrapper
             onPress={() => navigation.navigate('DataAndPrivacy')}
-            accessibilityLabel="Go to Data and Privacy Screen">
+            accessibilityLabel="Go to data and privacy screen.">
             <Octicons name="shield-lock" size={20} color={NEW_DARK_GREY} />
             <View style={{paddingLeft: 12}}>
               <BodyText variant="medium">
@@ -172,7 +172,7 @@ export function MenuScreen() {
           </MainMenuItemWrapper>
           <MainMenuItemWrapper
             onPress={() => navigation.navigate('AboutSettings')}
-            accessibilityLabel="Go to About CoMapeo Screen">
+            accessibilityLabel="Go to about CoMapeo screen.">
             <MaterialIcon name="info-outline" size={20} color={NEW_DARK_GREY} />
             <View style={{paddingLeft: 12}}>
               <BodyText variant="medium">

--- a/src/frontend/screens/Settings/AppSettings/index.tsx
+++ b/src/frontend/screens/Settings/AppSettings/index.tsx
@@ -38,6 +38,10 @@ const m = defineMessages({
     id: 'Screens.Settings.AppSettings.Drawer.security',
     defaultMessage: 'Security',
   },
+  deviceName: {
+    id: 'Screens.Settings.AppSettings.deviceName',
+    defaultMessage: 'Device Name',
+  },
 });
 
 export const AppSettings: NativeNavigationComponent<'AppSettings'> = ({
@@ -46,6 +50,14 @@ export const AppSettings: NativeNavigationComponent<'AppSettings'> = ({
   const {authState} = useAuthContext();
   const {formatMessage} = useIntl();
   const MenuItems: MenuListItemType[] = [
+    {
+      onPress: () => {
+        navigation.navigate('DeviceNameDisplay');
+      },
+      testID: 'device-name-list-item',
+      primaryText: formatMessage(m.deviceName),
+      materialIconName: 'phone-android',
+    },
     {
       onPress: () => {
         navigation.navigate('LanguageSettings');
@@ -80,6 +92,17 @@ export const AppSettings: NativeNavigationComponent<'AppSettings'> = ({
             },
             primaryText: formatMessage(m.security),
             materialIconName: 'security',
+          },
+        ]
+      : []),
+    ...(process.env.EXPO_PUBLIC_FEATURE_TEST_DATA_UI
+      ? [
+          {
+            onPress: () => {
+              navigation.navigate('CreateTestData');
+            },
+            primaryText: 'Create Test Data',
+            materialIconName: 'auto-fix-high',
           },
         ]
       : []),

--- a/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/DeviceName/EditScreen.tsx
@@ -154,7 +154,7 @@ export const EditScreen = ({
     <ScrollView contentContainerStyle={styles.container}>
       <FieldRow label={t(m.deviceNameLabel)}>
         <HookFormTextInput
-          testID="PROJECT.edit-device-name"
+          testID="edit-device-name"
           control={control}
           name="deviceName"
           rules={{maxLength: 60, required: true, minLength: 1}}

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -126,27 +126,27 @@ export const ProjectSettings = () => {
           onPress={() => navigate('YourTeam')}
         />
       )}
+      {isCoordinator && (
+        <SettingsCardRow
+          icon={<ExchangeIcon width={24} height={24} />}
+          title={formatMessage(
+            remoteArchiveOn ? m.remoteArchiveOn : m.remoteArchiveOff,
+          )}
+          subtitle={formatMessage(m.remoteArchiveDesc)}
+          buttonText={formatMessage(m.viewDetails)}
+          onPress={() =>
+            navigate(remoteArchiveOn ? 'RemoteArchiveOn' : 'RemoteArchiveOff')
+          }
+        />
+      )}
       {projectInfo.role !== 'participant' && (
-        <>
-          <SettingsCardRow
-            icon={<ExchangeIcon width={24} height={24} />}
-            title={formatMessage(
-              remoteArchiveOn ? m.remoteArchiveOn : m.remoteArchiveOff,
-            )}
-            subtitle={formatMessage(m.remoteArchiveDesc)}
-            buttonText={formatMessage(m.viewDetails)}
-            onPress={() =>
-              navigate(remoteArchiveOn ? 'RemoteArchiveOn' : 'RemoteArchiveOff')
-            }
-          />
-          <SettingsCardRow
-            icon={<ProjectCategoriesIcon width={24} height={24} />}
-            title={formatMessage(m.configTitle)}
-            subtitle={configData?.configMetadata?.name}
-            buttonText={formatMessage(m.updateCategories)}
-            onPress={() => navigate('Config')}
-          />
-        </>
+        <SettingsCardRow
+          icon={<ProjectCategoriesIcon width={24} height={24} />}
+          title={formatMessage(m.configTitle)}
+          subtitle={configData?.configMetadata?.name}
+          buttonText={formatMessage(m.updateCategories)}
+          onPress={() => navigate('Config')}
+        />
       )}
     </ScrollView>
   );

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -9,6 +9,7 @@ import {BodyText} from '../../../sharedComponents/Text/BodyText';
 import NoProjectIcon from '../../../images/NoProjectIcon.svg';
 import ProjectParticipantIcon from '../../../images/ProjectParticipant.svg';
 import ProjectCategoriesIcon from '../../../images/ProjectCategories.svg';
+import ExchangeIcon from '../../../images/Exchange.svg';
 import {
   COMAPEO_BLUE,
   NEW_DARK_GREY,
@@ -18,6 +19,7 @@ import {
 } from '../../../lib/styles';
 import {useProjectSettings} from '../../../hooks/server/projects';
 import {useNavigationFromRoot} from '../../../hooks/useNavigationWithTypes';
+import {useGetRemoteArchives} from '../../../hooks/server/projects';
 
 const m = defineMessages({
   title: {
@@ -60,6 +62,23 @@ const m = defineMessages({
     id: 'Screens.ProjectSettings.editInfo',
     defaultMessage: 'Edit Info',
   },
+  remoteArchiveOn: {
+    id: 'Screens.ProjectSettings.remoteArchiveOn',
+    defaultMessage: 'Remote Archive  |  ON',
+  },
+  remoteArchiveOff: {
+    id: 'Screens.ProjectSettings.remoteArchiveOff',
+    defaultMessage: 'Remote Archive  |  OFF',
+  },
+  remoteArchiveDesc: {
+    id: 'Screens.ProjectSettings.remoteArchiveDesc',
+    defaultMessage:
+      'Share with a secure, encypted server. URL required to access.',
+  },
+  viewDetails: {
+    id: 'Screens.ProjectSettings.viewDetails',
+    defaultMessage: 'View Details',
+  },
 });
 
 export const ProjectSettings = () => {
@@ -70,6 +89,8 @@ export const ProjectSettings = () => {
   const {data: configData} = useProjectSettings();
   const isSolo = projectInfo.role === 'solo';
   const isCoordinator = projectInfo.role === 'coordinator';
+  const {data: remoteArchives} = useGetRemoteArchives();
+  const remoteArchiveOn = remoteArchives && remoteArchives.length > 0;
 
   const displayTitle = isSolo
     ? projectInfo.projectHeader
@@ -106,13 +127,26 @@ export const ProjectSettings = () => {
         />
       )}
       {projectInfo.role !== 'participant' && (
-        <SettingsCardRow
-          icon={<ProjectCategoriesIcon width={24} height={24} />}
-          title={formatMessage(m.configTitle)}
-          subtitle={configData?.configMetadata?.name}
-          buttonText={formatMessage(m.updateCategories)}
-          onPress={() => navigate('Config')}
-        />
+        <>
+          <SettingsCardRow
+            icon={<ExchangeIcon width={24} height={24} />}
+            title={formatMessage(
+              remoteArchiveOn ? m.remoteArchiveOn : m.remoteArchiveOff,
+            )}
+            subtitle={formatMessage(m.remoteArchiveDesc)}
+            buttonText={formatMessage(m.viewDetails)}
+            onPress={() =>
+              navigate(remoteArchiveOn ? 'RemoteArchiveOn' : 'RemoteArchiveOff')
+            }
+          />
+          <SettingsCardRow
+            icon={<ProjectCategoriesIcon width={24} height={24} />}
+            title={formatMessage(m.configTitle)}
+            subtitle={configData?.configMetadata?.name}
+            buttonText={formatMessage(m.updateCategories)}
+            onPress={() => navigate('Config')}
+          />
+        </>
       )}
     </ScrollView>
   );

--- a/tests/e2e/specs/flow.test.ts
+++ b/tests/e2e/specs/flow.test.ts
@@ -4,7 +4,7 @@ describe('CoMapeo E2E Flow', function () {
   require('./onboarding/data-privacy.test');
   require('./onboarding/privacy-policy.test');
   require('./onboarding/device-naming.test');
-  // require('./project/edit-device-name.test');
+  require('./project/edit-device-name.test');
   require('./project/own-project-headers.test');
   require('./main/side-drawer-menu-no-proj.test');
   require('./project/project-settings-no-proj.test');

--- a/tests/e2e/specs/main/side-drawer-menu-no-proj.test.ts
+++ b/tests/e2e/specs/main/side-drawer-menu-no-proj.test.ts
@@ -7,7 +7,7 @@ describe('Main - Side Drawer Menu - No Project', () => {
   it('should open the side drawer and verify menu options', async () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
-    const deviceName = await $(byText(output.names.device));
+    const deviceName = await $(byText(output.names.editdevice));
     await expect(deviceName).toBeDisplayed();
 
     await expect($(byTextMatches('CURRENT PROJECT'))).toBeDisplayed();

--- a/tests/e2e/specs/main/side-drawer-menu-no-proj.test.ts
+++ b/tests/e2e/specs/main/side-drawer-menu-no-proj.test.ts
@@ -24,10 +24,10 @@ describe('Main - Side Drawer Menu - No Project', () => {
     const viewButton = await $(byText('View'));
     await expect(viewButton).toBeDisplayed();
 
-    await expect($('~Go to Data and Privacy Screen')).toBeDisplayed();
-    await expect($('~Go to Exchange Screen')).toBeDisplayed();
-    await expect($('~Go to App Settings')).toBeDisplayed();
-    await expect($('~Go to About CoMapeo Screen')).toBeDisplayed();
+    await expect($('~Go to data and privacy screen.')).toBeDisplayed();
+    await expect($('~Go to exchange screen.')).toBeDisplayed();
+    await expect($('~Go to app settings screen.')).toBeDisplayed();
+    await expect($('~Go to about CoMapeo screen.')).toBeDisplayed();
 
     await $('~Close Menu').click();
     const mapTab = await $('~Go to map.');

--- a/tests/e2e/specs/passcode/obscure-mode.test.ts
+++ b/tests/e2e/specs/passcode/obscure-mode.test.ts
@@ -57,7 +57,7 @@ describe('Passcode - Obscure Passcode Mode', () => {
   it('should not show security after entering obscure passcode', async () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
-    const appSettingsOption = await $('~Go to App Settings');
+    const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
 
     await expect($(byText('Security'))).not.toBeDisplayed();

--- a/tests/e2e/specs/passcode/obscure-passcode-visibility.test.ts
+++ b/tests/e2e/specs/passcode/obscure-passcode-visibility.test.ts
@@ -7,7 +7,7 @@ describe('Passcode - Obscure Passcode Visibility', () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
 
-    const appSettingsOption = await $('~Go to App Settings');
+    const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
 
     const securityOption = await $(byText('Security'));

--- a/tests/e2e/specs/passcode/post-passcode-setup.test.ts
+++ b/tests/e2e/specs/passcode/post-passcode-setup.test.ts
@@ -8,7 +8,7 @@ describe('Passcode - Post Passcode Setup Flow', () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
 
-    const appSettingsOption = await $('~Go to App Settings');
+    const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
 
     const securityOption = await $(byText('Security'));

--- a/tests/e2e/specs/passcode/set-passcode.test.ts
+++ b/tests/e2e/specs/passcode/set-passcode.test.ts
@@ -9,7 +9,7 @@ describe('Passcode - Set Passcode Flow', () => {
     if (await drawerIcon.isDisplayed()) {
       await drawerIcon.click();
     }
-    const appSettingsOption = await $('~Go to App Settings');
+    const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
 
     const securityOption = await $(byText('Security'));

--- a/tests/e2e/specs/project/edit-device-name.test.ts
+++ b/tests/e2e/specs/project/edit-device-name.test.ts
@@ -9,19 +9,15 @@ describe('Project - Edit Device Name Test', () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.tap();
 
-    const projectSettingsItem = await $('~Go to Project Settings');
-    await projectSettingsItem.tap();
+    const appSettingsItem = await $('~Go to app settings screen.');
+    await appSettingsItem.tap();
 
-    const deviceNameListItem = await $(
-      byResourceId('PROJECT.device-name-list-item'),
-    );
+    const deviceNameListItem = await $(byResourceId('device-name-list-item'));
     await deviceNameListItem.click();
 
     const editIcon = await $(byResourceId('edit-icon'));
     await editIcon.click();
-    const editDeviceNameField = await $(
-      byResourceId('PROJECT.edit-device-name'),
-    );
+    const editDeviceNameField = await $(byResourceId('edit-device-name'));
     await editDeviceNameField.click();
     await editDeviceNameField.clearValue();
     await editDeviceNameField.setValue(output.names.editdevice);
@@ -62,7 +58,7 @@ describe('Project - Edit Device Name Test', () => {
     await $('~Close Menu').click();
 
     await drawerIcon.tap();
-    await projectSettingsItem.click();
+    await appSettingsItem.click();
     await deviceNameListItem.click();
 
     await expect(editedDeviceName).toBeDisplayed();

--- a/tests/e2e/specs/settings/about-comapeo.test.ts
+++ b/tests/e2e/specs/settings/about-comapeo.test.ts
@@ -9,7 +9,7 @@ describe('Settings - About CoMapeo Flow', () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
 
-    const aboutComapeoOption = await $('~Go to About CoMapeo Screen');
+    const aboutComapeoOption = await $('~Go to about CoMapeo screen.');
     await aboutComapeoOption.click();
   });
 

--- a/tests/e2e/specs/settings/coordinates.test.ts
+++ b/tests/e2e/specs/settings/coordinates.test.ts
@@ -7,7 +7,7 @@ describe('Settings - Coordinates Settings Flow', () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
 
-    const appSettingsOption = await $('~Go to App Settings');
+    const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
   });
 

--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -7,7 +7,7 @@ describe('Settings - Language Settings Flow', () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
 
-    const appSettingsOption = await $('~Go to App Settings');
+    const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
 
     const languageOption = await $(byTextMatches('Language'));


### PR DESCRIPTION
closes #1131
closes #1136 
closes #1139

### Changes
- Adds back the menu item to edit a device name and puts it in App Settings at the top
   - The issue asks that the device name be tied to multiple projects, but that is already the case so nothing needs to be changed for that.
- Adds back the menu item to create test data in settings
- Adds the card within the project menu to add a remote archive 
  - that card is there for any coordinator, even one on a solo project. Not sure if that is as it should be.

### Screenshots
<image src="https://github.com/user-attachments/assets/06994fe2-5043-488e-a3f4-9beaee09f644" width="250" />
<image src="https://github.com/user-attachments/assets/bbf67dc0-a397-4633-b8a2-d481996c6b39" width="250" />



