### PR TITLE
fix: failing language test

### DIFF
--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -43,11 +43,14 @@ describe('Settings - Language Settings Flow', () => {
       await drawerIcon.click();
     }
 
-    //const settingsInSpanish = await $(byTextMatches('Ajustes de la'));
-    // commenting out until translation done
-    const settingsInEnglish = await $(byTextMatches('Settings'));
-    await settingsInEnglish.click();
+    const english = $(byTextMatches('Settings'));
+    const spanish = $(byTextMatches('Ajustes de la'));
 
+    if (await spanish.isDisplayed()) {
+      await spanish.click();
+    } else {
+      await english.click();
+    }
     const idiomaOption = await $(byTextMatches('Idioma'));
     await idiomaOption.click();
 

--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -43,14 +43,9 @@ describe('Settings - Language Settings Flow', () => {
       await drawerIcon.click();
     }
 
-    const english = $(byTextMatches('Settings'));
-    const spanish = $(byTextMatches('Ajustes de la'));
+    const settingsInSpanish = $(byTextMatches('Ajustes de la'));
+    await settingsInSpanish.click();
 
-    if (await spanish.isDisplayed()) {
-      await spanish.click();
-    } else {
-      await english.click();
-    }
     const idiomaOption = await $(byTextMatches('Idioma'));
     await idiomaOption.click();
 


### PR DESCRIPTION
Checks for spanish translation or english translation of settings. This is being translated correctly in the RC so the test is actually failing. Yay?
But locally and on develop, it is sometimes not translated. So this fix checks for either version.
