### PR TITLE
fix: Fix inifinite loop in messagePort.removeEventListener()

### DIFF
--- a/src/backend/src/message-port-like.js
+++ b/src/backend/src/message-port-like.js
@@ -85,7 +85,7 @@ class MessagePortLike extends TypedEmitter {
    * @param {any} listener
    */
   removeEventListener(event, listener) {
-    this.removeEventListener(event, listener)
+    this.removeListener(event, listener)
   }
 }
 


### PR DESCRIPTION
I don't _think_ any of our code currently calls `removeEventListener` in the backend MessagePortLike, but calling it would have been bad.