### PR TITLE
chore: only run e2e tests when source-code files change

### DIFF
--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -13,7 +13,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  files-changed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      app_source: ${{ steps.changes.outputs.app_source }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Check for Changes in App Source
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          # Filter any file that could change the build of the app.
+          # Excludes unit and integration tests
+          filters: |
+            app_source:
+              - 'index.js'
+              - 'src/**'
+              - '!src/**/*.test.js'
+              - 'tests/**'
+              - 'patches/**'
+              - 'assets/**'
+              - 'messages/**'
+              - 'expo-config-plugins/**'
+              - 'public/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'app.config.js'
+              - 'app.json'
+              - 'wdio.ci.config.js'
+              - 'wdio.local.config.js.template'
+              - '.github/workflows/e2e-appium-browserstack.yml'
+
   build-apk:
+    if: needs.files-changed.outputs.app_source == 'true'
+    needs: files-changed
     runs-on: ubuntu-latest
     outputs:
       app_url: ${{ steps.upload.outputs.app_url }}
@@ -95,7 +132,10 @@ jobs:
 
   run-e2e-tests:
     runs-on: ubuntu-latest
-    needs: build-apk
+    if: needs.files-changed.outputs.app_source == 'true'
+    needs:
+      - files-changed
+      - build-apk
 
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The next version of Mapeo Mobile
 
 ## Getting started
 
-1. Clone repository
+1. Clone repository 
 
    ```sh
    git clone https://github.com/digidem/comapeo-mobile.git

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The next version of Mapeo Mobile
 
 ## Getting started
 
-1. Clone repository 
+1. Clone repository
 
    ```sh
    git clone https://github.com/digidem/comapeo-mobile.git


### PR DESCRIPTION
Small change to reduce unnecessary e2e tests. Not sure if it will work as intended, so pushing to test. The action used [dorny/paths-filter](https://github.com/dorny/paths-filter) is [used by Sentry](https://github.com/getsentry/sentry/blob/38e0b080b5039ab1896c5d6bb889811c65a1dcd7/.github/workflows/backend.yml#L36) so I think it's fairly reliable and maintained.