### PR TITLE
fix: screen unresponsive when track running

### DIFF
--- a/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
@@ -30,10 +30,11 @@ export const TrackBottomSheet = React.memo(() => {
 
   // Re-check permissions on screen focus
   // Handles re-checking when navigating back from in-app
-  useFocusEffect(() => {
-    checkPermissions();
-  });
-
+  useFocusEffect(
+    React.useCallback(() => {
+      checkPermissions();
+    }, [checkPermissions]),
+  );
   // Re-check permissions when returning from system settings
   // App goes to background during system settings, then becomes active again when user returns
   // Only needed if permissions haven't been granted yet


### PR DESCRIPTION
- There was unresponsive UI (or extremely delayed touch handling) when the TrackBottomSheet was visible and E2E test failures and manual interactions being blocked.
- Because of a non memoized checking of permissions, there were unnecessary or repeated re-renders, making the app appear frozen or unresponsive.
- So, this PR updates useFocusEffect to use a memoized callback
- That is the way I originally had it my PR, so that is what I tested with the most. https://github.com/digidem/comapeo-mobile/pull/1261
- This ensures the checkPermissions() effect is stable and only re-runs when intended, preventing unnecessary re-renders or re-evaluation loops