### PR TITLE
[DO NOT MERGE] feat: save/create document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,8 +84,8 @@ ios/*.env*.local
 *.mobileprovision
 
 # Expo
-android/
-ios/
+/android
+/ios
 
 # WebdriverIO local configuration
 wdio.local.config.js

--- a/modules/action-create-document/android/build.gradle
+++ b/modules/action-create-document/android/build.gradle
@@ -1,0 +1,43 @@
+apply plugin: 'com.android.library'
+
+group = 'expo.modules.actioncreatedocument'
+version = '0.6.3'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
+// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
+// Most of the time, you may like to manage the Android SDK versions yourself.
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    // Simple helper that allows the root project to override versions declared by this library.
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 21)
+      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+    }
+  }
+}
+
+android {
+  namespace "expo.modules.actioncreatedocument"
+  defaultConfig {
+    versionCode 1
+    versionName "0.6.3"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/modules/action-create-document/android/src/main/AndroidManifest.xml
+++ b/modules/action-create-document/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/action-create-document/android/src/main/java/expo/modules/actioncreatedocument/CreateDocumentModule.kt
+++ b/modules/action-create-document/android/src/main/java/expo/modules/actioncreatedocument/CreateDocumentModule.kt
@@ -1,0 +1,118 @@
+package expo.modules.actioncreatedocument
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.core.errors.InvalidArgumentException
+import expo.modules.interfaces.filesystem.Permission
+import expo.modules.kotlin.exception.Exceptions
+import java.io.File
+import java.net.URLConnection
+import androidx.core.net.toUri
+
+class CreateDocumentModule : Module() {
+    private val context: Context
+        get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+    private var pendingPromise: Promise? = null
+    private var fileToSave: File? = null
+
+    // Each module class must implement the definition function. The definition consists of components
+    // that describes the module's functionality and behavior.
+    // See https://docs.expo.dev/modules/module-api for more details about available components.
+    override fun definition() = ModuleDefinition {
+        // Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument.
+        // Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
+        // The module will be accessible from `requireNativeModule('CreateDocument')` in JavaScript.
+        Name("CreateDocument")
+
+        // Defines a JavaScript function that always returns a Promise and whose native code
+        // is by default dispatched on the different thread than the JavaScript runtime runs on.
+        AsyncFunction("save") { url: String?, params: Options, promise: Promise ->
+            if (pendingPromise != null) {
+                throw InProgressException()
+            }
+
+            try {
+                fileToSave = getLocalFileFoUrl(url)
+                val mimeType = params.mimeType
+                    ?: URLConnection.guessContentTypeFromName(fileToSave!!.name)
+                    ?: "*/*"
+                val filename = params.filename ?: fileToSave!!.name
+                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    type = mimeType
+                    putExtra(Intent.EXTRA_TITLE, filename)
+                }
+                pendingPromise = promise
+                appContext.throwingActivity.startActivityForResult(intent, REQUEST_CODE)
+            } catch (e: InvalidArgumentException) {
+                throw InvalidArgsException(e.message, e)
+            } catch (e: Exception) {
+                throw FailedException("Failed to save the file: ${e.message}", e)
+            }
+
+        }
+
+        OnActivityResult { _, (requestCode, resultCode, resultData) ->
+            if (requestCode == REQUEST_CODE && pendingPromise != null) {
+                val uri = resultData?.data
+                if (resultCode != Activity.RESULT_OK) {
+                    pendingPromise?.reject(CancelledException())
+                    pendingPromise = null
+                    return@OnActivityResult
+                } else if (uri == null) {
+                    pendingPromise?.reject(FailedException("Result data is null.", Exception()))
+                    pendingPromise = null
+                    return@OnActivityResult
+                }
+                try {
+                    val inputStream = fileToSave!!.inputStream()
+                    val outputStream = context.contentResolver.openOutputStream(uri)
+                    inputStream.use { input ->
+                        outputStream?.use { output ->
+                            input.copyTo(output)
+                        } ?: throw FailedException(
+                            "Failed to open output stream for URI.",
+                            Exception()
+                        )
+                    }
+                    pendingPromise?.resolve(null)
+                } catch (e: Exception) {
+                    pendingPromise?.reject(FailedException("Failed to copy file: ${e.message}", e))
+                }
+                pendingPromise = null
+                fileToSave = null
+            }
+        }
+    }
+
+    @Throws(InvalidArgumentException::class)
+    private fun getLocalFileFoUrl(url: String?): File {
+        if (url == null) {
+            throw InvalidArgumentException("URL to save cannot be null.")
+        }
+        val uri = url.toUri()
+        if ("file" != uri.scheme) {
+            throw InvalidArgumentException("Only local file URLs are supported (expected scheme to be 'file', got '" + uri.scheme + "'.")
+        }
+        val path = uri.path
+            ?: throw InvalidArgumentException("Path component of the URL to share cannot be null.")
+        if (!isAllowedToRead(path)) {
+            throw InvalidArgumentException("Not allowed to read file under given URL.")
+        }
+        return File(path)
+    }
+
+    private fun isAllowedToRead(url: String?): Boolean {
+        val permissions = appContext.filePermission
+        return permissions?.getPathPermissions(context, url)?.contains(Permission.READ)
+            ?: false
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 1
+    }
+}

--- a/modules/action-create-document/android/src/main/java/expo/modules/actioncreatedocument/Exceptions.kt
+++ b/modules/action-create-document/android/src/main/java/expo/modules/actioncreatedocument/Exceptions.kt
@@ -1,0 +1,15 @@
+package expo.modules.actioncreatedocument
+
+import expo.modules.kotlin.exception.CodedException
+
+internal class InProgressException :
+    CodedException("Another share request is being processed now.")
+
+internal class FailedException(message: String, e: Exception) :
+    CodedException(message, e.cause)
+
+internal class InvalidArgsException(message: String?, e: Exception) :
+    CodedException(message, e.cause)
+
+internal class CancelledException :
+    CodedException("The request was cancelled by the user or the system.")

--- a/modules/action-create-document/android/src/main/java/expo/modules/actioncreatedocument/Options.kt
+++ b/modules/action-create-document/android/src/main/java/expo/modules/actioncreatedocument/Options.kt
@@ -1,0 +1,9 @@
+package expo.modules.actioncreatedocument
+
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+
+data class Options(
+    @Field val mimeType: String?,
+    @Field val filename: String?,
+) : Record

--- a/modules/action-create-document/expo-module.config.json
+++ b/modules/action-create-document/expo-module.config.json
@@ -1,0 +1,17 @@
+{
+  "platforms": [
+    "apple",
+    "android",
+    "web"
+  ],
+  "apple": {
+    "modules": [
+      "CreateDocumentModule"
+    ]
+  },
+  "android": {
+    "modules": [
+      "expo.modules.actioncreatedocument.CreateDocumentModule"
+    ]
+  }
+}

--- a/modules/action-create-document/index.ts
+++ b/modules/action-create-document/index.ts
@@ -1,0 +1,5 @@
+// Reexport the native module. On web, it will be resolved to CreateDocumentModule.web.ts
+// and on native platforms to CreateDocumentModule.ts
+export {default} from './src/CreateDocumentModule';
+export {default as CreateDocumentView} from './src/CreateDocumentView';
+export * from './src/CreateDocument.types';

--- a/modules/action-create-document/ios/CreateDocument.podspec
+++ b/modules/action-create-document/ios/CreateDocument.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'CreateDocument'
+  s.version        = '1.0.0'
+  s.summary        = 'A sample project summary'
+  s.description    = 'A sample project description'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/action-create-document/ios/CreateDocumentModule.swift
+++ b/modules/action-create-document/ios/CreateDocumentModule.swift
@@ -1,0 +1,48 @@
+import ExpoModulesCore
+
+public class CreateDocumentModule: Module {
+  // Each module class must implement the definition function. The definition consists of components
+  // that describes the module's functionality and behavior.
+  // See https://docs.expo.dev/modules/module-api for more details about available components.
+  public func definition() -> ModuleDefinition {
+    // Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument.
+    // Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
+    // The module will be accessible from `requireNativeModule('CreateDocument')` in JavaScript.
+    Name("CreateDocument")
+
+    // Sets constant properties on the module. Can take a dictionary or a closure that returns a dictionary.
+    Constants([
+      "PI": Double.pi
+    ])
+
+    // Defines event names that the module can send to JavaScript.
+    Events("onChange")
+
+    // Defines a JavaScript synchronous function that runs the native code on the JavaScript thread.
+    Function("hello") {
+      return "Hello world! 👋"
+    }
+
+    // Defines a JavaScript function that always returns a Promise and whose native code
+    // is by default dispatched on the different thread than the JavaScript runtime runs on.
+    AsyncFunction("setValueAsync") { (value: String) in
+      // Send an event to JavaScript.
+      self.sendEvent("onChange", [
+        "value": value
+      ])
+    }
+
+    // Enables the module to be used as a native view. Definition components that are accepted as part of the
+    // view definition: Prop, Events.
+    View(CreateDocumentView.self) {
+      // Defines a setter for the `url` prop.
+      Prop("url") { (view: CreateDocumentView, url: URL) in
+        if view.webView.url != url {
+          view.webView.load(URLRequest(url: url))
+        }
+      }
+
+      Events("onLoad")
+    }
+  }
+}

--- a/modules/action-create-document/src/CreateDocument.types.ts
+++ b/modules/action-create-document/src/CreateDocument.types.ts
@@ -1,0 +1,19 @@
+import type {StyleProp, ViewStyle} from 'react-native';
+
+export type OnLoadEventPayload = {
+  url: string;
+};
+
+export type CreateDocumentModuleEvents = {
+  onChange: (params: ChangeEventPayload) => void;
+};
+
+export type ChangeEventPayload = {
+  value: string;
+};
+
+export type CreateDocumentViewProps = {
+  url: string;
+  onLoad: (event: {nativeEvent: OnLoadEventPayload}) => void;
+  style?: StyleProp<ViewStyle>;
+};

--- a/modules/action-create-document/src/CreateDocumentModule.ts
+++ b/modules/action-create-document/src/CreateDocumentModule.ts
@@ -1,0 +1,25 @@
+import {NativeModule, requireNativeModule} from 'expo';
+
+import {CreateDocumentModuleEvents} from './CreateDocument.types';
+
+export type SharingOptions = {
+  /**
+   * Sets `mimeType` for `Intent`.
+   * @platform android
+   */
+  mimeType?: string;
+  /**
+   * Sets default filename
+   */
+  filename?: string;
+};
+
+declare class CreateDocumentModule extends NativeModule<CreateDocumentModuleEvents> {
+  save(url: string, options?: SharingOptions): Promise<void>;
+}
+
+// This call loads the native module object from the JSI.
+const {save: saveDocument} =
+  requireNativeModule<CreateDocumentModule>('CreateDocument');
+
+export {saveDocument};

--- a/src/backend/loader.js
+++ b/src/backend/loader.js
@@ -20,7 +20,7 @@ process.env = process.env || {}
 
 const { sentryEnvironment, sentryUserId, metricsIsEnabled } = parseArgs()
 
-const sentryDebug = sentryEnvironment === 'development'
+const sentryDebug = false //sentryEnvironment === 'development'
 const initialScope = sentryUserId ? { user: { id: sentryUserId } } : undefined
 
 /** @type {Array<"error" | "log" | "warn">} */

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -43,7 +43,7 @@ if (applicationId?.endsWith('.dev') || applicationId?.endsWith('.pre')) {
   sentryEnvironment = 'qa';
 }
 
-const sentryDebug = applicationId?.endsWith('.dev');
+const sentryDebug = false; // applicationId?.endsWith('.dev');
 const appMetricsOptIn = sentryEnvironment !== 'production';
 let navigationIntegration:
   | ReturnType<(typeof Sentry)['reactNavigationIntegration']>

--- a/src/frontend/hooks/share.ts
+++ b/src/frontend/hooks/share.ts
@@ -1,5 +1,6 @@
 import {useIsMutating, useMutation} from '@tanstack/react-query';
 import Share, {type ShareOptions} from 'react-native-share';
+import {saveDocument} from '../../../modules/action-create-document/src/CreateDocumentModule';
 
 const SHARE_OPEN_MUTATION_KEY = ['share', 'open'] as const;
 
@@ -9,7 +10,12 @@ export function useOpenShareDialog() {
     retry: false,
     mutationKey: SHARE_OPEN_MUTATION_KEY,
     mutationFn: async (options: ShareOptions) => {
-      return Share.open(options);
+      return saveDocument(options.url, {
+        mimeType: 'application/json',
+      }).catch(error => {
+        console.error('Error saving document for sharing:', error);
+        throw error;
+      });
     },
   });
 }


### PR DESCRIPTION
This is a quick experiment to try the [ACTION_CREATE_DOCUMENT](https://developer.android.com/training/data-storage/shared/documents-files#create-file) intent with Android to enable saving a file to a location chosen with the system file picker.

I was looking into this because, on my phones at least, "sharing" a file (e.g. via an ACTION_SEND intent) does not show the Files app as a destination. This means ACTION_SEND cannot be used to save something to phone storage.

This is a quick-and-dirty local expo module to use the documented Android way of creating a new file on disk. I could not find any existing React Native modules to do this.

This is done as a proof-of-concept to see if this is possible if we get feedback that this functionality is essential.