### PR TITLE
test: add test ID to SVG mocks

### DIFF
--- a/src/frontend/__mocks__/svg.tsx
+++ b/src/frontend/__mocks__/svg.tsx
@@ -1,3 +1,5 @@
 import {View} from 'react-native';
 
-export default () => <View />;
+export default ({testID}: Readonly<{testID?: string}>) => (
+  <View testID={testID} />
+);


### PR DESCRIPTION
*This change should have no impact today.*

We mock SVGs in our Jest tests, but don't pass them the `testID` prop.  This isn't causing problems now, but could in the future if we ever target an SVG by test ID. This fixes that.
