### PR TITLE
fix: data export file name

### DIFF
--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -118,7 +118,7 @@ export function useExportObservationsAndShare({
         exportOptions: {
           lang,
           observations: true,
-          tracks: true,
+          tracks: false,
           attachments: true,
         },
       });


### PR DESCRIPTION
towards #1245 
When exporting observations with media, the export options include tracks and that is hard coded to true.
Thus, when the file is returned, the type includes the word tracks, as it is being sent to the useExportZipFile no matter what.
I am not sure why that was done.
Instead, I have set the tracks boolean to false, as the type is for Observations and not tracks with Media.
It looks like the folder for media is supposed to just be about Observations based on the [original ticket](https://github.com/digidem/comapeo-mobile/issues/1122)

>  Folder name with media : CoMapeo_[Project Name]_Obsvns_YYYY-MM-DD_Media

I can correct that on the front end. However, I cannot correct where the word Media goes (currently it is like this: **CoMapeo_New project_Media_Mon Jun 23...** and it is supposed to look like the above with Media at the end.
Also, I cannot control how the date is formatted. It looks like it is not being formatted according to the Specs. That just comes in from the back end. It looks like this, 
CoMapeo_New project_Obsvns_Mon Jun 23 2025.zip instead of as YYYY-MM-DD

I am not sure what exactly was expected and so not sure if that Boolean was true for a reason, but it appears to be making the file naming come through incorrectly.