### PR TITLE
chore: always show leave project warning on invite

### DIFF
--- a/src/frontend/screens/Invites/InviteReceived.tsx
+++ b/src/frontend/screens/Invites/InviteReceived.tsx
@@ -7,12 +7,10 @@ import {
   useAcceptInvite,
   useRejectInvite,
   useSingleInvite,
-  useManyProjects,
 } from '@comapeo/core-react';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {UIActivityIndicator} from 'react-native-indicators';
-import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreContext';
 import * as Sentry from '@sentry/react-native';
 import {useListenToInviteCancel} from '../../hooks/useListenToInviteCancel';
 import {BLACK, NEW_DARK_GREY, VERY_LIGHT_GREY} from '../../lib/styles';
@@ -58,33 +56,13 @@ export const InviteReceived = ({
 
   const acceptInvite = useAcceptInvite();
   const rejectInvite = useRejectInvite();
-  const {setActiveProjectId} = useActiveProjectIdActions();
-  const projects = useManyProjects();
 
   useListenToInviteCancel(inviteId);
 
   function accept() {
-    if (projects.data.length > 1) {
-      navigation.replace('ExistingProjectWarning', {
-        inviteId,
-      });
-      return;
-    }
-    acceptInvite.mutate(
-      {inviteId: inviteId},
-      {
-        onSuccess: projectId => {
-          setActiveProjectId(projectId);
-          navigation.replace('InviteSuccessfullyAccepted', {
-            projectName: invite.projectName,
-          });
-        },
-        onError: err => {
-          Sentry.captureException(err);
-          navigation.replace('ErrorBottomSheet');
-        },
-      },
-    );
+    navigation.replace('ExistingProjectWarning', {
+      inviteId,
+    });
   }
 
   function reject() {

--- a/src/frontend/screens/Invites/LeaveProject.tsx
+++ b/src/frontend/screens/Invites/LeaveProject.tsx
@@ -90,7 +90,8 @@ export const LeaveProject = ({
           leaveProject.mutate(
             {projectId: currentProjectId},
             {
-              onSuccess: () => {
+              //If the leave project does not work, the user can still be on the other project so no sense in throwing an error
+              onSettled: () => {
                 setActiveProjectId(newProjectId);
                 navigation.replace('InviteSuccessfullyAccepted', {
                   projectName: invite.projectName,
@@ -98,7 +99,6 @@ export const LeaveProject = ({
               },
               onError: err => {
                 Sentry.captureException(err);
-                navigation.replace('ErrorBottomSheet');
               },
             },
           );


### PR DESCRIPTION
closes #1160 

Always show the leave project warning on an invite, since solo projects are now a valid project.

Not adding this to the develop branch since multi projects is being introduced right away meaning we won't need this code.
