### PR TITLE
fix: Fix track distance calculation

### DIFF
--- a/src/frontend/contexts/TrackStoreContext.test.tsx
+++ b/src/frontend/contexts/TrackStoreContext.test.tsx
@@ -10,6 +10,7 @@ import {
   useTrackState,
   PresetSchema,
 } from './TrackStoreContext';
+import {calculateTotalDistance} from '../utils/distance.ts';
 
 function createWrapper(trackStore: TrackStore) {
   return ({children}: {children: ReactNode}) => {
@@ -272,5 +273,24 @@ describe('useTrackActions()', () => {
       docId: null,
     });
     expect(stateHook.result.current.distance).toBeGreaterThan(previousDistance);
+    expect(stateHook.result.current.distance).toBeCloseTo(
+      calculateTotalDistance(stateHook.result.current.locationHistory),
+      1,
+    );
+
+    // This test exists to check a previous implementation bug where adding more
+    // than one location when there is already a location history would result
+    // in incorrect distance calculation.
+    act(() => {
+      actionsHook.result.current.addNewLocations([
+        {latitude: 0.5, longitude: 1, timestamp: timestamp3 + 1_000},
+        {latitude: 0.5, longitude: 1.5, timestamp: timestamp3 + 2_000},
+      ]);
+    });
+
+    expect(stateHook.result.current.distance).toBeCloseTo(
+      calculateTotalDistance(stateHook.result.current.locationHistory),
+      1,
+    );
   });
 });

--- a/src/frontend/contexts/TrackStoreContext.tsx
+++ b/src/frontend/contexts/TrackStoreContext.tsx
@@ -129,30 +129,11 @@ export function createTrackStore({persist} = {persist: false}) {
     },
     addNewLocations: (data: Array<LocationHistoryPoint>) => {
       store.setState(prev => {
-        if (data.length > 1) {
-          return {
-            locationHistory: [...prev.locationHistory, ...data],
-            distance: prev.distance + calculateTotalDistance(data),
-          };
-        }
-
-        if (prev.locationHistory.length < 1) {
-          return {
-            locationHistory: [...prev.locationHistory, ...data],
-          };
-        }
-
-        const lastLocation =
-          prev.locationHistory[prev.locationHistory.length - 1];
-
-        if (!lastLocation) {
-          throw Error('No lastLocation for state.locationHistory.length > 1');
-        }
-
+        const lastLocation = prev.locationHistory.at(-1);
+        const pointsToMeasure = lastLocation ? [lastLocation, ...data] : data;
         return {
           locationHistory: [...prev.locationHistory, ...data],
-          distance:
-            prev.distance + calculateTotalDistance([lastLocation, ...data]),
+          distance: prev.distance + calculateTotalDistance(pointsToMeasure),
         };
       });
     },


### PR DESCRIPTION
There was a bug in the track distance calculation: Adding more than one location when there was already a location history would exclude from the distance calculation the distance between the last point in the location history and the newly added locations.

This PR adds a failing test to identify this issue, and then a fix, which also simplifies the implementation.