### PR TITLE
fix: stops recording audio when app backgrounded

### DIFF
--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, TouchableOpacity, View} from 'react-native';
+import {StyleSheet, TouchableOpacity, View, AppState} from 'react-native';
 
 import {BLACK, MAGENTA, MEDIUM_GREY, WHITE} from '../../../lib/styles';
 import {ScreenContentWithDock} from '../../../sharedComponents/ScreenContentWithDock';
@@ -71,6 +71,18 @@ export function AudioRecording({
       finishRecording();
     }
   }, [timeElapsed, finishRecording, isRecording]);
+
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      if (nextAppState !== 'active' && isRecording) {
+        finishRecording();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isRecording, finishRecording]);
 
   return (
     <>


### PR DESCRIPTION
closes #1166 
When app is backgrounded, stops audio recording.
This prevents the app and the audio feature from recording more than 5 minutes.
This is just a stopgap...

