### PR TITLE
test: speed up Jest tests by transforming fewer files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,49 @@
 // @ts-check
 
+const NODE_MODULE_PATTERNS_TO_TRANSFORM = [
+  // React Native
+  '(?:jest-)?react-native',
+  '@react-native',
+  '@?expo',
+  '@?react-navigation',
+  '@sentry/react-native',
+  'native-base',
+  '@rnmapbox/maps',
+  '@gorhom/bottom-sheet',
+  // Awana modules distributed as ESM
+  '@comapeo/',
+  '@mapeo/',
+  // Helper modules distributed as ESM
+  '@sindresorhus/merge-streams',
+  'bcp-47',
+  'cheap-ruler',
+  'compress-commons',
+  'crc32-stream',
+  'dot-prop',
+  'ensure-error',
+  'filter-obj',
+  'into-stream',
+  'is-alphabetical',
+  'is-alphanumerical',
+  'is-decimal',
+  'is-stream',
+  'ky',
+  'map-obj',
+  'mbtiles-reader',
+  'mime',
+  'nanoid',
+  'p-defer',
+  'p-event',
+  'p-limit',
+  'p-timeout',
+  'string-timing-safe-equal',
+  'styled-map-package',
+  'uint8array-extras',
+  'yocto-queue',
+  'zip-stream-promise',
+  'zip-stream',
+];
+
 /** @type {import('jest').Config} */
 const config = {
   preset: 'jest-expo',
@@ -15,7 +59,8 @@ const config = {
     ],
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(...|@rnmapbox|(jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)',
+    `/node_modules/(?!${NODE_MODULE_PATTERNS_TO_TRANSFORM.join('|')})`,
+    '/node_modules/react-native-reanimated/plugin/',
   ],
   moduleNameMapper: {
     '\\.svg$': '<rootDir>/src/frontend/__mocks__/svg.tsx',


### PR DESCRIPTION
_tl;dr: Babel transpilation is slow. This removes a bunch of that for a ~2x speedup, but with some disadvantages._

Our Jest tests can be pretty slow. After some profiling[^a], ~80% of the time is spent transforming files with Babel. So how can we speed up this transformation?

We can't remove transformations entirely. We need transformations for:

- TypeScript and Flow compilation (the latter is used in React Native)
- Jest module mocking
- Turning ES Modules (`import` and `export`) into CommonJS (`require` and `module.exports`), because Jest lacks full support for ESM
- probably other things

Jest's default transformer, `babel-jest`, seems to be the best way to do this. Though we could get better performance with something like esbuild or SWC[^b], those tools can't do Jest module mocking. And I don't think we can get around using `babel-jest` entirely, so we'd have to create a custom transformer[^c].

Before this change, though it *looked* like we were being selective, we're actually transforming almost every file. We effectively had some code like this (simplified slightly):

```javascript
// ...
transform: {
  '\\.[jt]sx?$': 'babel-jest',
},
transformIgnorePatterns: [
  'node_modules/(?!(...|react-native|some-others))',
],
// ...
```

See the error? We're ignoring transformation for all Node modules except for those that start with *any three characters*...which is nearly all of them, save a couple of two-letter modules like `ms`.  That means that we were running Babel on way more files than necessary.[^d]

I fixed this by only transforming the modules we actually want to transform. Unfortunately, there were a bunch of them, and it was a simple game of whack-a-mole to find them all.

This has the advantage of speeding up tests by about 2x on my machine.  It has the disadvantage that a new/changed module could yield a somewhat-confusing Jest error, but it *does* mention looking at `transformIgnorePatterns` so it's not the worst. Another con: we have a big list of modules in our Jest config.

[^a]: The simplest "profiling": clear the Jest cache, run the tests, then run them again. They're much faster! You can also see this by [proxying our calls to `babel-jest` and recording durations][0]; in my testing, ~80% of test time was spent transforming with Babel.

[^b]: Both of which I tried...

[^c]: Which I also tried...

[^d]: This was introduced in ecc62135945d87c44f4f38ec8e0ca962e24b726e and is likely because [`@rnmapbox/maps` documents a code snippet][1] that is misleading.

[0]: https://gist.github.com/EvanHahn/ac7e66460af36478235e0de17e01245c
[1]: https://github.com/rnmapbox/maps/tree/003570ff9ce3ffd6daab45c1811c5f81488122b6?tab=readme-ov-file#testing-with-jest
