### PR TITLE
fix: app crash during tracks

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -35,6 +35,7 @@ import {getAppLanguageTag} from './lib/intl';
 import {IntlProvider} from './contexts/IntlContext';
 import {ServerLoading} from './ServerLoading';
 import type {StatusMessage} from '../backend/src/status';
+import type {EventEmitter} from 'events';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
@@ -162,10 +163,18 @@ const requestServerStatus = () => {
 const subscribeToServerStatus = (listener: (msg: StatusMessage) => unknown) => {
   nodejs.channel.addListener('server:status', listener);
   return () => {
-    nodejs.channel.removeListener('server:status', listener);
+    // ERROR    Warning: TypeError: channel.removeListener is not a function (it is undefined)
+    //     This error is located at:
+    //        in ServerLoading (created by App)
+    //        in IntlProvider (created by IntlProvider)
+    //        in IntlProvider (created by App)
+    //        in App (created by RootApp)
+    const channel = nodejs.channel as unknown as EventEmitter;
+    if (channel?.removeListener instanceof Function) {
+      channel.removeListener('server:status', listener);
+    }
   };
 };
-
 const App = () => {
   const [permissionsAsked, setPermissionsAsked] = React.useState(false);
   React.useEffect(() => {

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -35,7 +35,6 @@ import {getAppLanguageTag} from './lib/intl';
 import {IntlProvider} from './contexts/IntlContext';
 import {ServerLoading} from './ServerLoading';
 import type {StatusMessage} from '../backend/src/status';
-import type {EventEmitter} from 'events';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
@@ -169,8 +168,8 @@ const subscribeToServerStatus = (listener: (msg: StatusMessage) => unknown) => {
     //        in IntlProvider (created by IntlProvider)
     //        in IntlProvider (created by App)
     //        in App (created by RootApp)
-    const channel = nodejs.channel as unknown as EventEmitter;
-    if (channel?.removeListener instanceof Function) {
+    const channel = nodejs.channel;
+    if (channel?.removeListener) {
       channel.removeListener('server:status', listener);
     }
   };


### PR DESCRIPTION
closes #1233 
Prevents app crash caused by new functions in App.tsx
Here is the error:
 ERROR  Warning: TypeError: channel.removeListener is not a function (it is undefined)

This error is located at:
    in ServerLoading (created by App)
    in IntlProvider (created by IntlProvider)
    in IntlProvider (created by App)
    in App (created by RootApp)
    in FeedbackWidgetProvider (created by RootApp)
    in ReactNativeProfiler (created by RootApp)
    in RCTView (created by View)
    in View (created by __Sentry.TouchEventBoundary)
    in __Sentry.TouchEventBoundary (created by RootApp)
    in RootApp (created by withDevTools(RootApp))
    in withDevTools(RootApp)
    in RCTView (created by View)
    in View (created by AppContainer)
    in RCTView (created by View)
    in View (created by AppContainer)
    in AppContainer
    in main(RootComponent), js engine: hermes

I also checked for it on Sentry in the rc build just to be sure. Here it is there:
https://awana-digital.sentry.io/issues/6673926544/?environment=qa&query=&referrer=issue-stream&stream_index=0

Prevents error on undefined channel on app relaunch.

This is actually something Andrew was worried about as he was reviewing the PR that added this code:
https://github.com/digidem/comapeo-mobile/pull/1175

My change only runs the remove listener if it is defined. This is a temporary solution imo.
I don't think this is a long term, good solution to the problem, but finding one is a little out of my depth.

