### PR TITLE
chore: update rpc-reflector@3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33974,9 +33974,9 @@
       }
     },
     "node_modules/rpc-reflector": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-3.0.0.tgz",
-      "integrity": "sha512-9XQIn9OPwMxU14VLMtYMUAAjdvpo7pm+BdLy361vQY5qy5Xu1VEKh3mRtGinw2Qp5xwtaC/YFSg6dCSzoogbmw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rpc-reflector/-/rpc-reflector-3.0.1.tgz",
+      "integrity": "sha512-yUcgwFwrEWMgMgCjLUJwRYGT9KuIYyBb1KI7kqfxC83Y0oXNVwxTKIT3YrkPjuGm72YpU8o3Nj2nI7YFOaI3mQ==",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^18.19.115",


### PR DESCRIPTION
Updates rpc-reflector to include a fix for errors when debugging with react devtools and trying to inspect components which used a hook that referenced the comapeo API.
