### PR TITLE
chore: update `@types/node` to latest v20 version, fix `AbortController`s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "@types/lint-staged": "13.3.0",
         "@types/lodash.isequal": "4.5.8",
         "@types/mocha": "10.0.10",
-        "@types/node": "20.8.4",
+        "@types/node": "20.17.46",
         "@types/react": "18.3.18",
         "@types/react-native-indicators": "0.16.6",
         "@types/react-native-vector-icons": "6.4.18",
@@ -8632,12 +8632,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.8.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
-      "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+      "version": "20.17.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
+      "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-forge": {
@@ -9575,17 +9575,6 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/@wdio/cli/node_modules/@wdio/globals": {
       "version": "9.12.7",
       "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.12.7.tgz",
@@ -9659,14 +9648,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@wdio/cli/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@wdio/cli/node_modules/webdriver": {
       "version": "9.12.6",
@@ -9879,16 +9860,6 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/mocha-framework/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/@wdio/mocha-framework/node_modules/@wdio/utils": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.9.0.tgz",
@@ -9913,13 +9884,6 @@
       "engines": {
         "node": ">=18.20.0"
       }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@wdio/protocols": {
       "version": "9.12.5",
@@ -9982,16 +9946,6 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/runner/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/@wdio/runner/node_modules/@wdio/config": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.9.0.tgz",
@@ -10034,13 +9988,6 @@
       "engines": {
         "node": ">=18.20.0"
       }
-    },
-    "node_modules/@wdio/runner/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@wdio/spec-reporter": {
       "version": "9.9.0",
@@ -31267,9 +31214,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -31880,16 +31827,6 @@
         }
       }
     },
-    "node_modules/webdriverio/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/webdriverio/node_modules/@wdio/config": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.9.0.tgz",
@@ -31968,13 +31905,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/webdriverio/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@types/lint-staged": "13.3.0",
     "@types/lodash.isequal": "4.5.8",
     "@types/mocha": "10.0.10",
-    "@types/node": "20.8.4",
+    "@types/node": "20.17.46",
     "@types/react": "18.3.18",
     "@types/react-native-indicators": "0.16.6",
     "@types/react-native-vector-icons": "6.4.18",

--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -12,6 +12,7 @@ import type {CameraCapturedPicture} from 'expo-camera';
 import {manipulateAsync} from 'expo-image-manipulator';
 import {excludeKeys} from 'filter-obj';
 import type {Position} from '../../sharedTypes/index.ts';
+import {throwIfAborted} from '../../lib/throwIfAborted.ts';
 
 export type DraftObservationStore = ReturnType<
   typeof createDraftObservationStore
@@ -143,7 +144,7 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
         outputKey: 'raw',
         processPromise: capturePromise,
       });
-      signal.throwIfAborted();
+      throwIfAborted(signal);
 
       // TODO: Previously, rotation of the original photo could fail on older
       // devices with low memory, so we would skip rotation and save the raw
@@ -164,7 +165,7 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
           {compress: ORIGINAL_COMPRESSION},
         ),
       });
-      signal.throwIfAborted();
+      throwIfAborted(signal);
 
       const thumbnailDimensions =
         width > height ? {width: THUMBNAIL_SIZE} : {height: THUMBNAIL_SIZE};
@@ -177,7 +178,7 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
           {compress: THUMBNAIL_COMPRESSION},
         ),
       });
-      signal.throwIfAborted();
+      throwIfAborted(signal);
 
       const previewDimensions =
         width > height ? {width: PREVIEW_SIZE} : {height: PREVIEW_SIZE};
@@ -190,7 +191,7 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
           {compress: PREVIEW_COMPRESSION},
         ),
       });
-      signal.throwIfAborted();
+      throwIfAborted(signal);
     } catch (reason) {
       if (reason instanceof Error && reason.name === 'AbortError') {
         // TODO: Remove attachment from state

--- a/src/frontend/lib/sleep.ts
+++ b/src/frontend/lib/sleep.ts
@@ -17,7 +17,11 @@ export function sleep(
 
       const onAbort = () => {
         clearTimeout(timeout);
-        reject(signal.reason);
+        // Use the `reason` if it exists. It doesn't currently in React Native,
+        // but we want to be ready in case it's added.
+        const reason =
+          'reason' in signal ? signal.reason : new Error('Aborted');
+        reject(reason);
         signal.removeEventListener('abort', onAbort);
       };
       signal.addEventListener('abort', onAbort);

--- a/src/frontend/lib/throwIfAborted.test.ts
+++ b/src/frontend/lib/throwIfAborted.test.ts
@@ -2,17 +2,15 @@ import {throwIfAborted} from './throwIfAborted';
 
 describe('throwIfAborted', () => {
   it('is a no-op if not aborted', () => {
-    const {signal} = new AbortController();
-
-    expect(() => throwIfAborted(signal)).not.toThrow();
+    expect(() => throwIfAborted({aborted: false})).not.toThrow();
   });
 
   it('throws if aborted', () => {
-    const abortController = new AbortController();
-    const {signal} = abortController;
-
-    abortController.abort(new Error('uh oh'));
-
-    expect(() => throwIfAborted(signal)).toThrow('uh oh');
+    expect(() => throwIfAborted({aborted: true})).toThrow(
+      'The operation was aborted',
+    );
+    expect(() =>
+      throwIfAborted({aborted: true, reason: new Error('foo bar')}),
+    ).toThrow('foo bar');
   });
 });

--- a/src/frontend/lib/throwIfAborted.ts
+++ b/src/frontend/lib/throwIfAborted.ts
@@ -1,7 +1,18 @@
+class AbortError extends Error {
+  readonly name = 'AbortError';
+  constructor() {
+    super('The operation was aborted');
+  }
+}
+
 /**
- * Ponyfill of `AbortSignal.prototype.throwIfAborted`, which is not supported
- * in our version of Node.
+ * Throw an error if the given `AbortSignal` is aborted.
+ *
+ * Similar to `AbortSignal.prototype.throwIfAborted`, but handles the case where
+ * `reason` is missing, which is the case in React Native.
  */
-export function throwIfAborted(signal: AbortSignal) {
-  if (signal.aborted) throw signal.reason;
+export function throwIfAborted(
+  signal: Readonly<{aborted: boolean; reason?: unknown}>,
+) {
+  if (signal.aborted) throw signal.reason || new AbortError();
 }


### PR DESCRIPTION
This updates `@types/node` to the latest version in the v20 range.

Notably, it changes `AbortController` and `AbortSignal` to (correctly) use the version from React Native, which is more limited. That means we need to handle those more limited cases, which requires some small tweaks.
