### PR TITLE
fix: properly removes node js channel subscription

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -163,10 +163,9 @@ const requestServerStatus = () => {
 };
 
 const subscribeToServerStatus = (listener: (msg: StatusMessage) => unknown) => {
-  nodejs.channel.addListener('server:status', listener);
-  return () => {
-    nodejs.channel.removeListener('server:status', listener);
-  };
+  const subscription = nodejs.channel.addListener('server:status', listener);
+  // @ts-expect-error - incorrect types on nodejs.channel
+  return () => subscription.remove();
 };
 
 const App = () => {


### PR DESCRIPTION
closes #1233 
and closes #1250

Nodejs mobile has improper types. Previously we were removing the subscription be overwriting the ts via `ts-expect-error`. Evan had removed it as he thought we could just close the channel directly (which has a typing) - and this was causing the app to crash. This Pr re-introduces the old architecture.