### PR TITLE
chore: Add debug tracing for QA & dev

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,7 +1,9 @@
 const {getSentryExpoConfig} = require('@sentry/react-native/metro');
 
 /** @type {import('expo/metro-config').MetroConfig} */
-const config = getSentryExpoConfig(__dirname);
+const config = getSentryExpoConfig(__dirname, {
+  annotateReactComponents: true,
+});
 const defaultBlockList = Array.isArray(config.resolver.blockList)
   ? config.resolver.blockList
   : [config.resolver.blockList];

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -46,13 +46,29 @@ if (applicationId?.endsWith('.dev') || applicationId?.endsWith('.pre')) {
 }
 
 const sentryDebug = applicationId?.endsWith('.dev');
+const appMetricsOptIn = sentryEnvironment !== 'production';
+let sentryIntegrations: Sentry.ReactNativeOptions['integrations'] = [];
+let navigationIntegration:
+  | ReturnType<(typeof Sentry)['reactNavigationIntegration']>
+  | undefined = undefined;
+if (appMetricsOptIn) {
+  navigationIntegration = Sentry.reactNavigationIntegration({
+    enableTimeToInitialDisplay: true,
+  });
+  sentryIntegrations = [
+    Sentry.reactNativeTracingIntegration(),
+    navigationIntegration,
+  ];
+}
 
 Sentry.init({
   dsn: 'https://e0e02907e05dc72a6da64c3483ed88a6@o4507148235702272.ingest.us.sentry.io/4507170965618688',
-  tracesSampleRate: 1.0,
+  tracesSampleRate: appMetricsOptIn ? 1.0 : 0, // Only enable tracing once we have user consent
+  enableUserInteractionTracing: appMetricsOptIn, // Only enable user interaction tracing once we have user consent
   environment: sentryEnvironment,
   debug: sentryDebug, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   initialScope: {user: {id: getSentryUserId({now: new Date(), storage})}},
+  integrations: sentryIntegrations,
 });
 
 Mapbox.setTelemetryEnabled(false);
@@ -199,7 +215,10 @@ const App = () => {
             }
             activeProjectIdStore={persistedActiveProjectIdStore}
             metricsDiagnosticsStore={persistedMetricsDiagnosticsStore}>
-            <AppNavigator permissionAsked={permissionsAsked} />
+            <AppNavigator
+              permissionAsked={permissionsAsked}
+              navigationIntegration={navigationIntegration}
+            />
           </AppProviders>
         </ServerLoading>
       </IntlProvider>

--- a/src/frontend/AppNavigator.tsx
+++ b/src/frontend/AppNavigator.tsx
@@ -7,11 +7,20 @@ import * as SplashScreen from 'expo-splash-screen';
 import {AppStackParamsList} from './sharedTypes/navigation';
 import {useSetUpInvitesListeners} from '@comapeo/core-react';
 import {RootStackNavigator} from './Navigation/Stack';
+import type Sentry from '@sentry/react-native';
 
 export const rootNavigationRef =
   createNavigationContainerRef<AppStackParamsList>();
 
-export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
+export const AppNavigator = ({
+  permissionAsked,
+  navigationIntegration,
+}: {
+  permissionAsked: boolean;
+  navigationIntegration:
+    | ReturnType<(typeof Sentry)['reactNavigationIntegration']>
+    | undefined;
+}) => {
   useSetUpInvitesListeners();
 
   if (permissionAsked) {
@@ -19,7 +28,11 @@ export const AppNavigator = ({permissionAsked}: {permissionAsked: boolean}) => {
   }
 
   return (
-    <NavigationContainer ref={rootNavigationRef}>
+    <NavigationContainer
+      ref={rootNavigationRef}
+      onReady={() => {
+        navigationIntegration?.registerNavigationContainer(rootNavigationRef);
+      }}>
       <React.Suspense fallback={null}>
         <RootStackNavigator />
       </React.Suspense>

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -105,34 +105,52 @@ export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
 
   const sm = new StateMachine({
     async start() {
-      // start browsing straight away
-      const startZeroconfPromise = startZeroconf(zeroconf);
-      const {name, port} = await mapeoApi.startLocalPeerDiscoveryServer();
-      // publishedName could be different from the name we requested, if there
-      // was a conflict on the network (the conflict could come from the same
-      // name still being registered on the network and not yet cleaned up)
-      try {
-        const publishedName = await publishZeroconf(zeroconf, {name, port});
-        publishedNames.add(publishedName);
-      } catch (e) {
-        // Publishing could fail (timeout), but we don't want to throw the
-        // state machine start(), because that would leave the state machine
-        // in an "error" state and stop other things from working. By silently
-        // failing (with the report to Sentry), we are able to try again next
-        // time.
-        Sentry.captureException(e);
-      }
-      await startZeroconfPromise;
+      Sentry.startSpan(
+        {
+          name: 'startLocalDiscovery',
+          op: 'network.dns-sd',
+        },
+        async span => {
+          // start browsing straight away
+          const startZeroconfPromise = startZeroconf(zeroconf);
+          const {name, port} = await mapeoApi.startLocalPeerDiscoveryServer();
+          span.setAttribute('name', name);
+          // publishedName could be different from the name we requested, if there
+          // was a conflict on the network (the conflict could come from the same
+          // name still being registered on the network and not yet cleaned up)
+          try {
+            const publishedName = await publishZeroconf(zeroconf, {name, port});
+            publishedNames.add(publishedName);
+            span.setAttribute('publishedName', publishedName);
+          } catch (e) {
+            // Publishing could fail (timeout), but we don't want to throw the
+            // state machine start(), because that would leave the state machine
+            // in an "error" state and stop other things from working. By silently
+            // failing (with the report to Sentry), we are able to try again next
+            // time.
+            Sentry.captureException(e);
+          }
+          await startZeroconfPromise;
+        },
+      );
     },
     async stop() {
-      await Promise.all([
-        mapeoApi.stopLocalPeerDiscoveryServer(),
-        stopZeroconf(zeroconf),
-        unpublishZeroconf(zeroconf, publishedNames).catch(e => {
-          // See above for why we silently fail here
-          Sentry.captureException(e);
-        }),
-      ]);
+      Sentry.startSpan(
+        {
+          name: 'stopLocalDiscovery',
+          op: 'network.dns-sd',
+        },
+        async () => {
+          await Promise.all([
+            mapeoApi.stopLocalPeerDiscoveryServer(),
+            stopZeroconf(zeroconf),
+            unpublishZeroconf(zeroconf, publishedNames).catch(e => {
+              // See above for why we silently fail here
+              Sentry.captureException(e);
+            }),
+          ]);
+        },
+      );
     },
   });
   sm.on('state', smState => {
@@ -158,7 +176,26 @@ export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
       onAppState,
     );
     const onZeroconfResolved = (service: ZeroconfService) => {
+      Sentry.addBreadcrumb({
+        message: 'Zeroconf service resolved',
+        type: 'network',
+        data: {
+          serviceName: service.name,
+          serviceFullName: service.fullName,
+          serviceHost: service.host,
+          serviceAddresses: service.addresses,
+          servicePort: service.port,
+          serviceTxt: service.txt,
+        },
+      });
       const peer = zeroconfServiceToMapeoPeer(service);
+      if (!peer) {
+        Sentry.captureMessage(
+          'Zeroconf service resolved, but no peer found',
+          'warning',
+        );
+        return;
+      }
       if (peer) mapeoApi.connectLocalPeer(peer);
     };
     zeroconf.on('resolved', onZeroconfResolved);
@@ -300,104 +337,132 @@ export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
 }
 
 function startZeroconf(zeroconf: Zeroconf): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      zeroconf.off('start', onStart);
-      zeroconf.off('error', onError);
-    };
-    const onStart = () => {
-      cleanup();
-      resolve();
-    };
-    const onError = (err: Error) => {
-      cleanup();
-      reject(err);
-    };
-    zeroconf.on('start', onStart);
-    zeroconf.on('error', onError);
+  return Sentry.startSpan(
+    {name: 'startBrowsingZeroconf', op: 'network.dns-sd'},
+    () =>
+      new Promise((resolve, reject) => {
+        const cleanup = () => {
+          zeroconf.off('start', onStart);
+          zeroconf.off('error', onError);
+        };
+        const onStart = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: Error) => {
+          cleanup();
+          reject(err);
+        };
+        zeroconf.on('start', onStart);
+        zeroconf.on('error', onError);
 
-    zeroconf.scan(ZEROCONF_SERVICE_TYPE, ZEROCONF_PROTOCOL, ZEROCONF_DOMAIN);
-  });
+        zeroconf.scan(
+          ZEROCONF_SERVICE_TYPE,
+          ZEROCONF_PROTOCOL,
+          ZEROCONF_DOMAIN,
+        );
+      }),
+  );
 }
 
 function publishZeroconf(
   zeroconf: Zeroconf,
   {name, port}: {name: string; port: number},
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      cleanup();
-      reject(new Error('Timed out publishing zeroconf service'));
-    }, ZEROCONF_PUBLISH_TIMEOUT_MS);
+  return Sentry.startSpan(
+    {name: 'publishZeroconf', op: 'network.dns-sd'},
+    () =>
+      new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          cleanup();
+          reject(new Error('Timed out publishing zeroconf service'));
+        }, ZEROCONF_PUBLISH_TIMEOUT_MS);
 
-    const cleanup = () => {
-      clearTimeout(timeoutId);
-      zeroconf.off('published', onPublish);
-    };
-    const onPublish = ({name: publishedName}: ZeroconfService) => {
-      cleanup();
-      resolve(publishedName);
-    };
+        const cleanup = () => {
+          clearTimeout(timeoutId);
+          zeroconf.off('published', onPublish);
+        };
+        const onPublish = ({name: publishedName}: ZeroconfService) => {
+          cleanup();
+          resolve(publishedName);
+        };
 
-    zeroconf.on('published', onPublish);
-    zeroconf.publishService(
-      ZEROCONF_SERVICE_TYPE,
-      ZEROCONF_PROTOCOL,
-      ZEROCONF_DOMAIN,
-      name,
-      port,
-    );
-  });
+        zeroconf.on('published', onPublish);
+        zeroconf.publishService(
+          ZEROCONF_SERVICE_TYPE,
+          ZEROCONF_PROTOCOL,
+          ZEROCONF_DOMAIN,
+          name,
+          port,
+        );
+      }),
+  );
 }
 
 function stopZeroconf(zeroconf: Zeroconf): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      zeroconf.off('stop', onStop);
-      zeroconf.off('error', onError);
-    };
-    const onStop = () => {
-      cleanup();
-      resolve();
-    };
-    const onError = (err: Error) => {
-      cleanup();
-      reject(err);
-    };
-    zeroconf.on('stop', onStop);
-    zeroconf.on('error', onError);
+  return Sentry.startSpan(
+    {name: 'stopBrowsingZeroconf', op: 'network.dns-sd'},
+    () =>
+      new Promise((resolve, reject) => {
+        const cleanup = () => {
+          zeroconf.off('stop', onStop);
+          zeroconf.off('error', onError);
+        };
+        const onStop = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: Error) => {
+          cleanup();
+          reject(err);
+        };
+        zeroconf.on('stop', onStop);
+        zeroconf.on('error', onError);
 
-    zeroconf.stop();
-  });
+        zeroconf.stop();
+      }),
+  );
 }
 
 function unpublishZeroconf(
   zeroconf: Zeroconf,
   publishedNamesToBeMutated: Set<string>,
 ): Promise<void> {
-  if (publishedNamesToBeMutated.size === 0) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      cleanup();
-      reject(new Error('Timed out unpublishing zeroconf service'));
-    }, ZEROCONF_UNPUBLISH_TIMEOUT_MS);
+  return Sentry.startSpan(
+    {
+      name: 'unpublishZeroconf',
+      op: 'network.dns-sd',
+    },
+    span => {
+      span.setAttribute(
+        'publishedNames',
+        Array.from(publishedNamesToBeMutated),
+      );
+      if (publishedNamesToBeMutated.size === 0) return Promise.resolve();
+      return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          cleanup();
+          reject(new Error('Timed out unpublishing zeroconf service'));
+        }, ZEROCONF_UNPUBLISH_TIMEOUT_MS);
 
-    const cleanup = () => {
-      clearTimeout(timeoutId);
-      zeroconf.off('remove', onRemove);
-    };
-    const onRemove = (name: string) => {
-      publishedNamesToBeMutated.delete(name);
-      if (publishedNamesToBeMutated.size === 0) {
-        cleanup();
-        resolve();
-      }
-    };
-    zeroconf.on('remove', onRemove);
-    for (const name of publishedNamesToBeMutated) {
-      zeroconf.unpublishService(name);
-    }
-  });
+        const cleanup = () => {
+          clearTimeout(timeoutId);
+          zeroconf.off('remove', onRemove);
+        };
+        const onRemove = (name: string) => {
+          publishedNamesToBeMutated.delete(name);
+          if (publishedNamesToBeMutated.size === 0) {
+            cleanup();
+            resolve();
+          }
+        };
+        zeroconf.on('remove', onRemove);
+        for (const name of publishedNamesToBeMutated) {
+          zeroconf.unpublishService(name);
+        }
+      });
+    },
+  );
 }
 
 function zeroconfServiceToMapeoPeer({

--- a/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/YourTeam/SelectDevice.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 import {ScrollView, StyleSheet, View} from 'react-native';
+import * as Sentry from '@sentry/react-native';
 
 import {useManyMembers} from '@comapeo/core-react';
 import {useLocalDiscoveryState} from '../../../../hooks/useLocalDiscoveryState';
@@ -77,6 +78,27 @@ function InvitableDevicesList() {
 
     return false;
   });
+
+  React.useEffect(() => {
+    const span = Sentry.startInactiveSpan({
+      name: 'invitable devices list',
+      op: 'mapeo.invitableDevices',
+    });
+    span.setAttributes({
+      devices: devices.map(d => JSON.stringify(d)),
+      projectMembers: projectMembersQuery.data.map(m =>
+        JSON.stringify({
+          deviceId: m.deviceId,
+          role: m.role.name,
+          name: m.name,
+          joinedAt: m.joinedAt,
+        }),
+      ),
+      invitableDevices: invitableDevices.map(d => JSON.stringify(d)),
+    });
+
+    span.end();
+  }, [devices, projectMembersQuery.data, invitableDevices]);
 
   return (
     <View style={styles.deviceListContainer}>


### PR DESCRIPTION
Adds Sentry spans to trace and debug issues with local discovery and showing invitable devices.

I'm not sure it makes sense to merge this, but building a QA APK from this commit will give us some more insight into issues with device discovery issues.