### PR TITLE
fix: passcode and audio permission

### DIFF
--- a/src/frontend/contexts/AuthContext.tsx
+++ b/src/frontend/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ const {FlagSecureModule} = NativeModules;
 import {useIsShareDialogOpen} from '../hooks/share';
 import {DEFAULT_OBSCURE_CODE} from '../lib/security';
 import {useSecurityState} from './SecurityStoreContext';
+import {useIsAudioPermissionModalOpen} from '../hooks/useAudioPermissionTracker';
 
 type AuthState = 'unauthenticated' | 'authenticated' | 'obscured';
 
@@ -36,6 +37,7 @@ export const AuthProvider = ({children}: {children: React.ReactNode}) => {
   // If E2E test mode is enabled, disable FlagSecure to allow screen recordings on BrowserStack
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';
   const shareDialogIsOpen = useIsShareDialogOpen();
+  const isAudioPermissionModalOpen = useIsAudioPermissionModalOpen();
 
   React.useEffect(() => {
     if (passcode !== null && !isE2E) {
@@ -49,8 +51,8 @@ export const AuthProvider = ({children}: {children: React.ReactNode}) => {
     const appStateListener = AppState.addEventListener(
       'change',
       (nextAppState: AppStateStatus) => {
-        // If the app state changes due to opening a share dialog, do not unauthenticate
-        if (shareDialogIsOpen) return;
+        // If the app state changes due to opening a share dialog or the in app Audio Permissions, do not unauthenticate
+        if (shareDialogIsOpen || isAudioPermissionModalOpen) return;
 
         if (passcode !== null) {
           if (
@@ -65,7 +67,7 @@ export const AuthProvider = ({children}: {children: React.ReactNode}) => {
     );
 
     return () => appStateListener.remove();
-  }, [passcode, shareDialogIsOpen]);
+  }, [passcode, shareDialogIsOpen, isAudioPermissionModalOpen]);
 
   const authenticate: AuthContextType['authenticate'] = React.useCallback(
     (passcodeValue, validateOnly = false) => {

--- a/src/frontend/hooks/useAudioPermissionTracker.ts
+++ b/src/frontend/hooks/useAudioPermissionTracker.ts
@@ -1,0 +1,20 @@
+import {useMutation, useIsMutating} from '@tanstack/react-query';
+
+const AUDIO_PERMISSION_MODAL_KEY = ['audio', 'permission', 'modal'] as const;
+
+export function useAudioPermissionModalMutation<T>(fn: () => Promise<T>) {
+  return useMutation({
+    mutationKey: AUDIO_PERMISSION_MODAL_KEY,
+    mutationFn: fn,
+    networkMode: 'always',
+  });
+}
+
+export function useIsAudioPermissionModalOpen(): boolean {
+  return (
+    useIsMutating({
+      mutationKey: AUDIO_PERMISSION_MODAL_KEY,
+      status: 'pending',
+    }) > 0
+  );
+}

--- a/src/frontend/screens/Audio/AudioAskPermissionBottomSheet.tsx
+++ b/src/frontend/screens/Audio/AudioAskPermissionBottomSheet.tsx
@@ -66,14 +66,20 @@ export const AudioAskPermissionBottomSheet = ({
     });
   }, [replace]);
 
+  // We need *both* the AppState listener and the useFocusEffect because passcode being active shifts the timing.
+  //
+  // In the no-passcode flow, the app becomes "active" *after* returning from settings —
+  // so the AppState change is enough to detect permission changes.
+  //
+  // But in the passcode flow, the app becomes "active" *before* the user finishes authenticating.
+  // So we use useFocusEffect to re-check permissions after the user actually lands back on this screen.
+  //
+  // Without both, we’d miss the permission change in one of the two flows.
+
   // Covers re-entering from Auth screen (passcode is active flow)
   useFocusEffect(
     React.useCallback(() => {
-      if (
-        passcode &&
-        !hasNavigatedRef.current &&
-        permission.status !== 'granted'
-      ) {
+      if (passcode && permission.status !== 'granted') {
         checkAndNavigateIfGranted();
       }
     }, [checkAndNavigateIfGranted, permission.status, passcode]),

--- a/src/frontend/screens/Audio/AudioAskPermissionBottomSheet.tsx
+++ b/src/frontend/screens/Audio/AudioAskPermissionBottomSheet.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import {BottomSheetWrapper} from '../../sharedComponents/BottomSheetWrapper';
-import {
-  AppState,
-  AppStateStatus,
-  Linking,
-  StyleSheet,
-  View,
-} from 'react-native';
+import {Linking, StyleSheet, View} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import AudioPermission from '../../images/observationEdit/AudioPermission.svg';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
@@ -15,6 +9,7 @@ import {Audio} from 'expo-av';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {useFocusEffect} from '@react-navigation/native';
 import {PrimaryButton, SecondaryButton} from '../../sharedComponents/Buttons';
+import {useAudioPermissionModalMutation} from '../../hooks/useAudioPermissionTracker';
 
 const m = defineMessages({
   title: {
@@ -55,44 +50,38 @@ export const AudioAskPermissionBottomSheet = ({
   const [permission, setPermission] = React.useState<Audio.PermissionResponse>(
     route.params.audioPermission,
   );
+  const hasNavigatedRef = React.useRef(false);
 
-  // When the user changes their permission in phone settings and returns to the app,
-  // we need to check for updates and navigate accordingly.
-  // Without this, the app won't detect the permission change.
+  // Re-check microphone permission on focus in case it was granted via system settings,
+  // and navigate to AudioRecording if so.
   useFocusEffect(
     React.useCallback(() => {
-      let isCancelled = false;
-      const handleAppStateChange = async (nextAppState: AppStateStatus) => {
-        if (nextAppState === 'active') {
-          const newPermission = await Audio.getPermissionsAsync();
-          if (isCancelled) return;
-          setPermission(newPermission);
-          if (newPermission.status === 'granted') {
-            replace('AudioRecording');
-          }
+      const checkAndNavigate = async () => {
+        const newPermission = await Audio.getPermissionsAsync();
+        setPermission(newPermission);
+
+        if (newPermission.status === 'granted' && !hasNavigatedRef.current) {
+          hasNavigatedRef.current = true;
+          replace('AudioRecording');
         }
       };
 
-      const subscription = AppState.addEventListener(
-        'change',
-        handleAppStateChange,
-      );
-
-      return () => {
-        isCancelled = true;
-        subscription.remove();
-      };
+      checkAndNavigate();
     }, [replace]),
   );
 
-  async function askPermission() {
+  const askPermissionMutation = useAudioPermissionModalMutation(async () => {
     const response = await Audio.requestPermissionsAsync();
     setPermission(response);
     if (response.granted) {
       replace('AudioRecording');
       return;
     }
-  }
+  });
+
+  const goToSettingsMutation = useAudioPermissionModalMutation(() =>
+    Linking.openSettings(),
+  );
 
   return (
     <BottomSheetWrapper>
@@ -119,13 +108,13 @@ export const AudioAskPermissionBottomSheet = ({
             <PrimaryButton
               fullSize
               text={formatMessage(m.allowButtonText)}
-              onPress={askPermission}
+              onPress={() => askPermissionMutation.mutateAsync()}
             />
           ) : (
             <PrimaryButton
               fullSize
               text={formatMessage(m.goToSettingsButtonText)}
-              onPress={() => Linking.openSettings()}
+              onPress={() => goToSettingsMutation.mutateAsync()}
             />
           )}
         </View>

--- a/src/frontend/screens/Audio/AudioAskPermissionBottomSheet.tsx
+++ b/src/frontend/screens/Audio/AudioAskPermissionBottomSheet.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {BottomSheetWrapper} from '../../sharedComponents/BottomSheetWrapper';
-import {Linking, StyleSheet, View} from 'react-native';
+import {AppState, Linking, StyleSheet, View} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import AudioPermission from '../../images/observationEdit/AudioPermission.svg';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
@@ -10,6 +10,7 @@ import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {useFocusEffect} from '@react-navigation/native';
 import {PrimaryButton, SecondaryButton} from '../../sharedComponents/Buttons';
 import {useAudioPermissionModalMutation} from '../../hooks/useAudioPermissionTracker';
+import {useSecurityState} from '../../contexts/SecurityStoreContext';
 
 const m = defineMessages({
   title: {
@@ -51,24 +52,40 @@ export const AudioAskPermissionBottomSheet = ({
     route.params.audioPermission,
   );
   const hasNavigatedRef = React.useRef(false);
+  const {passcode} = useSecurityState();
 
-  // Re-check microphone permission on focus in case it was granted via system settings,
+  // Re-check microphone permission in case it was granted via system settings,
   // and navigate to AudioRecording if so.
+  const checkAndNavigateIfGranted = React.useCallback(() => {
+    Audio.getPermissionsAsync().then(newPermission => {
+      setPermission(newPermission);
+      if (newPermission.status === 'granted' && !hasNavigatedRef.current) {
+        hasNavigatedRef.current = true;
+        replace('AudioRecording');
+      }
+    });
+  }, [replace]);
+
+  // Covers re-entering from Auth screen (passcode is active flow)
   useFocusEffect(
     React.useCallback(() => {
-      const checkAndNavigate = async () => {
-        const newPermission = await Audio.getPermissionsAsync();
-        setPermission(newPermission);
-
-        if (newPermission.status === 'granted' && !hasNavigatedRef.current) {
-          hasNavigatedRef.current = true;
-          replace('AudioRecording');
-        }
-      };
-
-      checkAndNavigate();
-    }, [replace]),
+      if (
+        passcode &&
+        !hasNavigatedRef.current &&
+        permission.status !== 'granted'
+      ) {
+        checkAndNavigateIfGranted();
+      }
+    }, [checkAndNavigateIfGranted, permission.status, passcode]),
   );
+
+  // Covers non-passcode flow from system settings
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener('change', state => {
+      if (!passcode && state === 'active') checkAndNavigateIfGranted();
+    });
+    return () => subscription.remove();
+  }, [checkAndNavigateIfGranted, passcode]);
 
   const askPermissionMutation = useAudioPermissionModalMutation(async () => {
     const response = await Audio.requestPermissionsAsync();


### PR DESCRIPTION
closes #1226

This PR fixes an edge case in the audio permission flow: When using permissions with audio, the passcode would pop up and when authenticated would navigate back, which always brought the user back to the permissions modal and then they would be stuck in a loop.

To fix this, I created a small hook (inspired by the one we use for sharing) that tracks when a modal is open and prevents triggering the auth screen while doing in-app permission checks. That means if the user taps "Allow" in-app — which doesn’t technically leave the app — they’re no longer forced to re-enter their passcode. And if they do go to settings to enable mic access, they’ll now only be prompted for their passcode after returning, instead of before leaving, which used to happen.

In addition, I added a useFocusEffect in the AudioAskPermissionBottomSheet that only runs when passcode is enabled. This is because in the passcode flow, the app technically becomes "active" before the user completes authentication. Without this, we’d miss the permission change that happened in settings and never navigate forward.

I'm also using a hasNavigatedRef to make sure we don’t double-navigate, since the screen can become active in multiple ways (settings return, passcode unlock, etc). This makes the logic more predictable and hopefully avoids flickering or race conditions.

There are four situations that should be tested...
1. With no passcode enabled:
 - Hit microphone
 - Hit Allow
 -  Hit While Using the App
You should be taken right to the recording screen
2. With no passcode enabled:
- Hit microphone
 - Hit Allow
 - Don't Allow
 - Hit Go to Settings
 - Enable microphone permissions
 - Hit the back button to return to the app
 You should be taken right to the recording screen
 (If you don't enable permissions the modal will still be open)
 
 3. With passcode enabled
- Hit microphone
 - Hit Allow
 -  Hit While Using the App
You should be taken right to the recording screen and never have to enter your passcode
4.  With passcode enabled:
 - Hit microphone
 - Hit Allow
 - Don't Allow
 - Hit Go to Settings
 - Enable microphone permissions
 - Hit the back button to return to the app
 - You should then have to enter your passcode
 Now you should be taken right to the recording screen
