### PR TITLE
fix: fix query key for useGetCustomMapInfo

### DIFF
--- a/src/frontend/hooks/server/maps.ts
+++ b/src/frontend/hooks/server/maps.ts
@@ -123,7 +123,7 @@ export function useGetCustomMapInfo() {
   const {data: styleUrl} = useMapStyleJsonUrl();
 
   return useQuery({
-    queryKey: [getMapsQueryKey, 'custom', 'info', {styleUrl}],
+    queryKey: [...getMapsQueryKey(), 'custom', 'info', {styleUrl}],
     queryFn: async () => {
       const response = await fetchCustomMapInfo(styleUrl);
 


### PR DESCRIPTION
`getMapsQueryKey` is a function that returns the base key as an array so in order to build other query keys on top of it, it needs to be called and flattened.