### PR TITLE
fix: small improvements to tracking re-render performance

### DIFF
--- a/src/frontend/hooks/useTracking.ts
+++ b/src/frontend/hooks/useTracking.ts
@@ -7,13 +7,14 @@ import {
 import {LOCATION_TASK_NAME} from '../sharedTypes/location.ts';
 import {useNavigation} from '@react-navigation/native';
 import * as Sentry from '@sentry/react-native';
-import {useLocationState} from '../contexts/LocationContext';
+import {useLocationContext} from '../contexts/LocationContext';
 
 export function useTracking() {
   const {setTracking, addNewLocations, clearCurrentTrack} = useTrackActions();
   const navigation = useNavigation();
   const isTracking = useTrackState(state => state.isTracking);
-  const location = useLocationState(state => state.location);
+  // TODO: Once use() is available, we can put this in the cancel tracking function
+  const locationContext = useLocationContext();
 
   const startTracking = useCallback(() => {
     if (isTracking) {
@@ -43,22 +44,24 @@ export function useTracking() {
       Sentry.captureException(err);
     });
 
-    if (location?.coords) {
-      const {latitude, longitude, accuracy} = location.coords;
+    const currentLocation = locationContext.getState().location;
+
+    if (currentLocation?.coords) {
+      const {latitude, longitude, accuracy} = currentLocation.coords;
 
       if (typeof accuracy === 'number' && accuracy <= 3) {
         addNewLocations([
           {
             latitude,
             longitude,
-            timestamp: location.timestamp,
+            timestamp: currentLocation.timestamp,
           },
         ]);
       }
     }
 
     setTracking(false);
-  }, [location, addNewLocations, setTracking]);
+  }, [addNewLocations, setTracking, locationContext]);
 
   const cancelTracking = useCallback(() => {
     Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME).catch(err => {


### PR DESCRIPTION
This PR makes some small performance improvements to the `useTracking()` hook to avoid frequent re-renders. The current implementation uses the `useLocationContext()` hook, which will result in a re-render for every location update (approx every 1000ms). This PR addresses this by not subscribing to location store updates via the `useLocationContext()` hook, but instead gets a reference to the (stable) store instance, and reads the location directly when needed in the `cancelTracking()` function.

Before this PR, using the `useTracking()` hook would cause whichever component it was used in to render every location update. After the change in this PR, using the `useTracking()` hook should not result in any additional re-renders. Behaviour should stay the same.

EDIT: This is a slightly bigger issue: the `useTracking()` component is [used in the MapScreen](https://github.com/digidem/comapeo-mobile/blob/fef201da8dcdf93e99c8a567d62ca4834b1a2b9b/src/frontend/screens/MapScreen/index.tsx#L67-L68), and updates on every location update, which results in the map screen updating on every location update, whether tracking or not. This discounts the optimization efforts of the throttled location for map updates.