### PR TITLE
feat: add ability to remove remote archive

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -118,23 +118,59 @@
   "ProjectSettings.RemoteArchive.AddRemoteArchive.youAreAdding": {
     "message": "You are adding:"
   },
-  "ProjectSettings.RemoteArchive.Coordinator.addArchive": {
-    "message": "+ Add Remote Archive"
+  "ProjectSettings.RemoteArchive.RemoteArchiveOff.addArchive": {
+    "message": "Add Remote Archive"
   },
-  "ProjectSettings.RemoteArchive.Coordinator.dataNotShared": {
+  "ProjectSettings.RemoteArchive.RemoteArchiveOff.dataNotShared": {
     "message": "The data in your project is not shared over the internet. Only people in your project can see your data."
   },
-  "ProjectSettings.RemoteArchive.Coordinator.experimentalFeature": {
+  "ProjectSettings.RemoteArchive.RemoteArchiveOff.experimentalFeature": {
     "message": "This is an experimental feature. You need a Remote Archive URL to enable Remote Archive."
   },
-  "ProjectSettings.RemoteArchive.Coordinator.noServers": {
+  "ProjectSettings.RemoteArchive.RemoteArchiveOff.noServers": {
     "message": "No servers have been added to this project"
   },
-  "ProjectSettings.RemoteArchive.Coordinator.remoteArchiveOff": {
+  "ProjectSettings.RemoteArchive.RemoteArchiveOff.remoteArchiveOff": {
     "message": "Remote Archive is Off"
   },
-  "ProjectSettings.RemoteArchive.RemoteArchiveOn": {
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.coordinatorCanTurnOff": {
+    "message": "Only a Project Coordinator can turn off Remote Archive."
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.dateAdded": {
+    "message": "Date Added"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.deviceNames": {
+    "message": "Device Names"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.navTitle": {
+    "message": "Remote Archive"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.observations": {
+    "message": "Observations (including photos and audio)"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.projectSettings": {
+    "message": "Project Settings (categories, questions)"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.remoteArchiveOn": {
     "message": "Remote Archive is On"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.remove": {
+    "message": "Remove the server to stop Remote Archive."
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.removeServer": {
+    "message": "Remove Server"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.serverName": {
+    "message": "Server Name"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.syncWithInternet": {
+    "message": "Your project data is syncing to the archive over the internet to the secure, encrypted server below. The server owner can view the data."
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.thisIncludes": {
+    "message": "This includes:"
+  },
+  "ProjectSettings.RemoteArchive.RemoteArchiveOn.tracks": {
+    "message": "Tracks"
   },
   "ProjectSettings.RemoteArchive.Success.archiveAdded": {
     "message": "Remote Archive Added"
@@ -163,38 +199,8 @@
   "ProjectSettings.RemoteArchive.WhatsIncludedSheet.tracks": {
     "message": "Tracks"
   },
-  "ProjectSettings.RemoteArchive.coordinatorCanTurnOff": {
-    "message": "Only a Project Coordinator can turn off Remote Archive."
-  },
-  "ProjectSettings.RemoteArchive.dateAdded": {
-    "message": "Date Added"
-  },
-  "ProjectSettings.RemoteArchive.deviceNames": {
-    "message": "Device Names"
-  },
   "ProjectSettings.RemoteArchive.navTitle": {
     "message": "Remote Archive"
-  },
-  "ProjectSettings.RemoteArchive.observations": {
-    "message": "Observations (including photos and audio)"
-  },
-  "ProjectSettings.RemoteArchive.projectSettings": {
-    "message": "Project Settings (categories, questions)"
-  },
-  "ProjectSettings.RemoteArchive.remove": {
-    "message": "Remove the server to stop Remote Archive."
-  },
-  "ProjectSettings.RemoteArchive.serverName": {
-    "message": "Server Name"
-  },
-  "ProjectSettings.RemoteArchive.syncWithInternet": {
-    "message": "Your project data is syncing to the archive over the internet to the secure, encrypted server below. The server owner can view the data."
-  },
-  "ProjectSettings.RemoteArchive.thisIncludes": {
-    "message": "This includes"
-  },
-  "ProjectSettings.RemoteArchive.tracks": {
-    "message": "Tracks"
   },
   "SaveTrack.HeaderLeft.discardCancel": {
     "description": "Button on dialog to keep editing (cancelling close action)",
@@ -282,6 +288,22 @@
   },
   "Screens.Settings.AppSettings.title": {
     "message": "App Settings"
+  },
+  "Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.cancel": {
+    "description": "Text for cancel action button.",
+    "message": "Cancel"
+  },
+  "Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.description": {
+    "description": "Explanation for consequences of removing archive server.",
+    "message": "This will stop archiving new data for this project. Existing archived data will not be deleted."
+  },
+  "Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.removeArchive": {
+    "description": "Text for destructive action button.",
+    "message": "Remove Archive"
+  },
+  "Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.title": {
+    "description": "Text for title that asks about confirming archive server removal.",
+    "message": "Remove {name} from project?"
   },
   "SharedComponents.ActionButtons.cancel": {
     "description": "Button to cancel delete of observation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@bam.tech/react-native-image-resizer": "3.0.11",
-        "@comapeo/core-react": "4.0.0",
+        "@comapeo/core-react": "4.2.1",
         "@comapeo/ipc": "3.0.0",
         "@expo-google-fonts/rubik": "0.2.3",
         "@formatjs/intl-getcanonicallocales": "2.5.5",
@@ -2495,12 +2495,12 @@
       }
     },
     "node_modules/@comapeo/core-react": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-4.0.0.tgz",
-      "integrity": "sha512-lQjeuD5vmmp1Q5a20apkvnfLOVxNt3vddbk+OVBqbgQWPDsU0SEMirJj0AttXq4wLL24VM95gNWRMyM/BeRAAA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-4.2.1.tgz",
+      "integrity": "sha512-fDcB6XfOeqhimohXO6MAIjJi7IrGB+gXLreZRg7seR823rnLPCw22tWSKHlhVIP5ed+Y9pxDb21IWrAvb079nQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@comapeo/core": "^3.0.0",
+        "@comapeo/core": "^3.1.0",
         "@comapeo/ipc": "^3.0.0",
         "@comapeo/schema": "*",
         "@tanstack/react-query": "^5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "3.0.11",
-    "@comapeo/core-react": "4.0.0",
+    "@comapeo/core-react": "4.2.1",
     "@comapeo/ipc": "3.0.0",
     "@expo-google-fonts/rubik": "0.2.3",
     "@formatjs/intl-getcanonicallocales": "2.5.5",

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -70,11 +70,9 @@ import {SettingsPrivacyPolicy} from '../../screens/Settings/DataAndPrivacy/Setti
 import {TrackEdit} from '../../screens/TrackEdit/index.tsx';
 import {Config} from '../../screens/Settings/Config';
 import {HowToLeaveProject} from '../../screens/HowToLeaveProject.tsx';
-import {RemoteArchiveOff} from '../../screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOff.tsx';
 import {SaveButton} from '../../sharedComponents/SaveButton.tsx';
 import {AddRemoteArchive} from '../../screens/Settings/ProjectSettings/RemoteArchive/AddRemoteArchive.tsx';
 import {SuccessfullyAddedArchive} from '../../screens/Settings/ProjectSettings/RemoteArchive/SuccessfullyAddedArchive.tsx';
-import {RemoteArchiveOn} from '../../screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOn.tsx';
 import {
   createNavigationOptions as createMapManagementNavigationOptions,
   MapManagementScreen,
@@ -105,6 +103,14 @@ import {MenuScreen} from '../../screens/MenuScreen';
 import {InviteCollaboratorsScreen} from '../../screens/Settings/ProjectSettings/YourTeam/InviteCollaborators.tsx';
 import {MenuHeader} from '../../sharedComponents/MenuHeader.tsx';
 import {TrackRecordingActive} from '../../screens/TrackRecordingActive.tsx';
+import {
+  RemoteArchiveScreen,
+  createNavigationOptions as createRemoteArchiveNavigationOptions,
+} from '../../screens/Settings/ProjectSettings/RemoteArchive/index.tsx';
+import {
+  RemoveRemoteArchive,
+  navigationOptions as removeRemoteArchiveNavigationOptions,
+} from '../../screens/Settings/ProjectSettings/RemoteArchive/RemoveRemoteArchive.tsx';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -364,9 +370,9 @@ export const createDefaultScreenGroup = ({
         />
       )}
       <RootStack.Screen
-        name="RemoteArchiveOff"
-        component={RemoteArchiveOff}
-        options={{headerTitle: intl(RemoteArchiveOff.navTitle)}}
+        name="RemoteArchive"
+        component={RemoteArchiveScreen}
+        options={createRemoteArchiveNavigationOptions({intl})}
       />
       <RootStack.Screen
         name="AddRemoteArchive"
@@ -384,9 +390,9 @@ export const createDefaultScreenGroup = ({
         options={{headerShown: false}}
       />
       <RootStack.Screen
-        name="RemoteArchiveOn"
-        component={RemoteArchiveOn}
-        options={{headerTitle: intl(RemoteArchiveOn.navTitle)}}
+        name="RemoveRemoteArchive"
+        component={RemoveRemoteArchive}
+        options={removeRemoteArchiveNavigationOptions}
       />
       <RootStack.Screen
         name="AudioRecording"

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {type MemberInfo} from '@comapeo/core/dist/member-api';
 import {
   useProjectSettings as useComapeoProjectSettings,
   useManyMembers,
@@ -7,16 +7,7 @@ import {
 import {useQuery} from '@tanstack/react-query';
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
-
-export const ALL_PROJECTS_KEY = 'all_projects';
-export const PROJECT_SETTINGS_KEY = 'project_settings';
-export const CREATE_PROJECT_KEY = 'create_project';
-export const PROJECT_KEY = 'project';
-export const PROJECT_MEMBERS_KEY = 'project_members';
-export const ORIGINAL_VERSION_ID_TO_DEVICE_ID_KEY =
-  'originalVersionIdToDeviceId';
-export const THIS_USERS_ROLE_KEY = 'my_role';
-export const REMOTE_ARCHIVE = 'remote_archive';
+import {MEMBER_ROLE_ID} from '../../sharedTypes';
 
 export function useProjectSettings() {
   const {projectId} = useActiveProject();
@@ -28,19 +19,29 @@ export function useGetOwnRole() {
   return useOwnRoleInProject({projectId});
 }
 
-export function useGetRemoteArchives() {
-  const {projectId} = useActiveProject();
-  const {data: members, error, isRefetching} = useManyMembers({projectId});
+// TODO: Ideally this is handled in @comapeo/core (https://github.com/digidem/comapeo-core/issues/1031)
+export type ArchiveServerMemberInfo = MemberInfo & {
+  deviceType: 'selfHostedServer';
+  selfHostedServerDetails: NonNullable<MemberInfo['selfHostedServerDetails']>;
+};
 
-  const archives = useMemo(() => {
-    return members?.filter(m => m.deviceType === 'selfHostedServer') ?? [];
-  }, [members]);
+// TODO: Ideally this is handled in @comapeo/core (https://github.com/digidem/comapeo-core/issues/1031)
+function isActiveArchiveServerMember(
+  member: MemberInfo,
+): member is ArchiveServerMemberInfo {
+  if (member.deviceType !== 'selfHostedServer') return false;
+  if (!member.selfHostedServerDetails) return false;
+  if (member.role.roleId !== MEMBER_ROLE_ID) return false;
+  return true;
+}
 
-  return {
-    data: archives,
-    error,
-    isRefetching,
-  };
+export function useActiveArchiveServer({
+  projectId,
+}: {
+  projectId: string;
+}): ArchiveServerMemberInfo | undefined {
+  const {data: members} = useManyMembers({projectId});
+  return members.find(isActiveArchiveServerMember);
 }
 
 export function useFindRemoteArchive({url}: {url?: string}) {

--- a/src/frontend/screens/Exchange/ExchangeScreenContent.tsx
+++ b/src/frontend/screens/Exchange/ExchangeScreenContent.tsx
@@ -42,7 +42,7 @@ import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {PrimaryButton, SecondaryButton} from '../../sharedComponents/Buttons';
 import {ROOT_QUERY_KEY} from '../../constants';
-import {useGetRemoteArchives} from '../../hooks/server/projects';
+import {useActiveArchiveServer} from '../../hooks/server/projects';
 import {Button} from '../../sharedComponents/Button';
 
 const m = defineMessages({
@@ -147,9 +147,7 @@ export const ExchangeScreenContent = ({syncState}: {syncState: SyncState}) => {
     syncState.remoteDeviceSyncState,
   );
 
-  const {data: remoteArchives} = useGetRemoteArchives();
-
-  const remoteArchiveConnected = remoteArchives && remoteArchives.length > 0;
+  const remoteArchiveConnected = !!useActiveArchiveServer({projectId});
 
   const syncingPeersCount = getSyncingPeersCount(
     syncState.remoteDeviceSyncState,

--- a/src/frontend/screens/Exchange/index.tsx
+++ b/src/frontend/screens/Exchange/index.tsx
@@ -3,7 +3,7 @@ import {useSyncState} from '@comapeo/core-react';
 
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {
-  useGetRemoteArchives,
+  useActiveArchiveServer,
   useProjectSettings,
 } from '../../hooks/server/projects';
 import {useLocalDiscoveryState} from '../../hooks/useLocalDiscoveryState';
@@ -26,18 +26,15 @@ const m = defineMessages({
 export const SyncScreen = ({navigation}: NativeRootNavigationProps<'Sync'>) => {
   const wifiStatus = useLocalDiscoveryState(state => state.wifiStatus);
 
-  const {data: remoteArchive, isRefetching: remoteArchiveLoading} =
-    useGetRemoteArchives();
-
-  const hasRemoteArchive = remoteArchive && remoteArchive.length > 0;
-
   const hasInternetAccess = useNetInfo().isConnected;
 
   const {projectId} = useActiveProject();
   const syncState = useSyncState({projectId});
   const projectSettingsQuery = useProjectSettings();
 
-  if (!syncState || remoteArchiveLoading) {
+  const hasRemoteArchive = !!useActiveArchiveServer({projectId});
+
+  if (!syncState) {
     return <Loading />;
   }
 

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOff.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOff.tsx
@@ -1,85 +1,83 @@
-import {NativeNavigationComponent} from '../../../../sharedTypes/navigation';
-import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
-import {Button} from '../../../../sharedComponents/Button';
+import {ScrollView, StyleSheet, View} from 'react-native';
+
 import {MEDIUM_GREY} from '../../../../lib/styles';
-import {useNavigationFromRoot} from '../../../../hooks/useNavigationWithTypes';
-import {useGetOwnRole} from '../../../../hooks/server/projects';
-import {COORDINATOR_ROLE_ID, CREATOR_ROLE_ID} from '../../../../sharedTypes';
-import {HeaderText} from '../../../../sharedComponents/Text/HeaderText';
+import {SecondaryButton} from '../../../../sharedComponents/Buttons';
 import {BodyText} from '../../../../sharedComponents/Text/BodyText';
+import {HeaderText} from '../../../../sharedComponents/Text/HeaderText';
+import MaterialIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 const m = defineMessages({
-  navTitle: {
-    id: 'ProjectSettings.RemoteArchive.navTitle',
-    defaultMessage: 'Remote Archive',
-  },
   remoteArchiveOff: {
-    id: 'ProjectSettings.RemoteArchive.Coordinator.remoteArchiveOff',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOff.remoteArchiveOff',
     defaultMessage: 'Remote Archive is Off',
   },
   dataNotShared: {
-    id: 'ProjectSettings.RemoteArchive.Coordinator.dataNotShared',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOff.dataNotShared',
     defaultMessage:
       'The data in your project is not shared over the internet. Only people in your project can see your data.',
   },
   experimentalFeature: {
-    id: 'ProjectSettings.RemoteArchive.Coordinator.experimentalFeature',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOff.experimentalFeature',
     defaultMessage:
       'This is an experimental feature. You need a Remote Archive URL to enable Remote Archive.',
   },
   noServers: {
-    id: 'ProjectSettings.RemoteArchive.Coordinator.noServers',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOff.noServers',
     defaultMessage: 'No servers have been added to this project',
   },
   addArchive: {
-    id: 'ProjectSettings.RemoteArchive.Coordinator.addArchive',
-    defaultMessage: '+ Add Remote Archive',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOff.addArchive',
+    defaultMessage: 'Add Remote Archive',
   },
 });
 
-export const RemoteArchiveOff: NativeNavigationComponent<
-  'RemoteArchiveOff'
-> = () => {
-  const {formatMessage} = useIntl();
-  const {navigate} = useNavigationFromRoot();
-  const {data: role} = useGetOwnRole();
-  const isCoordinator =
-    role?.roleId === COORDINATOR_ROLE_ID || role?.roleId === CREATOR_ROLE_ID;
+export function RemoteArchiveOff({
+  isCoordinator,
+  onAdd,
+}: {
+  isCoordinator: boolean;
+  onAdd: () => void;
+}) {
+  const {formatMessage: t} = useIntl();
 
   return (
-    <View style={styles.container}>
+    <ScrollView contentContainerStyle={styles.container}>
       <HeaderText variant="header2" style={styles.title}>
-        {formatMessage(m.remoteArchiveOff) + ' '}
+        {t(m.remoteArchiveOff)}
       </HeaderText>
-      <BodyText style={{marginTop: 20}}>
-        {formatMessage(m.dataNotShared)}
-      </BodyText>
-      <BodyText style={{marginTop: 20}}>
-        {formatMessage(m.experimentalFeature)}
-      </BodyText>
-      <BodyText variant="smallMeta" style={styles.subtext}>
-        {formatMessage(m.noServers)}
-      </BodyText>
-      {isCoordinator ? (
-        <Button
-          variant="outlined"
-          style={{marginTop: 20}}
-          onPress={() => {
-            navigate('AddRemoteArchive');
-          }}>
-          {formatMessage(m.addArchive)}
-        </Button>
-      ) : null}
-    </View>
+      <View style={{gap: 20}}>
+        <BodyText>{t(m.dataNotShared)}</BodyText>
+        <BodyText>{t(m.experimentalFeature)}</BodyText>
+      </View>
+
+      <View style={{gap: 20}}>
+        <BodyText variant="smallMeta" style={styles.subtext}>
+          {t(m.noServers)}
+        </BodyText>
+        {isCoordinator && (
+          <SecondaryButton
+            fullSize
+            renderIcon={({color, size}) => (
+              <MaterialIcons size={size} name="plus" color={color} />
+            )}
+            text={t(m.addArchive)}
+            onPress={() => {
+              onAdd();
+            }}
+          />
+        )}
+      </View>
+    </ScrollView>
   );
-};
+}
 
 const styles = StyleSheet.create({
   container: {
     padding: 20,
-    paddingTop: 40,
+    paddingVertical: 40,
+    gap: 40,
+    alignItems: 'center',
   },
   title: {
     textAlign: 'center',
@@ -87,8 +85,5 @@ const styles = StyleSheet.create({
   subtext: {
     color: MEDIUM_GREY,
     textAlign: 'center',
-    marginTop: 20,
   },
 });
-
-RemoteArchiveOff.navTitle = m.navTitle;

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOn.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoteArchiveOn.tsx
@@ -1,214 +1,167 @@
 import * as React from 'react';
-import {BackHandler, StyleSheet, View} from 'react-native';
 import {FormattedDate, defineMessages, useIntl} from 'react-intl';
-import {
-  useGetOwnRole,
-  useGetRemoteArchives,
-} from '../../../../hooks/server/projects';
-import {Loading} from '../../../../sharedComponents/Loading';
-import {COORDINATOR_ROLE_ID, CREATOR_ROLE_ID} from '../../../../sharedTypes';
-import {NativeNavigationComponent} from '../../../../sharedTypes/navigation';
-import {LIGHT_GREY, MEDIUM_GREY} from '../../../../lib/styles';
+import {StyleSheet, TouchableOpacity, View} from 'react-native';
 import {ScrollView} from 'react-native-gesture-handler';
-import {useFocusEffect} from '@react-navigation/native';
-import {CustomHeaderLeft} from '../../../../sharedComponents/CustomHeaderLeft';
-import {HeaderText} from '../../../../sharedComponents/Text/HeaderText';
+
+import {LIGHT_GREY, MAGENTA, MEDIUM_GREY} from '../../../../lib/styles';
 import {BodyText} from '../../../../sharedComponents/Text/BodyText';
-// import {TouchableOpacity} from 'react-native';
+import {HeaderText} from '../../../../sharedComponents/Text/HeaderText';
 
 const m = defineMessages({
   navTitle: {
-    id: 'ProjectSettings.RemoteArchive.navTitle',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.navTitle',
     defaultMessage: 'Remote Archive',
   },
   remoteArchiveOn: {
-    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.remoteArchiveOn',
     defaultMessage: 'Remote Archive is On',
   },
   syncWithInternet: {
-    id: 'ProjectSettings.RemoteArchive.syncWithInternet',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.syncWithInternet',
     defaultMessage:
       'Your project data is syncing to the archive over the internet to the secure, encrypted server below. The server owner can view the data.',
   },
   remove: {
-    id: 'ProjectSettings.RemoteArchive.remove',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.remove',
     defaultMessage: 'Remove the server to stop Remote Archive.',
   },
   coordinatorCanTurnOff: {
-    id: 'ProjectSettings.RemoteArchive.coordinatorCanTurnOff',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.coordinatorCanTurnOff',
     defaultMessage: 'Only a Project Coordinator can turn off Remote Archive.',
   },
   thisIncludes: {
-    id: 'ProjectSettings.RemoteArchive.thisIncludes',
-    defaultMessage: 'This includes ',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.thisIncludes',
+    defaultMessage: 'This includes:',
   },
   observations: {
-    id: 'ProjectSettings.RemoteArchive.observations',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.observations',
     defaultMessage: 'Observations (including photos and audio)',
   },
   tracks: {
-    id: 'ProjectSettings.RemoteArchive.tracks',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.tracks',
     defaultMessage: 'Tracks',
   },
   deviceNames: {
-    id: 'ProjectSettings.RemoteArchive.deviceNames',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.deviceNames',
     defaultMessage: 'Device Names',
   },
   projectSettings: {
-    id: 'ProjectSettings.RemoteArchive.projectSettings',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.projectSettings',
     defaultMessage: 'Project Settings (categories, questions)',
   },
   serverName: {
-    id: 'ProjectSettings.RemoteArchive.serverName',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.serverName',
     defaultMessage: 'Server Name',
   },
   dateAdded: {
-    id: 'ProjectSettings.RemoteArchive.dateAdded',
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.dateAdded',
     defaultMessage: 'Date Added',
   },
-  //   remove: {
-  //     id: 'ProjectSettings.RemoteArchive.remove',
-  //     defaultMessage: 'Remove Server',
-  //   },
+  removeServer: {
+    id: 'ProjectSettings.RemoteArchive.RemoteArchiveOn.removeServer',
+    defaultMessage: 'Remove Server',
+  },
 });
 
-export const RemoteArchiveOn: NativeNavigationComponent<'RemoteArchiveOn'> = ({
-  navigation,
-}) => {
-  const {formatMessage} = useIntl();
-  const {data: role} = useGetOwnRole();
-  const {data: remoteArchive, isRefetching} = useGetRemoteArchives();
-
-  const isCoordinator =
-    role?.roleId === COORDINATOR_ROLE_ID || role?.roleId === CREATOR_ROLE_ID;
-
-  const currentRemoteArchive = !remoteArchive ? undefined : remoteArchive[0];
-
-  const handleGoBack = React.useCallback(() => {
-    navigation.popTo('ProjectSettings');
-  }, [navigation]);
-
-  React.useLayoutEffect(() => {
-    navigation.setOptions({
-      headerLeft: props => (
-        <CustomHeaderLeft
-          onPress={handleGoBack}
-          headerBackButtonProps={props}
-        />
-      ),
-    });
-  }, [handleGoBack, navigation]);
-
-  useFocusEffect(
-    React.useCallback(() => {
-      const onBackPress = () => {
-        handleGoBack();
-        return true;
-      };
-
-      const subscription = BackHandler.addEventListener(
-        'hardwareBackPress',
-        onBackPress,
-      );
-
-      return () => subscription.remove();
-    }, [handleGoBack]),
-  );
-
-  if (isRefetching) {
-    return <Loading />;
-  }
+export function RemoteArchiveOn({
+  archiveBaseUrl,
+  archiveDateAdded,
+  archiveName,
+  isCoordinator,
+  onRemove,
+}: {
+  archiveBaseUrl: string;
+  archiveDateAdded?: string;
+  archiveName?: string;
+  isCoordinator: boolean;
+  onRemove: () => void;
+}) {
+  const {formatMessage: t} = useIntl();
 
   return (
-    <ScrollView
-      style={styles.container}
-      contentContainerStyle={{paddingBottom: 60}}>
+    <ScrollView contentContainerStyle={styles.container}>
       <HeaderText variant="header2" style={styles.title}>
-        {formatMessage(m.remoteArchiveOn)}
+        {t(m.remoteArchiveOn)}
       </HeaderText>
-      <BodyText style={{marginTop: 20}}>
-        {formatMessage(m.syncWithInternet)}
-      </BodyText>
+
+      <View>
+        <BodyText>{t(m.syncWithInternet)}</BodyText>
+        {isCoordinator && <BodyText>{t(m.remove)}</BodyText>}
+      </View>
 
       {isCoordinator ? (
-        <>
-          {/* <Text>{formatMessage(m.remove)}</Text> */}
-          <BodyText variant="smallMeta" style={{marginTop: 20}}>
-            {formatMessage(m.thisIncludes)}
+        <View>
+          <BodyText variant="smallMeta" style={{fontWeight: 'bold'}}>
+            {t(m.thisIncludes)}
           </BodyText>
-          <BodyText variant="smallMeta">
-            {formatMessage(m.observations)}
-          </BodyText>
-          <BodyText variant="smallMeta">{formatMessage(m.tracks)}</BodyText>
-          <BodyText variant="smallMeta">
-            {formatMessage(m.deviceNames)}
-          </BodyText>
-          <BodyText variant="smallMeta">
-            {formatMessage(m.projectSettings)}
-          </BodyText>
-        </>
+          <BodyText variant="smallMeta">{t(m.observations)}</BodyText>
+          <BodyText variant="smallMeta">{t(m.tracks)}</BodyText>
+          <BodyText variant="smallMeta">{t(m.deviceNames)}</BodyText>
+          <BodyText variant="smallMeta">{t(m.projectSettings)}</BodyText>
+        </View>
       ) : (
-        <BodyText>{formatMessage(m.coordinatorCanTurnOff)}</BodyText>
+        <BodyText>{t(m.coordinatorCanTurnOff)}</BodyText>
       )}
 
-      {currentRemoteArchive && (
-        <>
-          <View style={styles.nameDate}>
-            <BodyText variant="smallMeta" style={styles.smallGrayText}>
-              {formatMessage(m.serverName)}
-            </BodyText>
-            <BodyText variant="smallMeta" style={styles.smallGrayText}>
-              {formatMessage(m.dateAdded)}
-            </BodyText>
-          </View>
-          <View style={styles.card}>
-            <View style={{alignSelf: 'flex-start', maxWidth: '70%'}}>
-              <HeaderText variant="header6">
-                {currentRemoteArchive.name}
-              </HeaderText>
-              {currentRemoteArchive.selfHostedServerDetails && (
-                <BodyText variant="smallMeta">
-                  {currentRemoteArchive.selfHostedServerDetails.baseUrl}
-                </BodyText>
-              )}
-              {/* {isCoordinator && (
-                <TouchableOpacity>
-                  <Text style={{fontSize: 14, color: RED, marginTop: 10}}>
-                    {formatMessage(m.remove)}
-                  </Text>
-                </TouchableOpacity>
-              )} */}
+      <View style={{gap: 12}}>
+        <View style={styles.nameDate}>
+          <BodyText variant="smallMeta" style={{color: MEDIUM_GREY}}>
+            {t(m.serverName)}
+          </BodyText>
+          <BodyText variant="smallMeta" style={{color: MEDIUM_GREY}}>
+            {t(m.dateAdded)}
+          </BodyText>
+        </View>
+
+        <View style={styles.card}>
+          <View style={{alignSelf: 'flex-start', maxWidth: '70%', gap: 20}}>
+            <View style={{gap: 4}}>
+              <HeaderText variant="header6">{archiveName}</HeaderText>
+              <BodyText variant="smallMeta" style={{color: MEDIUM_GREY}}>
+                {archiveBaseUrl}
+              </BodyText>
             </View>
-            <BodyText
-              variant="tinyMeta"
-              style={{
-                flex: 1,
-                alignSelf: 'flex-start',
-                textAlign: 'right',
-                justifyContent: 'center',
-                color: MEDIUM_GREY,
-              }}>
-              <FormattedDate
-                value={currentRemoteArchive.joinedAt}
-                year="numeric"
-                month="short"
-                day="2-digit"
-              />
-            </BodyText>
+            {isCoordinator && (
+              <TouchableOpacity
+                onPress={() => {
+                  onRemove();
+                }}>
+                <BodyText
+                  style={{color: MAGENTA, fontWeight: 'bold'}}
+                  variant="smallMeta">
+                  {t(m.removeServer)}
+                </BodyText>
+              </TouchableOpacity>
+            )}
           </View>
-        </>
-      )}
+
+          <BodyText
+            variant="tinyMeta"
+            style={{
+              flex: 1,
+              alignSelf: 'flex-start',
+              textAlign: 'right',
+              justifyContent: 'center',
+              color: MEDIUM_GREY,
+            }}>
+            <FormattedDate
+              value={archiveDateAdded}
+              year="numeric"
+              month="short"
+              day="2-digit"
+            />
+          </BodyText>
+        </View>
+      </View>
     </ScrollView>
   );
-};
-
-RemoteArchiveOn.navTitle = m.navTitle;
+}
 
 const styles = StyleSheet.create({
   container: {
     padding: 20,
-    paddingTop: 40,
-    marginBottom: 20,
+    paddingVertical: 40,
+    gap: 20,
   },
   title: {
     textAlign: 'center',
@@ -216,13 +169,7 @@ const styles = StyleSheet.create({
   nameDate: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 20,
     justifyContent: 'space-between',
-    marginBottom: 10,
-  },
-  smallGrayText: {
-    fontSize: 12,
-    color: MEDIUM_GREY,
   },
   card: {
     flex: 1,

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoveRemoteArchive.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/RemoveRemoteArchive.tsx
@@ -1,0 +1,129 @@
+import {useRemoveServerPeer} from '@comapeo/core-react';
+import {type NativeStackNavigationOptions} from '@react-navigation/native-stack';
+import * as Sentry from '@sentry/react-native';
+import {defineMessages, useIntl} from 'react-intl';
+import {StyleSheet, View} from 'react-native';
+import {UIActivityIndicator} from 'react-native-indicators';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+
+import {useActiveProject} from '../../../../contexts/ActiveProjectContext';
+import Error from '../../../../images/Error.svg';
+import {BottomSheetWrapper} from '../../../../sharedComponents/BottomSheetWrapper';
+import {
+  DestructiveButton,
+  SecondaryButton,
+} from '../../../../sharedComponents/Buttons';
+import {BodyText} from '../../../../sharedComponents/Text/BodyText';
+import {HeaderText} from '../../../../sharedComponents/Text/HeaderText';
+import {type NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
+
+const m = defineMessages({
+  title: {
+    id: 'Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.title',
+    defaultMessage: 'Remove {name} from project?',
+    description:
+      'Text for title that asks about confirming archive server removal.',
+  },
+  description: {
+    id: 'Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.description',
+    defaultMessage:
+      'This will stop archiving new data for this project. Existing archived data will not be deleted.',
+    description: 'Explanation for consequences of removing archive server.',
+  },
+  removeArchive: {
+    id: 'Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.removeArchive',
+    defaultMessage: 'Remove Archive',
+    description: 'Text for destructive action button.',
+  },
+  cancel: {
+    id: 'Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Text for cancel action button.',
+  },
+});
+
+export function RemoveRemoteArchive({
+  navigation,
+  route,
+}: NativeRootNavigationProps<'RemoveRemoteArchive'>) {
+  const {baseUrl, name, serverDeviceId} = route.params;
+
+  const {formatMessage: t} = useIntl();
+  const {projectId} = useActiveProject();
+
+  const removeServerPeer = useRemoveServerPeer({projectId});
+
+  return (
+    <BottomSheetWrapper>
+      <View style={styles.container}>
+        <View style={styles.infoContainer}>
+          <Error />
+          <HeaderText variant="header2" style={{textAlign: 'center'}}>
+            {t(m.title, {name: name || baseUrl})}
+          </HeaderText>
+          <BodyText style={{textAlign: 'center'}}>{t(m.description)}</BodyText>
+        </View>
+
+        <View style={styles.buttonContainer}>
+          {removeServerPeer.status === 'pending' ? (
+            <UIActivityIndicator style={{flex: 0}} />
+          ) : (
+            <>
+              <DestructiveButton
+                fullSize
+                text={t(m.removeArchive)}
+                renderIcon={({color, size}) => (
+                  <MaterialIcons name="delete" size={size} color={color} />
+                )}
+                onPress={() => {
+                  removeServerPeer.mutate(
+                    {serverDeviceId},
+                    {
+                      onError: err => {
+                        Sentry.captureException(err);
+                        navigation.navigate('ErrorBottomSheet');
+                      },
+                      onSuccess: () => {
+                        navigation.goBack();
+                      },
+                    },
+                  );
+                }}
+              />
+              <SecondaryButton
+                fullSize
+                text={t(m.cancel)}
+                onPress={() => {
+                  navigation.goBack();
+                }}
+              />
+            </>
+          )}
+        </View>
+      </View>
+    </BottomSheetWrapper>
+  );
+}
+
+export const navigationOptions: NativeStackNavigationOptions = {
+  animation: 'none',
+  contentStyle: {
+    backgroundColor: 'transparent',
+  },
+  headerShown: false,
+  presentation: 'transparentModal',
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: 40,
+  },
+  infoContainer: {
+    alignItems: 'center',
+    gap: 20,
+  },
+  buttonContainer: {
+    gap: 20,
+  },
+});

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/SuccessfullyAddedArchive.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/SuccessfullyAddedArchive.tsx
@@ -38,7 +38,7 @@ export const SuccessfullyAddedArchive = ({
           fullWidth
           variant="outlined"
           onPress={() => {
-            navigation.navigate('RemoteArchiveOn');
+            navigation.popTo('RemoteArchive');
           }}>
           {formatMessage(m.close)}
         </Button>

--- a/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/RemoteArchive/index.tsx
@@ -1,0 +1,64 @@
+import {useOwnRoleInProject} from '@comapeo/core-react';
+import {type NativeStackNavigationOptions} from '@react-navigation/native-stack';
+import {defineMessages, type MessageDescriptor} from 'react-intl';
+
+import {useActiveProject} from '../../../../contexts/ActiveProjectContext';
+import {useActiveArchiveServer} from '../../../../hooks/server/projects';
+import {COORDINATOR_ROLE_ID, CREATOR_ROLE_ID} from '../../../../sharedTypes';
+import {type NativeRootNavigationProps} from '../../../../sharedTypes/navigation';
+import {RemoteArchiveOff} from './RemoteArchiveOff';
+import {RemoteArchiveOn} from './RemoteArchiveOn';
+
+const m = defineMessages({
+  navTitle: {
+    id: 'ProjectSettings.RemoteArchive.navTitle',
+    defaultMessage: 'Remote Archive',
+  },
+});
+
+export function RemoteArchiveScreen({
+  navigation,
+}: NativeRootNavigationProps<'RemoteArchive'>) {
+  const {projectId} = useActiveProject();
+  const {data: role} = useOwnRoleInProject({projectId});
+
+  const isCoordinator =
+    role.roleId === COORDINATOR_ROLE_ID || role.roleId === CREATOR_ROLE_ID;
+
+  const activeArchiveServer = useActiveArchiveServer({projectId});
+
+  return activeArchiveServer ? (
+    <RemoteArchiveOn
+      archiveBaseUrl={activeArchiveServer.selfHostedServerDetails.baseUrl}
+      archiveDateAdded={activeArchiveServer.joinedAt}
+      archiveName={activeArchiveServer.name}
+      isCoordinator={isCoordinator}
+      onRemove={() => {
+        navigation.navigate('RemoveRemoteArchive', {
+          name: activeArchiveServer.name,
+          serverDeviceId: activeArchiveServer.deviceId,
+          baseUrl: activeArchiveServer.selfHostedServerDetails.baseUrl,
+        });
+      }}
+    />
+  ) : (
+    <RemoteArchiveOff
+      isCoordinator={isCoordinator}
+      onAdd={() => {
+        navigation.navigate('AddRemoteArchive');
+      }}
+    />
+  );
+}
+
+export function createNavigationOptions({
+  intl,
+}: {
+  intl: (title: MessageDescriptor) => string;
+}) {
+  return (): NativeStackNavigationOptions => {
+    return {
+      headerTitle: intl(m.navTitle),
+    };
+  };
+}

--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -17,9 +17,11 @@ import {
   VERY_LIGHT_GREY,
   BLACK,
 } from '../../../lib/styles';
-import {useProjectSettings} from '../../../hooks/server/projects';
+import {
+  useActiveArchiveServer,
+  useProjectSettings,
+} from '../../../hooks/server/projects';
 import {useNavigationFromRoot} from '../../../hooks/useNavigationWithTypes';
-import {useGetRemoteArchives} from '../../../hooks/server/projects';
 
 const m = defineMessages({
   title: {
@@ -89,8 +91,7 @@ export const ProjectSettings = () => {
   const {data: configData} = useProjectSettings();
   const isSolo = projectInfo.role === 'solo';
   const isCoordinator = projectInfo.role === 'coordinator';
-  const {data: remoteArchives} = useGetRemoteArchives();
-  const remoteArchiveOn = remoteArchives && remoteArchives.length > 0;
+  const remoteArchiveOn = !!useActiveArchiveServer({projectId});
 
   const displayTitle = isSolo
     ? projectInfo.projectHeader
@@ -134,9 +135,7 @@ export const ProjectSettings = () => {
           )}
           subtitle={formatMessage(m.remoteArchiveDesc)}
           buttonText={formatMessage(m.viewDetails)}
-          onPress={() =>
-            navigate(remoteArchiveOn ? 'RemoteArchiveOn' : 'RemoteArchiveOff')
-          }
+          onPress={() => navigate('RemoteArchive')}
         />
       )}
       {projectInfo.role !== 'participant' && (

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -92,10 +92,7 @@ export type RootStackParamsList = {
   DataAndPrivacy: undefined;
   SettingsPrivacyPolicy: undefined;
   HowToLeaveProject: undefined;
-  RemoteArchiveOff: undefined;
-  AddRemoteArchive: undefined;
   SuccessfullyAddedArchive: {archiveName: string; url: string};
-  RemoteArchiveOn: undefined;
   MapManagement: undefined;
   BackgroundMaps: undefined;
   SyncPreviewsBottomSheet: undefined;
@@ -126,6 +123,13 @@ export type RootStackParamsList = {
   Menu: undefined;
   InviteCollaborators: undefined;
   TrackRecordingActive: undefined;
+  RemoteArchive: undefined;
+  AddRemoteArchive: undefined;
+  RemoveRemoteArchive: {
+    baseUrl: string;
+    name?: string;
+    serverDeviceId: string;
+  };
 };
 
 export type OnboardingParamsList = {


### PR DESCRIPTION
Closes #1140

Notable changes:

- Updates `@comapeo/core-react` to v4.2.1 to introduce the necessary write hook.

- Consolidates the remote archive setting screen to a single screen. This was agreed upon to reduce the technical awkwardness that having two navigation screens caused.

- UI adjustments to various remote-archive related screens/states to more closely match the designs.

---

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bfcad3ce-d3c8-4c98-b255-51f8751985d1" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bb1ba7d3-e319-469b-945b-2e47f3344fa7" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/97b0eeb7-6e0c-484c-b261-4deefcbc683e" />

https://github.com/user-attachments/assets/b29293c1-53c4-4843-b4c3-68bb47bbaad8