### PR TITLE
WIP: indexing in worker

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@comapeo/core": "4.3.0",
+        "@comapeo/core": "github:digidem/comapeo-core#feat/worker-indexing",
         "@comapeo/ipc": "5.0.0",
         "@mapeo/default-config": "5.0.0",
         "@sentry/node": "9.28.0",
@@ -303,12 +303,11 @@
     },
     "node_modules/@comapeo/core": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-4.3.0.tgz",
-      "integrity": "sha512-fVdUNLhscIuU8XfV6zxC+6A8U1o7mlosN//bSB/O52Oangn9U5MCoPCwwJDNhs0Y9p3eYWyC4eLHodwKdif7VA==",
+      "resolved": "git+ssh://git@github.com/digidem/comapeo-core.git#9cdc678fbc84b689a02c3a133cc76315862262ea",
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "^2.1.1",
+        "@comapeo/schema": "2.1.1",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -13,7 +13,7 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "dependencies": {
-    "@comapeo/core": "4.3.0",
+    "@comapeo/core": "github:digidem/comapeo-core#feat/worker-indexing",
     "@comapeo/ipc": "5.0.0",
     "@mapeo/default-config": "5.0.0",
     "@sentry/node": "9.28.0",

--- a/src/backend/patches/@comapeo+core+4.3.0.patch
+++ b/src/backend/patches/@comapeo+core+4.3.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@comapeo/core/src/index-writer/index-worker.js b/node_modules/@comapeo/core/src/index-writer/index-worker.js
+index 77c57ce..b9b071b 100644
+--- a/node_modules/@comapeo/core/src/index-writer/index-worker.js
++++ b/node_modules/@comapeo/core/src/index-writer/index-worker.js
+@@ -6,6 +6,8 @@ import Database from 'better-sqlite3'
+ 
+ /** @import {WorkerRequest, BatchRequestData, DeleteSchemaRequestData, BatchResponseData, DeleteSchemaResponseData, WorkerData, WorkerResponse} from './index-writer-proxy.js' */
+ 
++console.log("IN WORKER")
++
+ const { schemas, dbPath, parentLoggerNamespace, deviceId } =
+   /** @type {WorkerData} */ (workerData)
+ 

--- a/src/backend/rollup.config.js
+++ b/src/backend/rollup.config.js
@@ -56,6 +56,9 @@ const config = {
   input: {
     index: path.join(__dirname, 'index.js'),
     loader: path.join(__dirname, 'loader.js'),
+    'index-worker': require.resolve(
+      '@comapeo/core/src/index-writer/index-worker.js',
+    ),
     // This is a [module loading hook]
     // (https://nodejs.org/api/module.html#customization-hooks) used by
     // OpenTelemetry (which is used by Sentry) to install instrumentation. It is

--- a/src/backend/src/app.js
+++ b/src/backend/src/app.js
@@ -88,6 +88,7 @@ export async function init({
     defaultIsArchiveDevice: false,
     defaultOnlineStyleUrl: DEFAULT_ONLINE_MAP_STYLE_URL,
     customMapPath: join(customMapsDir, DEFAULT_CUSTOM_MAP_FILE_NAME),
+    useIndexWorkers: true,
   })
 
   // Don't await, methods that use the server will await this internally


### PR DESCRIPTION
Updates rollup config to bundle the index worker, and adds the `useIndexWorker: true` opt to CoMapeoManager.

Verified on a device by:

1. Adding a `console.log("IN WORKER")` to the worker, and verifying it in adb logcat.
2. Tested creating a new project and creating an observation on the device.

To finialize this PR:

- [ ] Publish new core with index worker and update here
- [ ] Remove patch (just adds console.log)
