### PR TITLE
fix: shows preset color ring

### DIFF
--- a/src/frontend/screens/Observation/PresetHeader.tsx
+++ b/src/frontend/screens/Observation/PresetHeader.tsx
@@ -19,6 +19,7 @@ export const PresetHeader = ({
         size="medium"
         iconId={preset?.iconRef?.docId}
         testID={`OBS.${preset?.name}-view-icon`}
+        color={preset?.color}
       />
       <HeaderText
         variant="header3"

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -338,6 +338,7 @@ export const ObservationCreate = ({
           size="medium"
           iconId={preset?.iconRef?.docId}
           testID={`OBS.${preset?.name}-icon`}
+          color={preset?.color}
         />
       }
       onPressPreset={() => navigation.navigate('PresetChooser')}

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -246,6 +246,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
           size="medium"
           iconId={preset?.iconRef?.docId}
           testID={`OBS.${preset?.name}-icon`}
+          color={preset?.color}
         />
       }
       onPressPreset={() => navigation.navigate('PresetChooser')}

--- a/src/frontend/screens/ObservationsList/ObservationListItem.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationListItem.tsx
@@ -87,7 +87,11 @@ function ObservationListItemInner({
         <View style={styles.photoContainer}>
           <PhotoStack photos={photos} />
           <View style={styles.smallIconContainer}>
-            <PresetCircleIcon iconId={preset?.iconRef?.docId} size="small" />
+            <PresetCircleIcon
+              iconId={preset?.iconRef?.docId}
+              size="small"
+              color={preset?.color}
+            />
           </View>
         </View>
       ) : (
@@ -95,6 +99,7 @@ function ObservationListItemInner({
           iconId={preset?.iconRef?.docId}
           size="medium"
           testID={`OBS.${preset?.name}-list-icon`}
+          color={preset?.color}
         />
       )}
     </View>

--- a/src/frontend/screens/PresetChooser.tsx
+++ b/src/frontend/screens/PresetChooser.tsx
@@ -125,7 +125,11 @@ const Item = React.memo(
       activeOpacity={1}
       underlayColor="#000033">
       <View style={styles.cellContainer}>
-        <PresetCircleIcon iconId={item.iconRef?.docId} size="medium" />
+        <PresetCircleIcon
+          iconId={item.iconRef?.docId}
+          size="medium"
+          color={item.color}
+        />
         <Text numberOfLines={3} style={styles.categoryName}>
           <DynFormattedMessage
             id={`presets.${item.docId}.name`}

--- a/src/frontend/sharedComponents/icons/Circle.tsx
+++ b/src/frontend/sharedComponents/icons/Circle.tsx
@@ -6,7 +6,7 @@ import {ViewStyleProp} from '../../sharedTypes';
 
 const BORDER_DEFAULTS = {
   color: '#EAEAEA',
-  width: 1,
+  width: 3,
 } as const;
 
 export const Circle = ({

--- a/src/frontend/sharedComponents/icons/Circle.tsx
+++ b/src/frontend/sharedComponents/icons/Circle.tsx
@@ -6,7 +6,7 @@ import {ViewStyleProp} from '../../sharedTypes';
 
 const BORDER_DEFAULTS = {
   color: '#EAEAEA',
-  width: 3,
+  width: 1,
 } as const;
 
 export const Circle = ({

--- a/src/frontend/sharedComponents/icons/PresetIcon.tsx
+++ b/src/frontend/sharedComponents/icons/PresetIcon.tsx
@@ -9,6 +9,7 @@ interface PresetIconProps {
   iconId?: string;
   size: IconSize;
   testID?: string;
+  color?: string;
 }
 
 const iconSizes = {
@@ -58,9 +59,14 @@ const PresetIcon = ({iconId, size, testID}: PresetIconProps) => {
   return <LoadedPresetIcon iconId={iconId} size={size} testID={testID} />;
 };
 
-export const PresetCircleIcon = ({iconId, size, testID}: PresetIconProps) => {
+export const PresetCircleIcon = ({
+  iconId,
+  size,
+  testID,
+  color,
+}: PresetIconProps) => {
   return (
-    <Circle radius={radii[size]} style={{elevation: 5}}>
+    <Circle radius={radii[size]} style={{elevation: 5}} color={color}>
       <PresetIcon iconId={iconId} size={size} testID={testID} />
     </Circle>
   );

--- a/src/frontend/sharedComponents/icons/PresetIcon.tsx
+++ b/src/frontend/sharedComponents/icons/PresetIcon.tsx
@@ -66,7 +66,10 @@ export const PresetCircleIcon = ({
   color,
 }: PresetIconProps) => {
   return (
-    <Circle radius={radii[size]} style={{elevation: 5}} color={color}>
+    <Circle
+      radius={radii[size]}
+      style={{elevation: 5, borderWidth: 3}}
+      color={color}>
       <PresetIcon iconId={iconId} size={size} testID={testID} />
     </Circle>
   );


### PR DESCRIPTION
closes #1257 
As far as I can tell, we haven't shown the color ring around the presets/ categories since May of 2024 [when the issue included the to do item of removing the color prop](https://github.com/digidem/comapeo-mobile/issues/340). I am not sure why that was done.

So, this PR reinstates the color prop. Passes color to the PresetCircleIcon component wherever it is used, which then passes it to the Circle component.
I increased the border width to 3 px because that is [what it appears to be in Figma](https://www.figma.com/design/iUeC0Qzhb4H0unuPfxQAsM/-Mobile--CoMapeo?node-id=3379-985&t=ttzOfc0HnvSjPCG6-0).

---

<image src="https://github.com/user-attachments/assets/53aa4a5a-59f9-486d-838a-942f2e128f0c" width="250" />
<image src="https://github.com/user-attachments/assets/16d70a1c-9449-4dec-929f-009b806b7840" width="250" />
<image src="https://github.com/user-attachments/assets/82eb783b-6e8c-4817-9ecc-d0da7e45a4c5" width="250" />
<image src="https://github.com/user-attachments/assets/e1f3595b-7c2b-4e64-95ea-948717d6bd26" width="250" />



