### PR TITLE
fix: wait for backend start before sending RPC

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -34,7 +34,7 @@ import {getAppLanguageTag} from './lib/intl';
 import {IntlProvider} from './contexts/IntlContext';
 import {ServerLoading} from './ServerLoading';
 import {createSavedLocationStore} from './contexts/SavedLocationContext';
-import {createServerStateStore} from './lib/serverStateStore.ts';
+import {createServerStateStore} from './lib/ServerStateStore.ts';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -12,7 +12,6 @@ import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Sentry from '@sentry/react-native';
 import * as TaskManager from 'expo-task-manager';
-import nodejs from 'nodejs-mobile-react-native';
 import {applicationId} from 'expo-application';
 import {LOCATION_TASK_NAME, LocationCallbackInfo} from './sharedTypes/location';
 import {storage} from './hooks/persistedState/createPersistedState';
@@ -34,8 +33,8 @@ import {
 import {getAppLanguageTag} from './lib/intl';
 import {IntlProvider} from './contexts/IntlContext';
 import {ServerLoading} from './ServerLoading';
-import type {StatusMessage} from '../backend/src/status';
 import {createSavedLocationStore} from './contexts/SavedLocationContext';
+import {createServerStateStore} from './lib/serverStateStore.ts';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
@@ -81,8 +80,10 @@ const appDiagnosticMetrics = new AppDiagnosticMetrics({
 });
 
 const deviceDiagnosticMetrics = new DeviceDiagnosticMetrics();
-const messagePort = new MessagePortLike();
+const serverStateStore = createServerStateStore();
+const messagePort = new MessagePortLike({serverStateStore});
 const mapeoApi = createMapeoClient(messagePort, {timeout: Infinity});
+messagePort.start();
 const localDiscoveryController = createLocalDiscoveryController(mapeoApi);
 localDiscoveryController.start();
 
@@ -161,16 +162,6 @@ TaskManager.defineTask(
 
 const queryClient = new QueryClient();
 
-const requestServerStatus = () => {
-  nodejs.channel.post('get-server-status');
-};
-
-const subscribeToServerStatus = (listener: (msg: StatusMessage) => unknown) => {
-  const subscription = nodejs.channel.addListener('server:status', listener);
-  // @ts-expect-error - incorrect types on nodejs.channel
-  return () => subscription.remove();
-};
-
 const App = () => {
   const [permissionsAsked, setPermissionsAsked] = React.useState(false);
   React.useEffect(() => {
@@ -187,10 +178,7 @@ const App = () => {
     <LocaleStoreProvider value={persistedLocaleStore}>
       <IntlProvider>
         {/* ServerLoading requires internationalization to be set up */}
-        <ServerLoading
-          messagePort={messagePort}
-          requestServerStatus={requestServerStatus}
-          subscribeToServerStatus={subscribeToServerStatus}>
+        <ServerLoading serverStateStore={serverStateStore}>
           <AppProviders
             queryClient={queryClient}
             localDiscoveryController={localDiscoveryController}

--- a/src/frontend/ServerLoading.tsx
+++ b/src/frontend/ServerLoading.tsx
@@ -1,55 +1,27 @@
 import * as React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 
-import type {StatusMessage} from '../backend/src/status';
-import {MessagePortLike} from './lib/MessagePortLike.js';
 import {FatalError} from './screens/FatalError';
+import type {ServerStateStore} from './lib/serverStateStore.js';
 
 export const ServerLoading = ({
-  messagePort,
-  requestServerStatus,
-  subscribeToServerStatus,
+  serverStateStore,
   children,
 }: React.PropsWithChildren<{
-  messagePort: MessagePortLike;
-  requestServerStatus: () => unknown;
-  subscribeToServerStatus: (
-    listener: (msg: StatusMessage) => unknown,
-  ) => () => void;
+  serverStateStore: ServerStateStore;
 }>) => {
-  const [serverStatus, setServerStatus] = React.useState<StatusMessage>({
-    value: 'STARTING',
-  });
+  const serverState = React.useSyncExternalStore(
+    serverStateStore.subscribe,
+    serverStateStore.getSnapshot,
+  );
 
-  React.useEffect(() => {
-    const unsubscribe = subscribeToServerStatus(msg => {
-      if (msg.value === 'STARTED') {
-        messagePort.start();
-      }
-
-      setServerStatus(msg);
-    });
-
-    // In case the server starts before us (we miss the original
-    // "server started" event), prompt the server to re-send.
-    requestServerStatus();
-
-    return unsubscribe;
-  }, [
-    messagePort,
-    requestServerStatus,
-    subscribeToServerStatus,
-    setServerStatus,
-  ]);
-
-  // Don't render any children while the backend is starting - this avoids
-  // timeouts from API methods if server startup takes more than 5 seconds - all
-  // api calls should be from children of this component.
-  if (serverStatus.value === 'STARTING') {
+  // TODO: We could now render the app during the server startup, however
+  // leaving as-is for now since this is the current behavior.
+  if (serverState.value === 'STARTING') {
     return null;
   }
 
-  if (serverStatus.value === 'ERROR') {
+  if (serverState.value === 'ERROR') {
     SplashScreen.hide();
     return <FatalError />;
   }

--- a/src/frontend/ServerLoading.tsx
+++ b/src/frontend/ServerLoading.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 
 import {FatalError} from './screens/FatalError';
-import type {ServerStateStore} from './lib/serverStateStore.js';
+import type {ServerStateStore} from './lib/ServerStateStore.js';
 
 export const ServerLoading = ({
   serverStateStore,

--- a/src/frontend/lib/MessagePortLike.ts
+++ b/src/frontend/lib/MessagePortLike.ts
@@ -1,22 +1,43 @@
 import {EventSubscription} from 'react-native';
 import EventEmitter from 'eventemitter3';
 import nodejs from 'nodejs-mobile-react-native';
+import type {ServerStateStore, ServerState} from './serverStateStore.ts';
+import {ExhaustivenessError} from './ExhaustivenessError.ts';
 
-export type ServerState = 'idle' | 'started' | 'closed';
+type MessagePortState = 'idle' | 'started' | 'closed';
 
 export class MessagePortLike extends EventEmitter {
   #API_EVENT_NAME = '@@API_MESSAGE';
   #channelSubscription: EventSubscription;
-  #state: ServerState = 'idle';
-  #queuedMessages: unknown[] = [];
+  #unsubscribeServerState: () => void;
+  #state: MessagePortState = 'idle';
+  #serverState: ServerState = {value: 'STARTING'};
+  #incomingQueue: unknown[] = [];
+  #outgoingQueue: unknown[] = [];
   #handleChannelMessage;
 
-  constructor() {
+  #handleServerStateChange = () => {
+    this.#serverState = this.#serverStateStore.getSnapshot();
+    if (this.#serverState.value === 'STARTED') {
+      let message;
+      while ((message = this.#outgoingQueue.shift())) {
+        this.postMessage(message);
+      }
+    }
+  };
+  #serverStateStore: ServerStateStore;
+
+  constructor({serverStateStore}: {serverStateStore: ServerStateStore}) {
     super();
+
+    this.#serverStateStore = serverStateStore;
+    this.#unsubscribeServerState = serverStateStore.subscribe(
+      this.#handleServerStateChange,
+    );
 
     this.#handleChannelMessage = (message: unknown) => {
       if (this.#state === 'idle') {
-        this.#queuedMessages.push(message);
+        this.#incomingQueue.push(message);
       } else if (this.#state === 'started') {
         this.emit('message', message);
       } else {
@@ -33,9 +54,24 @@ export class MessagePortLike extends EventEmitter {
   }
 
   postMessage(message: unknown) {
-    nodejs.channel.post(this.#API_EVENT_NAME, message);
+    switch (this.#serverState.value) {
+      case 'STARTING':
+        this.#outgoingQueue.push(message);
+        break;
+      case 'STARTED':
+        nodejs.channel.post(this.#API_EVENT_NAME, message);
+        break;
+      case 'ERROR':
+        throw new Error(this.#serverState.error || 'Unknown server error');
+      default:
+        throw new ExhaustivenessError(this.#serverState.value);
+    }
   }
 
+  /**
+   * Start receiving messages from the channel. Messages received before calling
+   * `start` are queued and processed once `start` is called.
+   */
   start() {
     if (this.#state !== 'idle') {
       return;
@@ -44,7 +80,7 @@ export class MessagePortLike extends EventEmitter {
 
     let message;
 
-    while ((message = this.#queuedMessages.shift())) {
+    while ((message = this.#incomingQueue.shift())) {
       this.#handleChannelMessage(message);
     }
   }
@@ -55,9 +91,10 @@ export class MessagePortLike extends EventEmitter {
     }
 
     this.#state = 'closed';
-    this.#queuedMessages = [];
+    this.#incomingQueue = [];
 
     this.#channelSubscription.remove();
+    this.#unsubscribeServerState();
   }
 
   addEventListener(event: string, listener: (msg: unknown) => void) {

--- a/src/frontend/lib/MessagePortLike.ts
+++ b/src/frontend/lib/MessagePortLike.ts
@@ -1,7 +1,7 @@
 import {EventSubscription} from 'react-native';
 import EventEmitter from 'eventemitter3';
 import nodejs from 'nodejs-mobile-react-native';
-import type {ServerStateStore, ServerState} from './serverStateStore.ts';
+import type {ServerStateStore, ServerState} from './ServerStateStore.ts';
 import {ExhaustivenessError} from './ExhaustivenessError.ts';
 
 type MessagePortState = 'idle' | 'started' | 'closed';

--- a/src/frontend/lib/ServerStateStore.ts
+++ b/src/frontend/lib/ServerStateStore.ts
@@ -1,0 +1,50 @@
+import nodejs from 'nodejs-mobile-react-native';
+import type {StatusMessage} from '../../backend/src/status';
+export type {StatusMessage as ServerState} from '../../backend/src/status';
+
+export type ServerStateStore = {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => StatusMessage;
+};
+
+export function createServerStateStore(): ServerStateStore {
+  const listeners = new Set<() => void>();
+  let serverStatusSubscription: {remove: () => void} | null = null;
+  let serverState: StatusMessage = {
+    value: 'STARTING',
+  };
+
+  function subscribeInternal() {
+    if (serverStatusSubscription) return;
+    // @ts-expect-error - incorrect types on nodejs.channel
+    serverStatusSubscription = nodejs.channel.addListener(
+      'server:status',
+      (msg: StatusMessage) => {
+        serverState = msg;
+      },
+    );
+    // The backend will send a `'server:status'` message when it starts, but if
+    // it started before the frontend (e.g. when react native reloads the
+    // frontend), we need to tell it to re-send the status.
+    nodejs.channel.post('get-server-status');
+  }
+
+  function unsubscribeInternal() {
+    serverStatusSubscription?.remove();
+    serverStatusSubscription = null;
+  }
+
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      if (!serverStatusSubscription) subscribeInternal();
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) unsubscribeInternal();
+      };
+    },
+    getSnapshot() {
+      return serverState;
+    },
+  };
+}

--- a/src/frontend/lib/ServerStateStore.ts
+++ b/src/frontend/lib/ServerStateStore.ts
@@ -21,6 +21,7 @@ export function createServerStateStore(): ServerStateStore {
       'server:status',
       (msg: StatusMessage) => {
         serverState = msg;
+        listeners.forEach(listener => listener());
       },
     );
     // The backend will send a `'server:status'` message when it starts, but if


### PR DESCRIPTION
This fixes https://github.com/digidem/comapeo-core/issues/1063

The `ServerLoading` component had been largely protecting us from this issue, because it does not render any of the app until the server has started, which ensures that not RPC messages are sent before the server is started. However, the LocalDiscoveryController is initiated outside the React render tree, and the RPC message sent by `mapeoApi.startLocalDiscoveryServer()` can happen before the backend nodejs process has started, which results in the server never starting.

This is not an issue if it only happens on one phone out of a pair of phones trying to connect, since the connection can happen in the other direction, however if it happens on both phones, then they will never be able to connect to each other, so they will not show as available devices for invite or sync.

This issue is more likely to occur on slower phones or when additional code is added to the backend, which slows in initial nodejs startup.

This PR adds an internal queue to the frontend MessagePort implementation that waits for the backend to start before sending any RPC messages. It moves the logic to listen for server start out of the react tree and into a new `ServerStateStore`. It uses `React.useSyncExternalStore()` to use this state in the `ServerLoading` component which is now much simpler and mainly responsible for showing an error screen if there is a fatal server error. `ServerLoading` also currently does not render the app while the backend is starting, but it does not need to do this now, and could just render the app and the user would see the observation list loading animation as the server starts. However I have left this behavior as-is for now.

A similar queue is not needed in the backend, because we only post RPC messages to the frontend after receiving a message first from the frontend, so it is guaranteed that the frontend process is started and listening before the backend sends anything.