### PR TITLE
chore: E2E docs & config clarifications

### DIFF
--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -110,11 +110,10 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Set PR Metadata Env Vars
-        if: github.event_name == 'pull_request'
+      - name: Set Metadata for Build Context
         run: |
-          echo "GITHUB_PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          echo "GITHUB_PR_TITLE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+          echo "GITHUB_SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha || github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+          echo "GITHUB_PR_TITLE=${{ github.event.pull_request.title || 'Manual Run' }}" >> $GITHUB_ENV
 
       - name: Run Webdriver IO E2E Tests on BrowserStack
         run: |
@@ -125,6 +124,8 @@ jobs:
           BROWSERSTACK_APP_URL: ${{ needs.build-apk.outputs.app_url }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          GITHUB_SHORT_SHA: ${{ env.GITHUB_SHORT_SHA }}
+          GITHUB_PR_TITLE: ${{ env.GITHUB_PR_TITLE }}
 
       - name: Upload Spec Reporter Logs
         if: always()

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -84,19 +84,9 @@ jobs:
       - name: Upload APK to BrowserStack
         id: upload
         run: |
-          TITLE="${{ github.event.pull_request.title || 'manual' }}"
-          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          SHORT_SHA=$(echo "$SHA" | cut -c1-7)
-          SAFE_TITLE=$(echo "$TITLE" | tr ' /:' '-' | cut -c1-50)
-          CUSTOM_ID="${SAFE_TITLE}-${SHORT_SHA}"
-
-          echo "Using custom_id: $CUSTOM_ID"
-
           APP_URL=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
             -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
-            -F "file=@$APK_PATH" \
-            -F "custom_id=$CUSTOM_ID" \
-            | jq -r '.app_url')
+            -F "file=@$APK_PATH" | jq -r '.app_url')
 
           echo "app_url=$APP_URL" >> $GITHUB_ENV
           echo "app_url=$APP_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -86,7 +86,9 @@ jobs:
         run: |
           APP_URL=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
             -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
-            -F "file=@$APK_PATH" | jq -r '.app_url')
+            -F "file=@$APK_PATH" \
+            -F "custom_id=${{ github.event.pull_request.title || 'manual' }}-${{ github.sha }}" \
+            | jq -r '.app_url')
           echo "app_url=$APP_URL" >> $GITHUB_ENV
           echo "app_url=$APP_URL" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -84,11 +84,20 @@ jobs:
       - name: Upload APK to BrowserStack
         id: upload
         run: |
+          TITLE="${{ github.event.pull_request.title || 'manual' }}"
+          SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          SHORT_SHA=$(echo "$SHA" | cut -c1-7)
+          SAFE_TITLE=$(echo "$TITLE" | tr ' /:' '-' | cut -c1-50)
+          CUSTOM_ID="${SAFE_TITLE}-${SHORT_SHA}"
+
+          echo "Using custom_id: $CUSTOM_ID"
+
           APP_URL=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
             -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
             -F "file=@$APK_PATH" \
-            -F "custom_id=${{ github.event.pull_request.title || 'manual' }}-${{ github.sha }}" \
+            -F "custom_id=$CUSTOM_ID" \
             | jq -r '.app_url')
+
           echo "app_url=$APP_URL" >> $GITHUB_ENV
           echo "app_url=$APP_URL" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -110,6 +110,12 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Set PR Metadata Env Vars
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GITHUB_PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "GITHUB_PR_TITLE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+
       - name: Run Webdriver IO E2E Tests on BrowserStack
         run: |
           set -o pipefail

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -87,7 +87,6 @@ jobs:
           APP_URL=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
             -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
             -F "file=@$APK_PATH" | jq -r '.app_url')
-
           echo "app_url=$APP_URL" >> $GITHUB_ENV
           echo "app_url=$APP_URL" >> $GITHUB_OUTPUT
         env:

--- a/docs/EndToEndTests/E2ETestingNotes.md
+++ b/docs/EndToEndTests/E2ETestingNotes.md
@@ -8,7 +8,7 @@ The environment variable `EXPO_PUBLIC_E2E_TEST=true` is used in CI and for the b
 
 ### Auth Flow (Passcode Input)
 
-- `src/frontend/contexts/AuthContext.tsx`: Disables ``FlagSecureModule` during E2E tests to allow screen recording on BrowserStack.
+- `src/frontend/contexts/AuthContext.tsx`: Disables `FlagSecureModule` during E2E tests to allow screen recording on BrowserStack.
 - `src/frontend/screens/AuthScreen.tsx`: Hides the `CoMapeoLogoSvg`, which was delaying input responsiveness.
 
 ### Map Style Fallback

--- a/docs/EndToEndTests/E2ETestingNotes.md
+++ b/docs/EndToEndTests/E2ETestingNotes.md
@@ -1,0 +1,24 @@
+# Additional Notes for E2E Testing Performance on BrowserStack
+
+Here find environment-specific changes made to reduce execution time for E2E tests on BrowserStack.
+
+## E2E-Specific UI Behavior
+
+The environment variable `EXPO_PUBLIC_E2E_TEST=true` is used in CI and for the build type "test" to modify app behavior and improve test performance in the following ways:
+
+### Auth Flow (Passcode Input)
+
+- `src/frontend/contexts/AuthContext.tsx`: Disables ``FlagSecureModule` during E2E tests to allow screen recording on BrowserStack.
+- `src/frontend/screens/AuthScreen.tsx`: Hides the `CoMapeoLogoSvg`, which was delaying input responsiveness.
+
+### Map Style Fallback
+
+- `src/frontend/hooks/server/maps.ts`: Switches to a public Mapbox style instead of fetching from the internal map server, which can fail with 502 errors in CI (issue #1008).
+
+### Audio Recording
+
+- `src/frontend/screens/Audio/AudioRecording/index.tsx`: Replaces the `AnimatedBackground` with a blank `<View />` in E2E mode. This animation was causing unnecessary Appium rendering delays that seem to happen with animations.
+
+### GPS Pill
+
+- `src/frontend/sharedComponents/GPSPill.tsx`: Replaces the `UIActivityIndicator` spinner with text (`...`) during E2E tests to eliminate rendering delays that seem to happen with animations when checking for GPS status.

--- a/src/frontend/contexts/AuthContext.tsx
+++ b/src/frontend/contexts/AuthContext.tsx
@@ -33,6 +33,7 @@ export const AuthProvider = ({children}: {children: React.ReactNode}) => {
   const [authState, setAuthState] = React.useState<AuthState>(
     passcode === null ? 'authenticated' : 'unauthenticated',
   );
+  // If E2E test mode is enabled, disable FlagSecure to allow screen recordings on BrowserStack
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';
   const shareDialogIsOpen = useIsShareDialogOpen();
 

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -121,6 +121,7 @@ export function AudioRecording({
           </HeaderText>
         </View>
       </ScreenContentWithDock>
+      {/* Remove animated background in E2E mode to avoid performance issues in Appium/BrowserStack */}
       {isE2E ? (
         <View style={{height: 0}} />
       ) : (

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -95,6 +95,7 @@ export const AuthScreen = ({
       dockContent={
         error && <Text style={styles.wrongPass}>{t(m.wrongPass)}</Text>
       }>
+      {/* Hide SVG logo in E2E mode to reduce rendering lag on BrowserStack */}
       {process.env.EXPO_PUBLIC_E2E_TEST !== 'true' && (
         <CoMapeoLogoSvg height={window.height / 3} />
       )}

--- a/src/frontend/sharedComponents/GPSPill.tsx
+++ b/src/frontend/sharedComponents/GPSPill.tsx
@@ -22,6 +22,7 @@ type GPSPillProps = {
 export const GPSPill = (props: GPSPillProps) => {
   let textValue: string | React.ReactNode;
   let IconToRender: React.FC;
+  // Replace spinner with static text in E2E mode to prevent rendering delays in tests
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';
 
   switch (props.status) {

--- a/wdio.config.js
+++ b/wdio.config.js
@@ -1,8 +1,8 @@
 // @ts-check
 const path = require('path');
-const prNumber = process.env.GITHUB_PR_NUMBER || 'Manual Run';
-const prTitle = process.env.GITHUB_PR_TITLE || 'Manual Trigger';
+const shortSha = process.env.GITHUB_SHORT_SHA || 'manual';
 const timestamp = new Date().toISOString();
+const prTitle = process.env.GITHUB_PR_TITLE;
 // Type is very questionably declared in the global namespace via @wdio/types
 /** @type {WebdriverIO.Config} */
 
@@ -18,12 +18,12 @@ const config = {
       'browserstack',
       {
         app: process.env.BROWSERSTACK_APP_URL,
-        buildIdentifier: prNumber,
+        buildIdentifier: `${process.env.BUILD_NUMBER || `build-${timestamp}`}`,
         browserstackLocal: true,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',
-          buildName: `PR #${prNumber} – ${prTitle}`,
+          buildName: `${prTitle || 'Manual Run'} (${shortSha}) at ${timestamp}`,
         },
       },
     ],
@@ -38,8 +38,8 @@ const config = {
       'appium:autoGrantPermissions': true,
       'bstack:options': {
         projectName: 'CoMapeo',
-        buildName: `PR #${prNumber} – ${prTitle}`,
-        sessionName: `Spec Run – ${timestamp}`,
+        buildName: `${prTitle || 'Manual Run'} (${shortSha}) at ${timestamp}`,
+        sessionName: `Spec Run – ${shortSha}`,
         appiumVersion: '2.12.1',
         debug: true,
         networkLogs: true,

--- a/wdio.config.js
+++ b/wdio.config.js
@@ -1,5 +1,8 @@
 // @ts-check
 const path = require('path');
+const prNumber = process.env.GITHUB_PR_NUMBER || 'Manual Run';
+const prTitle = process.env.GITHUB_PR_TITLE || 'Manual Trigger';
+const timestamp = new Date().toISOString();
 // Type is very questionably declared in the global namespace via @wdio/types
 /** @type {WebdriverIO.Config} */
 
@@ -15,12 +18,12 @@ const config = {
       'browserstack',
       {
         app: process.env.BROWSERSTACK_APP_URL,
-        buildIdentifier: `${process.env.BUILD_NUMBER || `build-${new Date().toISOString()}`}`,
+        buildIdentifier: prNumber,
         browserstackLocal: true,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',
-          buildName: `CoMapeo E2E Tests - ${new Date().toISOString()}`,
+          buildName: `PR #${prNumber} – ${prTitle}`,
         },
       },
     ],
@@ -35,8 +38,8 @@ const config = {
       'appium:autoGrantPermissions': true,
       'bstack:options': {
         projectName: 'CoMapeo',
-        buildName: 'CoMapeo Android Build',
-        sessionName: 'Pixel 7 - Android 13',
+        buildName: `PR #${prNumber} – ${prTitle}`,
+        sessionName: `Spec Run – ${timestamp}`,
         appiumVersion: '2.12.1',
         debug: true,
         networkLogs: true,

--- a/wdio.config.js
+++ b/wdio.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 const path = require('path');
 const shortSha = process.env.GITHUB_SHORT_SHA || 'manual';
-const timestamp = new Date().toISOString();
 const prTitle = process.env.GITHUB_PR_TITLE;
 // Type is very questionably declared in the global namespace via @wdio/types
 /** @type {WebdriverIO.Config} */
@@ -18,7 +17,7 @@ const config = {
       'browserstack',
       {
         app: process.env.BROWSERSTACK_APP_URL,
-        buildIdentifier: timestamp,
+        buildIdentifier: '#${DATE_TIME}',
         browserstackLocal: true,
         testObservability: true,
         testObservabilityOptions: {

--- a/wdio.config.js
+++ b/wdio.config.js
@@ -18,12 +18,12 @@ const config = {
       'browserstack',
       {
         app: process.env.BROWSERSTACK_APP_URL,
-        buildIdentifier: `${process.env.BUILD_NUMBER || `build-${timestamp}`}`,
+        buildIdentifier: timestamp,
         browserstackLocal: true,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',
-          buildName: `${prTitle || 'Manual Run'} (${shortSha}) at ${timestamp}`,
+          buildName: `${prTitle || 'Manual Run'} – ${shortSha}`,
         },
       },
     ],
@@ -38,8 +38,8 @@ const config = {
       'appium:autoGrantPermissions': true,
       'bstack:options': {
         projectName: 'CoMapeo',
-        buildName: `${prTitle || 'Manual Run'} (${shortSha}) at ${timestamp}`,
-        sessionName: `Spec Run – ${shortSha}`,
+        buildName: `${prTitle || 'Manual Run'} – ${shortSha}`,
+        sessionName: `E2E: ${shortSha}`,
         appiumVersion: '2.12.1',
         debug: true,
         networkLogs: true,


### PR DESCRIPTION
Documentation for E2E exceptions. 
Some refinements in our E2E config to make builds in Browserstack have clearly viewable links to which github run they are for.