### PR TITLE
fix: fix sqlite prebuilds for x86

### DIFF
--- a/app.json
+++ b/app.json
@@ -81,7 +81,6 @@
         }
       ],
       ["./expo-config-plugins/removeExpoInputStyles.js"],
-      ["./expo-config-plugins/targetArmArchsOnly.js"],
       ["./expo-config-plugins/increaseJavaMemory.js"],
       ["./expo-config-plugins/flagSecure"],
       ["./expo-config-plugins/customPermissionText.js"],

--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -35,9 +35,15 @@ export async function downloadPrebuilds(modules, {verbose} = {verbose: false}) {
 
           fs.mkdirSync(targetDir, {recursive: true});
 
+          /** TEMPORARY FIX: bare-make builds are tagged with `-bare-make` to
+           * avoid conflicts with our current releases built with node-gyp */
+          const releaseTag =
+            name === 'better-sqlite3' ? `${version}-bare-make` : version;
+
           const artifactInfo = getArtifactInfo({
             name,
             version,
+            releaseTag,
             target,
             nodeAbi: usesNapi ? undefined : NODE_ABI,
           });
@@ -56,10 +62,12 @@ export async function downloadPrebuilds(modules, {verbose} = {verbose: false}) {
 
           fs.unlinkSync(path.join(targetDir, artifactInfo.name));
 
-          // better-sqlite3 includes an additional native module for testing purposes
-          // removing since it's not needed and also causes issues with nodejs-mobile-react-native
+          // better-sqlite3 bare-make builds are named better-sqlite3.node, but the module expects better_sqlite3.node
           if (name === 'better-sqlite3') {
-            fs.unlinkSync(path.join(targetDir, 'test_extension.node'));
+            fs.renameSync(
+              path.join(targetDir, 'better-sqlite3.node'),
+              path.join(targetDir, 'better_sqlite3.node'),
+            );
           }
 
           if (verbose) {
@@ -97,16 +105,16 @@ function getNodeJsMobileNodeVersions() {
 }
 
 /**
- * @param {{name: string, version: string, target: string, nodeAbi?: string}} opts
+ * @param {{name: string, version: string, releaseTag: string, target: string, nodeAbi?: string}} opts
  * @returns {{name: string, url: string}}
  */
-function getArtifactInfo({name, version, target, nodeAbi}) {
+function getArtifactInfo({name, version, releaseTag, target, nodeAbi}) {
   const assetName = nodeAbi
     ? `${name}-${version}-node-${nodeAbi}-${target}.tar.gz`
     : `${name}-${version}-${target}.tar.gz`;
 
   return {
     name,
-    url: `https://github.com/digidem/${name}-nodejs-mobile/releases/download/${version}/${assetName}`,
+    url: `https://github.com/digidem/${name}-nodejs-mobile/releases/download/${releaseTag}/${assetName}`,
   };
 }


### PR DESCRIPTION
This switches the prebuilds of better-sqlite3 to ones built with bare-make toolchain, instead of the previous node-gyp build. This seems to fix running the app on x86 architecture (previously the x86 builds of better-sqlite3 crashed the app).

The builds are generated by the updated workflow in https://github.com/digidem/better-sqlite3-nodejs-mobile/pull/5, which was run manually with v11.10.0 of better-sqlite3 and the `11.10.0-bare-make` release tag, so that the release would not conflict with the current node-gyp version we are using.

The question remains about how to actually build this for dev using an x86 emulator. Currently I have just enabled building APKs for all architectures, but this increases the APK size significantly. Looking for input on how to only enable x86_64 arch for local dev builds, and keep production apks to arm-only.