### PR TITLE
tests: Add timeout for remote archive invalid url

### DIFF
--- a/tests/e2e/specs/remote-archive/add-remote-error.test.ts
+++ b/tests/e2e/specs/remote-archive/add-remote-error.test.ts
@@ -21,7 +21,10 @@ describe('Remote Archive - Add Error Flow', () => {
     const urlInput = await $(byResourceId('RA.url-inp'));
     await urlInput.setValue('example.com');
     await $(byResourceId('OBS.edit-save-btn')).click();
-    await expect($(byTextMatches('example.com'))).toBeDisplayed();
+    await $(byTextMatches('example.com')).waitForExist({
+      timeout: 10000,
+      reverse: false,
+    });
 
     await expect($(byTextMatches('Invalid URL'))).toBeDisplayed();
     const backButton = await $(byResourceId('MAIN.header-back-btn'));


### PR DESCRIPTION
The CI errors related to remote archive seem to be from the connection attempt to `example.com` taking too long to error out.

(IIUC) this should help avoid the false negative. Testing locally it just needed like 2-5 seconds to show the error.