### PR TITLE
chore: hardcoded release name on about page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -448,11 +448,19 @@
   },
   "screens.AboutSettings.emojiSource": {
     "description": "Label for the source of emojis used in CoMapeo",
-    "message": "Emojis source:"
+    "message": "Emojis source"
   },
   "screens.AboutSettings.phoneModel": {
     "description": "Label for phone model",
     "message": "Phone model"
+  },
+  "screens.AboutSettings.releaseName": {
+    "description": "The CoMapeo chosen release name for the version of the app",
+    "message": "Preview"
+  },
+  "screens.AboutSettings.releaseNameLabel": {
+    "description": "Label for the release name",
+    "message": "Release name"
   },
   "screens.AboutSettings.title": {
     "description": "Title of 'About CoMapeo' screen",

--- a/src/frontend/screens/Settings/About.tsx
+++ b/src/frontend/screens/Settings/About.tsx
@@ -50,8 +50,18 @@ const m = defineMessages({
   },
   emojiSource: {
     id: 'screens.AboutSettings.emojiSource',
-    defaultMessage: 'Emojis source:',
+    defaultMessage: 'Emojis source',
     description: 'Label for the source of emojis used in CoMapeo',
+  },
+  releaseNameLabel: {
+    id: 'screens.AboutSettings.releaseNameLabel',
+    defaultMessage: 'Release name',
+    description: 'Label for the release name',
+  },
+  releaseName: {
+    id: 'screens.AboutSettings.releaseName',
+    defaultMessage: 'Preview',
+    description: 'The CoMapeo chosen release name for the version of the app',
   },
 });
 
@@ -117,6 +127,12 @@ export const AboutSettings = () => {
           <ListItemText
             primary={t(m.emojiSource)}
             secondary="https://openmoji.org/"
+          />
+        </ListItem>
+        <ListItem disableGutters>
+          <ListItemText
+            primary={t(m.releaseNameLabel)}
+            secondary={t(m.releaseName)}
           />
         </ListItem>
       </List>

--- a/tests/e2e/specs/settings/about-comapeo.test.ts
+++ b/tests/e2e/specs/settings/about-comapeo.test.ts
@@ -22,6 +22,8 @@ describe('Settings - About CoMapeo Flow', () => {
     await expect($(byTextMatches('Android version'))).toBeDisplayed();
     await expect($(byTextMatches('Android build number'))).toBeDisplayed();
     await expect($(byTextMatches('Phone model'))).toBeDisplayed();
+    await expect($(byTextMatches('Emojis source'))).toBeDisplayed();
+    await expect($(byTextMatches('Release name'))).toBeDisplayed();
   });
 
   it('should navigate back to map screen', async () => {


### PR DESCRIPTION
closes #1277 

Adds a hardcoded release name to the about page. I called the label release name. Hope that makes sense!
Added new labels to E2E test also. I actually got rid of the colon (:) after emojis after I took the screen shot though.

<img width="250" alt="about" src="https://github.com/user-attachments/assets/8e87f1a9-e770-4aea-853c-6404ced32869" />


