### PR TITLE
fix: fix issue with GPS-related EXIF data not being written into photo

### DIFF
--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -2,7 +2,6 @@ import {captureException} from '@sentry/react-native';
 import React from 'react';
 import {View, StyleSheet, Text} from 'react-native';
 import {
-  CameraCapturedPicture,
   CameraPictureOptions,
   CameraView as ExpoCameraView,
   useCameraPermissions,
@@ -125,7 +124,13 @@ export const CameraView = ({onAddPress}: Props) => {
         }
 
         onAddPress({
-          capturePromise: rotatePhoto(pic, accelerometerMeasurement.current),
+          capturePromise: resizePhoto({
+            uri: pic.uri,
+            width: pic.width,
+            height: pic.height,
+            rotation: getPhotoRotation(accelerometerMeasurement.current),
+            keepMeta: !!pic.exif,
+          }),
           mediaMetadata,
         });
       })
@@ -171,22 +176,31 @@ export const CameraView = ({onAddPress}: Props) => {
   );
 };
 
-function rotatePhoto(
-  {uri, width, height}: CameraCapturedPicture,
-  acc?: AccelerometerMeasurement,
-) {
-  const resizePromise = ImageResizer.createResizedImage(
+async function resizePhoto({
+  uri,
+  width,
+  height,
+  rotation,
+  keepMeta,
+}: {
+  uri: string;
+  width: number;
+  height: number;
+  rotation?: number;
+  keepMeta?: boolean;
+}) {
+  const result = await ImageResizer.createResizedImage(
     uri,
     width,
     height,
     'JPEG',
     CAPTURE_QUALITY,
-    getPhotoRotation(acc),
-  ).then(resized => {
-    return {uri: resized.uri};
-  });
+    rotation,
+    undefined,
+    keepMeta,
+  );
 
-  return resizePromise;
+  return {uri: result.uri};
 }
 
 const ACC_AT_45_DEG = Math.sin(Math.PI / 4);

--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -88,13 +88,16 @@ export const CameraView = ({onAddPress}: Props) => {
 
     setCapturing(true);
 
-    const captureOptions = location
+    const captureOptions: CameraPictureOptions = location
       ? {
           ...BASE_CAMERA_CAPTURE_OPTIONS,
           // Apparently not all devices will encode GPS information when taking a photo
           // so we provide it manually to ensure its presence.
           // https://github.com/expo/expo/commit/dce5905664dc4559ea1935a6c946526e4c46278c
           additionalExif: locationToEXIF(location),
+          // Needs to be set to false in order for EXIF data to be written into the captured picture.
+          // See implementation here: https://github.com/expo/expo/blob/3003a1f01fb4b74a00cec6fbb1a607fa13737221/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+          skipProcessing: false,
         }
       : BASE_CAMERA_CAPTURE_OPTIONS;
 


### PR DESCRIPTION
Towards #1043

Should've caught this in #1191 but it turns out that `skipProcessing` needs to be `false` in order for the fields specified in `additionalExif` to actually be written into the photo that's created. Without this, the existing code will not actually write the relevant EXIF values into core when saving the observation.

This PR offers the bare minimum in terms of fixing the issue, although it may warrant some deeper thinking about whether it's the proper solution since it does comes with potentially user-facing consequences.

From Expo Camera's [docs](https://docs.expo.dev/versions/v52.0.0/sdk/camera/#camerapictureoptions): 

> If set to true, camera skips orientation adjustment and returns an image straight from the device's camera. If enabled, quality option is discarded (processing pipeline is skipped as a whole). Although enabling this option reduces image delivery time significantly, it may cause the image to appear in a wrong orientation in the Image component (at the time of writing, it does not respect EXIF orientation of the images).
>
> Note: Enabling skipProcessing would cause orientation uncertainty. Image component does not respect EXIF stored orientation information, that means obtained image would be displayed wrongly (rotated by 90°, 180° or 270°). Different devices provide different orientations. For example some Sony Xperia or Samsung devices don't provide correctly oriented images by default. To always obtain correctly oriented image disable skipProcessing option