### PR TITLE
fix: comapeo-metrics-url as variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,5 @@ jobs:
         run: npm run test:jest
         env:
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          COMAPEO_METRICS_URL: ${{ secrets.COMAPEO_METRICS_URL }}
+          COMAPEO_METRICS_URL: ${{ vars.COMAPEO_METRICS_URL }}
           COMAPEO_METRICS_API_KEY: ${{ secrets.COMAPEO_METRICS_API_KEY }}

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -70,7 +70,7 @@ jobs:
           SENTRY_DISABLE_AUTO_UPLOAD: 'true'
           EXPO_PUBLIC_E2E_TEST: 'true'
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          COMAPEO_METRICS_URL: ${{ secrets.COMAPEO_METRICS_URL }}
+          COMAPEO_METRICS_URL: ${{ vars.COMAPEO_METRICS_URL }}
           COMAPEO_METRICS_API_KEY: ${{ secrets.COMAPEO_METRICS_API_KEY }}
         run: |
           npm run extract-messages


### PR DESCRIPTION
Gregor (I think) changed the location of the COMAPEO_METRICS_URL when he updated its value.
This PR changes the prefix to be for variable not for the secret to reflect where it lives in github.
Without this change, CI and E2E fail right away.