### PR TITLE
fix: don't stop and start media server

### DIFF
--- a/src/backend/src/app.js
+++ b/src/backend/src/app.js
@@ -2,7 +2,7 @@ import debug from 'debug'
 import { join } from 'path'
 import { mkdirSync } from 'fs'
 import { createRequire } from 'module'
-import { MapeoManager, FastifyController } from '@comapeo/core'
+import { MapeoManager } from '@comapeo/core'
 import { createMapeoServer } from '@comapeo/ipc/server.js'
 import Fastify from 'fastify'
 import * as Sentry from '@sentry/node'
@@ -76,7 +76,6 @@ export async function init({
   mkdirSync(customMapsDir, { recursive: true })
 
   const fastify = Fastify()
-  const fastifyController = new FastifyController({ fastify })
 
   const manager = new MapeoManager({
     rootKey,
@@ -91,19 +90,20 @@ export async function init({
   })
 
   // Don't await, methods that use the server will await this internally
-  fastifyController.start()
+  // Server is listening on loopback only, so will not be accessible from other devices on the network
+  fastify.listen({ host: '127.0.0.1', port: 0 }).catch((error) => {
+    Sentry.captureException(error)
+  })
 
   rnBridge.app.on('pause', async (pauseLock) => {
     log('App went into background')
     manager.onBackgrounded()
-    await fastifyController.stop()
     pauseLock.release()
   })
 
   rnBridge.app.on('resume', () => {
     log('App went into foreground')
     manager.onForegrounded()
-    fastifyController.start()
   })
 
   const messagePort = new MessagePortLike()


### PR DESCRIPTION
fixes #1364

Removes FastifyController import, which is no longer needed.