### PR TITLE
fix: participant not seeing remote archive

### DIFF
--- a/src/frontend/screens/Settings/ProjectSettings/index.tsx
+++ b/src/frontend/screens/Settings/ProjectSettings/index.tsx
@@ -92,6 +92,8 @@ export const ProjectSettings = () => {
   const isSolo = projectInfo.role === 'solo';
   const isCoordinator = projectInfo.role === 'coordinator';
   const remoteArchiveOn = !!useActiveArchiveServer({projectId});
+  const participantWithRemote =
+    projectInfo.role === 'participant' && remoteArchiveOn;
 
   const displayTitle = isSolo
     ? projectInfo.projectHeader
@@ -135,7 +137,7 @@ export const ProjectSettings = () => {
           onPress={() => navigate('YourTeam')}
         />
       )}
-      {isCoordinator && (
+      {(isCoordinator || participantWithRemote) && (
         <SettingsCardRow
           icon={<ExchangeIcon width={24} height={24} />}
           title={formatMessage(


### PR DESCRIPTION
closes #1243 
Here is the issue as reported in Notion: https://www.notion.so/digidem/Remote-Archive-ACTIVE-Participant-doesnt-see-it-2161b08162d58019843ffa3a8c24934c
Here is the fix:
Shows the remote archive **on** for participants in the project menu.
If (and only if) the remote archive is activated and on, we show a menu card for it in the project menu.
The participant can click on it, but does not have the option to remove it.
<image src="https://github.com/user-attachments/assets/16ca12a2-a937-4876-a8c9-53a9df332bb2" width="250" />
<image src="https://github.com/user-attachments/assets/119c7f8f-997c-450b-9e13-5d8055db5f50" width="250" />

