### PR TITLE
fix: scrollview onboarding success

### DIFF
--- a/src/frontend/screens/Onboarding/Success.tsx
+++ b/src/frontend/screens/Onboarding/Success.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {ScrollView, StyleSheet, View} from 'react-native';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 
 import SuccessIcon from '../../images/Success.svg';
@@ -49,20 +49,22 @@ export const Success = ({
 
   return (
     <View style={styles.container}>
-      <View style={{alignItems: 'center'}}>
-        <SuccessIcon />
-        <Text style={styles.text}>{t(m.success)}</Text>
-        <Text style={{marginTop: 20}}>{t(m.description)} </Text>
-        <View style={styles.deviceText}>
-          <NewDeviceLogo />
-          <Text style={{marginLeft: 10}}>{deviceName}</Text>
+      <ScrollView>
+        <View style={{alignItems: 'center'}}>
+          <SuccessIcon />
+          <Text style={styles.text}>{t(m.success)}</Text>
+          <Text style={{marginTop: 20}}>{t(m.description)} </Text>
+          <View style={styles.deviceText}>
+            <NewDeviceLogo />
+            <Text style={{marginLeft: 10}}>{deviceName}</Text>
+          </View>
+          <View>
+            <Text style={{marginTop: 20}}>{t(m.startMappingInstructions)}</Text>
+            <Text></Text>
+            <Text>{t(m.findSettings)}</Text>
+          </View>
         </View>
-        <View>
-          <Text style={{marginTop: 20}}>{t(m.startMappingInstructions)}</Text>
-          <Text></Text>
-          <Text>{t(m.findSettings)}</Text>
-        </View>
-      </View>
+      </ScrollView>
       <Button
         testID="ONBOARDING.go-to-map-btn"
         fullWidth


### PR DESCRIPTION
Closes #1352 
Adds a scrollview around the content on the success to onboarding screen so that the button is available on all screen sizes.
I tested on the Emulator titled "small phone" with a 4.65" screen. I also changed the language to Spanish and increased the font size just to be sure.
I also tested on a regular phone (Pixel 8) to make sure it still behaved as expected on a "normal" screen size.
I had to leave the button out of the scroll view so that it would still be fixed to the bottom of the page but that seemed to work fine as you can see from the video.

https://github.com/user-attachments/assets/8bde6e4d-4061-455d-bb48-a11917127f83


