### PR TITLE
feat: success screen after data export

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -25,6 +25,24 @@
     "description": "Title of dialog that shows when cancelling a new observation",
     "message": "Discard observation?"
   },
+  "Export.Success.done": {
+    "message": "Done"
+  },
+  "Export.Success.exportBody": {
+    "message": "have been downloaded to your device."
+  },
+  "Export.Success.title": {
+    "message": "Success!"
+  },
+  "Export.Success.typeObservations": {
+    "message": "All Observations"
+  },
+  "Export.Success.typeObservationsWithMedia": {
+    "message": "All Observations with Media"
+  },
+  "Export.Success.typeTracks": {
+    "message": "Tracks"
+  },
   "MapManagement.ErrorBottomSheet.goBack": {
     "message": "Go Back"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,23 +25,20 @@
     "description": "Title of dialog that shows when cancelling a new observation",
     "message": "Discard observation?"
   },
-  "Export.Success.done": {
+  "ExportSuccess.done": {
     "message": "Done"
   },
-  "Export.Success.exportBody": {
-    "message": "have been downloaded to your device."
+  "ExportSuccess.obs": {
+    "message": "<bold>All observations</bold> have been downloaded to your device."
   },
-  "Export.Success.title": {
+  "ExportSuccess.obsMedia": {
+    "message": "<bold>All observations with media</bold> have been downloaded to your device."
+  },
+  "ExportSuccess.title": {
     "message": "Success!"
   },
-  "Export.Success.typeObservations": {
-    "message": "All Observations"
-  },
-  "Export.Success.typeObservationsWithMedia": {
-    "message": "All Observations with Media"
-  },
-  "Export.Success.typeTracks": {
-    "message": "Tracks"
+  "ExportSuccess.tracks": {
+    "message": "<bold>Tracks</bold> have been downloaded to your device."
   },
   "MapManagement.ErrorBottomSheet.goBack": {
     "message": "Go Back"

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -111,6 +111,7 @@ import {sharedPhotoPreviewNavOptions} from '../../screens/PhotoPreviewModal/shar
 import {ConfirmPasscodeBottomSheet} from '../../screens/AppPasscode/ConfirmPasscodeSheet.tsx';
 import {CreateProjectScreen} from '../../screens/Settings/CreateOrJoinProject/CreateOrNameSoloProject/CreateProject.tsx';
 import {NameSoloProjectScreen} from '../../screens/Settings/CreateOrJoinProject/CreateOrNameSoloProject/NameSoloProject.tsx';
+import {ExportSuccess} from '../../screens/ExportSuccess.tsx';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -445,6 +446,11 @@ export const createDefaultScreenGroup = ({
         name="DraftPhotoPreviewModal"
         component={DraftPhotoPreviewModal}
         options={DraftPhotoPreviewModalNavOptions({intl})}
+      />
+      <RootStack.Screen
+        name="ExportSuccess"
+        component={ExportSuccess}
+        options={{headerShown: false}}
       />
     </RootStack.Group>
     <RootStack.Group

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -493,9 +493,7 @@ export const createDefaultScreenGroup = ({
         name="ExportSuccess"
         component={ExportSuccess}
         options={{
-          headerShown: false,
           contentStyle: {backgroundColor: 'white'},
-          animation: 'none',
         }}
       />
     </RootStack.Group>

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -447,11 +447,6 @@ export const createDefaultScreenGroup = ({
         component={DraftPhotoPreviewModal}
         options={DraftPhotoPreviewModalNavOptions({intl})}
       />
-      <RootStack.Screen
-        name="ExportSuccess"
-        component={ExportSuccess}
-        options={{headerShown: false}}
-      />
     </RootStack.Group>
     <RootStack.Group
       screenOptions={{
@@ -493,6 +488,15 @@ export const createDefaultScreenGroup = ({
       <RootStack.Screen
         name="ConfirmPasscodeSheet"
         component={ConfirmPasscodeBottomSheet}
+      />
+      <RootStack.Screen
+        name="ExportSuccess"
+        component={ExportSuccess}
+        options={{
+          headerShown: false,
+          contentStyle: {backgroundColor: 'white'},
+          animation: 'none',
+        }}
       />
     </RootStack.Group>
   </>

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -17,7 +17,14 @@ import {useAppLanguageTag} from '../useAppLanguageTag';
 import {useIntl} from 'react-intl';
 import noop from '../../lib/noop';
 
-type ExportOutcome = 'saved' | 'cancelled';
+export function isUserCancelled(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    (err as {message?: string}).message === 'user canceled the document picker'
+  );
+}
 
 export function useProjectSettings() {
   const {projectId} = useActiveProject();
@@ -92,20 +99,10 @@ export function useExportObservations({projectId}: {projectId: string}) {
   const lang = useAppLanguageTag();
   const {formatDate} = useIntl();
 
-  function isUserCancelled(err: unknown): boolean {
-    return (
-      typeof err === 'object' &&
-      err !== null &&
-      'message' in err &&
-      (err as {message?: string}).message ===
-        'user canceled the document picker'
-    );
-  }
-
-  return useMutation<ExportOutcome, Error, {exportType: Exports}>({
+  return useMutation({
     retry: false,
     networkMode: 'always',
-    mutationFn: async ({exportType}) => {
+    mutationFn: async ({exportType}: {exportType: Exports}) => {
       const exportDir = FileSystem.cacheDirectory + 'exports/';
       const exportDirectory = await FileSystem.getInfoAsync(exportDir);
 
@@ -116,33 +113,34 @@ export function useExportObservations({projectId}: {projectId: string}) {
       const fileName = `CoMapeo_Obsvns_${formatDate(Date.now())}`;
 
       if (exportType === 'Observation' || exportType === 'Tracks') {
-        try {
-          const path = await exportNoMedia.mutateAsync({
+        return exportNoMedia
+          .mutateAsync({
             path: normalizeFilePath(exportDir),
             exportOptions: {
               lang,
               observations: exportType === 'Observation',
               tracks: exportType === 'Tracks',
             },
-          });
+          })
+          .then(async path => {
+            const filepath = `file://${path}`;
+            const results = await saveDocuments({
+              sourceUris: [filepath],
+              mimeType: 'application/geo+json',
+              fileName,
+            });
 
-          const filepath = `file://${path}`;
-          await saveDocuments({
-            sourceUris: [filepath],
-            mimeType: 'application/geo+json',
-            fileName,
-          });
+            FileSystem.deleteAsync(filepath, {idempotent: true}).catch(() => {
+              //do nothing as it is a temp file system that will eventually delete itself
+              noop();
+            });
 
-          FileSystem.deleteAsync(filepath, {idempotent: true}).catch(noop);
-          return 'saved';
-        } catch (err) {
-          if (isUserCancelled(err)) return 'cancelled';
-          throw err instanceof Error ? err : new Error(String(err));
-        }
+            return results;
+          });
       }
 
-      try {
-        const path = await exportWithMedia.mutateAsync({
+      return await exportWithMedia
+        .mutateAsync({
           path: normalizeFilePath(exportDir),
           exportOptions: {
             lang,
@@ -150,21 +148,22 @@ export function useExportObservations({projectId}: {projectId: string}) {
             tracks: false,
             attachments: true,
           },
-        });
+        })
+        .then(async path => {
+          const filepath = `file://${path}`;
+          const results = await saveDocuments({
+            sourceUris: [filepath],
+            mimeType: 'application/zip',
+            fileName,
+          });
 
-        const filepath = `file://${path}`;
-        await saveDocuments({
-          sourceUris: [filepath],
-          mimeType: 'application/zip',
-          fileName,
-        });
+          FileSystem.deleteAsync(filepath, {idempotent: true}).catch(() => {
+            //do nothing as it is a temp file system that will eventually delete itself
+            noop();
+          });
 
-        FileSystem.deleteAsync(filepath, {idempotent: true}).catch(noop);
-        return 'saved';
-      } catch (err) {
-        if (isUserCancelled(err)) return 'cancelled';
-        throw err instanceof Error ? err : new Error(String(err));
-      }
+          return results;
+        });
     },
   });
 }

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -17,6 +17,8 @@ import {useAppLanguageTag} from '../useAppLanguageTag';
 import {useIntl} from 'react-intl';
 import noop from '../../lib/noop';
 
+type ExportOutcome = 'saved' | 'cancelled';
+
 export function useProjectSettings() {
   const {projectId} = useActiveProject();
   return useComapeoProjectSettings({projectId});
@@ -90,59 +92,57 @@ export function useExportObservations({projectId}: {projectId: string}) {
   const lang = useAppLanguageTag();
   const {formatDate} = useIntl();
 
-  return useMutation({
+  function isUserCancelled(err: unknown): boolean {
+    return (
+      typeof err === 'object' &&
+      err !== null &&
+      'message' in err &&
+      (err as {message?: string}).message ===
+        'user canceled the document picker'
+    );
+  }
+
+  return useMutation<ExportOutcome, Error, {exportType: Exports}>({
     retry: false,
     networkMode: 'always',
-    mutationFn: async ({exportType}: {exportType: Exports}) => {
+    mutationFn: async ({exportType}) => {
       const exportDir = FileSystem.cacheDirectory + 'exports/';
       const exportDirectory = await FileSystem.getInfoAsync(exportDir);
-
-      function dealWithError(err: unknown) {
-        if (
-          typeof err === 'object' &&
-          err !== null &&
-          'message' in err &&
-          err.message === 'user canceled the document picker'
-        ) {
-          //don't surface error if user cancels doc picker
-          return;
-        }
-        throw err;
-      }
 
       if (!exportDirectory.exists) {
         await FileSystem.makeDirectoryAsync(exportDir);
       }
+
+      const fileName = `CoMapeo_Obsvns_${formatDate(Date.now())}`;
+
       if (exportType === 'Observation' || exportType === 'Tracks') {
-        return exportNoMedia
-          .mutateAsync({
+        try {
+          const path = await exportNoMedia.mutateAsync({
             path: normalizeFilePath(exportDir),
             exportOptions: {
               lang,
               observations: exportType === 'Observation',
               tracks: exportType === 'Tracks',
             },
-          })
-          .then(async path => {
-            const filepath = `file://${path}`;
-            const results = await saveDocuments({
-              sourceUris: [filepath],
-              mimeType: 'application/geo+json',
-              fileName: `CoMapeo_Obsvns_${formatDate(Date.now())}`,
-            });
+          });
 
-            FileSystem.deleteAsync(filepath, {idempotent: true}).catch(() => {
-              //do nothing as it is a temp file system that will eventually delete itself
-              noop();
-            });
+          const filepath = `file://${path}`;
+          await saveDocuments({
+            sourceUris: [filepath],
+            mimeType: 'application/geo+json',
+            fileName,
+          });
 
-            return results;
-          })
-          .catch(dealWithError);
+          FileSystem.deleteAsync(filepath, {idempotent: true}).catch(noop);
+          return 'saved';
+        } catch (err) {
+          if (isUserCancelled(err)) return 'cancelled';
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       }
 
-      return await exportWithMedia
-        .mutateAsync({
+      try {
+        const path = await exportWithMedia.mutateAsync({
           path: normalizeFilePath(exportDir),
           exportOptions: {
             lang,
@@ -150,23 +150,21 @@ export function useExportObservations({projectId}: {projectId: string}) {
             tracks: false,
             attachments: true,
           },
-        })
-        .then(async path => {
-          const filepath = `file://${path}`;
-          const results = await saveDocuments({
-            sourceUris: [filepath],
-            mimeType: 'application/zip',
-            fileName: `CoMapeo_Obsvns_${formatDate(Date.now())}`,
-          });
+        });
 
-          FileSystem.deleteAsync(filepath, {idempotent: true}).catch(() => {
-            //do nothing as it is a temp file system that will eventually delete itself
-            noop();
-          });
+        const filepath = `file://${path}`;
+        await saveDocuments({
+          sourceUris: [filepath],
+          mimeType: 'application/zip',
+          fileName,
+        });
 
-          return results;
-        })
-        .catch(dealWithError);
+        FileSystem.deleteAsync(filepath, {idempotent: true}).catch(noop);
+        return 'saved';
+      } catch (err) {
+        if (isUserCancelled(err)) return 'cancelled';
+        throw err instanceof Error ? err : new Error(String(err));
+      }
     },
   });
 }

--- a/src/frontend/screens/ExportObservations.tsx
+++ b/src/frontend/screens/ExportObservations.tsx
@@ -75,6 +75,11 @@ export const ExportObservations = ({
     exportAndShare.mutate(
       {exportType: typeToExport},
       {
+        onSuccess: outcome => {
+          if (outcome === 'saved') {
+            navigation.replace('ExportSuccess', {exportType: typeToExport});
+          }
+        },
         onError: err => {
           Sentry.captureException(err);
           navigation.navigate('ErrorBottomSheet');

--- a/src/frontend/screens/ExportObservations.tsx
+++ b/src/frontend/screens/ExportObservations.tsx
@@ -13,7 +13,7 @@ import {UIActivityIndicator} from 'react-native-indicators';
 import {useObservations} from '../hooks/server/observations';
 import {useTracks} from '../hooks/server/track';
 import * as Sentry from '@sentry/react-native';
-import {useExportObservations} from '../hooks/server/projects';
+import {isUserCancelled, useExportObservations} from '../hooks/server/projects';
 
 const m = defineMessages({
   close: {
@@ -75,12 +75,13 @@ export const ExportObservations = ({
     exportAndShare.mutate(
       {exportType: typeToExport},
       {
-        onSuccess: outcome => {
-          if (outcome === 'saved') {
-            navigation.replace('ExportSuccess', {exportType: typeToExport});
-          }
+        onSuccess: () => {
+          navigation.replace('ExportSuccess', {exportType: typeToExport});
         },
         onError: err => {
+          if (isUserCancelled(err)) {
+            return;
+          }
           Sentry.captureException(err);
           navigation.navigate('ErrorBottomSheet');
         },

--- a/src/frontend/screens/ExportSuccess.tsx
+++ b/src/frontend/screens/ExportSuccess.tsx
@@ -81,10 +81,11 @@ export const ExportSuccess = ({
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    backgroundColor: 'white',
     padding: 20,
     paddingTop: 80,
     alignItems: 'center',
-    height: '100%',
     justifyContent: 'space-between',
   },
 });

--- a/src/frontend/screens/ExportSuccess.tsx
+++ b/src/frontend/screens/ExportSuccess.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import {StyleSheet, View} from 'react-native';
+import {defineMessages, useIntl} from 'react-intl';
+import {HeaderText} from '../sharedComponents/Text/HeaderText';
+import {BodyText} from '../sharedComponents/Text/BodyText';
+import {SecondaryButton} from '../sharedComponents/Buttons';
+import SuccessIcon from '../images/Success.svg';
+import {type NativeRootNavigationProps} from '../sharedTypes/navigation';
+import {BLACK, NEW_DARK_GREY} from '../lib/styles';
+import {type Exports} from './ExportObservations';
+
+const m = defineMessages({
+  title: {id: 'Export.Success.title', defaultMessage: 'Success!'},
+  exportBody: {
+    id: 'Export.Success.exportBody',
+    defaultMessage: 'have been downloaded to your device.',
+  },
+  done: {id: 'Export.Success.done', defaultMessage: 'Done'},
+  typeObservations: {
+    id: 'Export.Success.typeObservations',
+    defaultMessage: 'All Observations',
+  },
+  typeObservationsWithMedia: {
+    id: 'Export.Success.typeObservationsWithMedia',
+    defaultMessage: 'All Observations with Media',
+  },
+  typeTracks: {id: 'Export.Success.typeTracks', defaultMessage: 'Tracks'},
+});
+
+export type ExportSuccessParams = {exportType: Exports};
+
+export const ExportSuccess = ({
+  navigation,
+  route,
+}: NativeRootNavigationProps<'ExportSuccess'>) => {
+  const {formatMessage: t} = useIntl();
+  const {exportType} = route.params;
+
+  const selectedtype =
+    exportType === 'Observation'
+      ? t(m.typeObservations)
+      : exportType === 'ObservationsWithMedia'
+        ? t(m.typeObservationsWithMedia)
+        : t(m.typeTracks);
+
+  return (
+    <View style={styles.container}>
+      <View style={{alignItems: 'center', gap: 30}}>
+        <SuccessIcon />
+        <HeaderText
+          variant="header1"
+          style={{textAlign: 'center', color: BLACK}}>
+          {t(m.title)}
+        </HeaderText>
+
+        <View style={{gap: 10}}>
+          <HeaderText variant="header5" style={{textAlign: 'center'}}>
+            {selectedtype}
+          </HeaderText>
+          <BodyText
+            style={{
+              textAlign: 'center',
+              color: NEW_DARK_GREY,
+              paddingHorizontal: 20,
+            }}>
+            {t(m.exportBody)}
+          </BodyText>
+        </View>
+      </View>
+
+      <View>
+        <SecondaryButton
+          fullSize
+          text={t(m.done)}
+          onPress={() => navigation.goBack()}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+    paddingTop: 80,
+    alignItems: 'center',
+    height: '100%',
+    justifyContent: 'space-between',
+  },
+});

--- a/src/frontend/screens/ExportSuccess.tsx
+++ b/src/frontend/screens/ExportSuccess.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
-import {defineMessages, useIntl} from 'react-intl';
+import {defineMessages, FormattedMessage, useIntl} from 'react-intl';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {BodyText} from '../sharedComponents/Text/BodyText';
 import {SecondaryButton} from '../sharedComponents/Buttons';
@@ -10,21 +10,22 @@ import {BLACK, NEW_DARK_GREY} from '../lib/styles';
 import {type Exports} from './ExportObservations';
 
 const m = defineMessages({
-  title: {id: 'Export.Success.title', defaultMessage: 'Success!'},
-  exportBody: {
-    id: 'Export.Success.exportBody',
-    defaultMessage: 'have been downloaded to your device.',
+  title: {id: 'ExportSuccess.title', defaultMessage: 'Success!'},
+  obs: {
+    id: 'ExportSuccess.obs',
+    defaultMessage:
+      '<bold>All observations</bold> have been downloaded to your device.',
   },
-  done: {id: 'Export.Success.done', defaultMessage: 'Done'},
-  typeObservations: {
-    id: 'Export.Success.typeObservations',
-    defaultMessage: 'All Observations',
+  obsMedia: {
+    id: 'ExportSuccess.obsMedia',
+    defaultMessage:
+      '<bold>All observations with media</bold> have been downloaded to your device.',
   },
-  typeObservationsWithMedia: {
-    id: 'Export.Success.typeObservationsWithMedia',
-    defaultMessage: 'All Observations with Media',
+  tracks: {
+    id: 'ExportSuccess.tracks',
+    defaultMessage: '<bold>Tracks</bold> have been downloaded to your device.',
   },
-  typeTracks: {id: 'Export.Success.typeTracks', defaultMessage: 'Tracks'},
+  done: {id: 'ExportSuccess.done', defaultMessage: 'Done'},
 });
 
 export type ExportSuccessParams = {exportType: Exports};
@@ -36,12 +37,12 @@ export const ExportSuccess = ({
   const {formatMessage: t} = useIntl();
   const {exportType} = route.params;
 
-  const selectedtype =
+  const bodyMsg =
     exportType === 'Observation'
-      ? t(m.typeObservations)
+      ? m.obs
       : exportType === 'ObservationsWithMedia'
-        ? t(m.typeObservationsWithMedia)
-        : t(m.typeTracks);
+        ? m.obsMedia
+        : m.tracks;
 
   return (
     <View style={styles.container}>
@@ -53,19 +54,22 @@ export const ExportSuccess = ({
           {t(m.title)}
         </HeaderText>
 
-        <View style={{gap: 10}}>
-          <HeaderText variant="header5" style={{textAlign: 'center'}}>
-            {selectedtype}
-          </HeaderText>
-          <BodyText
-            style={{
-              textAlign: 'center',
-              color: NEW_DARK_GREY,
-              paddingHorizontal: 20,
-            }}>
-            {t(m.exportBody)}
-          </BodyText>
-        </View>
+        <BodyText
+          style={{
+            textAlign: 'center',
+            color: NEW_DARK_GREY,
+            lineHeight: 30,
+            paddingHorizontal: 10,
+          }}>
+          <FormattedMessage
+            {...bodyMsg}
+            values={{
+              bold: (chunks: React.ReactNode) => (
+                <HeaderText variant="header5">{chunks}</HeaderText>
+              ),
+            }}
+          />
+        </BodyText>
       </View>
 
       <View>

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -11,6 +11,7 @@ import {
   SavedPhoto,
 } from '../contexts/PhotoPromiseContext/types';
 import {Audio} from 'expo-av';
+import {Exports} from '../screens/ExportObservations';
 
 export interface TabBarIconProps {
   size: number;
@@ -146,6 +147,7 @@ export type RootStackParamsList = {
   };
   ExportObservations: undefined;
   DidNotMoveBottomSheet: undefined;
+  ExportSuccess: {exportType: Exports};
 };
 
 export type OnboardingParamsList = {


### PR DESCRIPTION
closes #1376 

This PR adds a success screen after successfully saving whichever kind of data.
The biggest changes I made were because of needing to type the export result.
I navigated to the regular error bottom sheet, but if we want to do something more like the import Map Error Bottom Sheet, I can amend the PR.

Sorry about the flash on the Observations List before going to the Success Screen. I don't know how to prevent that and would love to hear suggestions.

https://github.com/user-attachments/assets/77aea3c2-6f24-4681-939d-25f0a94f2355


