### PR TITLE
chore: order default presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,5 @@ jobs:
         run: npm run test:jest
         env:
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          COMAPEO_METRICS_URL: ${{ secrets.COMAPEO_METRICS_URL }}
+          COMAPEO_METRICS_URL: ${{ vars.COMAPEO_METRICS_URL }}
           COMAPEO_METRICS_API_KEY: ${{ secrets.COMAPEO_METRICS_API_KEY }}

--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -70,7 +70,7 @@ jobs:
           SENTRY_DISABLE_AUTO_UPLOAD: 'true'
           EXPO_PUBLIC_E2E_TEST: 'true'
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          COMAPEO_METRICS_URL: ${{ secrets.COMAPEO_METRICS_URL }}
+          COMAPEO_METRICS_URL: ${{ vars.COMAPEO_METRICS_URL }}
           COMAPEO_METRICS_API_KEY: ${{ secrets.COMAPEO_METRICS_API_KEY }}
         run: |
           npm run extract-messages

--- a/src/frontend/lib/orderPresets.test.ts
+++ b/src/frontend/lib/orderPresets.test.ts
@@ -1,0 +1,124 @@
+import {orderPresets} from './orderPresets';
+import type {Preset, ProjectSettings} from '@comapeo/schema';
+
+function makePreset(
+  docId: string,
+  name: string,
+  geometry: Array<'point' | 'line'>,
+): Preset {
+  return {docId, name, geometry} as unknown as Preset;
+}
+
+function settingsWith(overrides: Partial<ProjectSettings['defaultPresets']>) {
+  const base: ProjectSettings['defaultPresets'] = {
+    point: [],
+    line: [],
+    area: [],
+    vertex: [],
+    relation: [],
+  };
+  return {defaultPresets: {...base, ...overrides}};
+}
+
+describe('orderPresets', () => {
+  const allPresets: Preset[] = [
+    makePreset('a', 'Alpha', ['point']),
+    makePreset('b', 'beta', ['point']),
+    makePreset('c', 'Charlie', ['point']),
+    makePreset('l1', 'Line One', ['line']),
+    makePreset('l2', 'Line Two', ['line']),
+    makePreset('both-1', 'Both One', ['point', 'line']),
+  ];
+
+  describe('geometry is point (observations)', () => {
+    it('uses defaultPresets.point order when provided', () => {
+      const settings = settingsWith({point: ['c', 'a', 'both-1']});
+      const result = orderPresets({
+        allPresets,
+        settings,
+        geometry: 'point',
+      });
+
+      expect(result.map(r => r.docId)).toEqual(['c', 'a', 'both-1']);
+    });
+
+    it('falls back to alphabetical when defaultPresets.point is empty', () => {
+      const settings = settingsWith({point: []});
+      const result = orderPresets({
+        allPresets,
+        settings,
+        geometry: 'point',
+      });
+
+      expect(result.map(r => r.name)).toEqual([
+        'Alpha',
+        'beta',
+        'Both One',
+        'Charlie',
+      ]);
+    });
+
+    it('falls back to alphabetical when defaultPresets is missing', () => {
+      const result = orderPresets({
+        allPresets,
+        settings: null,
+        geometry: 'point',
+      });
+      expect(result.map(r => r.name)).toEqual([
+        'Alpha',
+        'beta',
+        'Both One',
+        'Charlie',
+      ]);
+    });
+
+    it('ignores unknown IDs; if none match, falls back to alphabetical', () => {
+      const settingsNoMatches = settingsWith({point: ['zzz']});
+      const resultNoMatches = orderPresets({
+        allPresets,
+        settings: settingsNoMatches,
+        geometry: 'point',
+      });
+      expect(resultNoMatches.map(r => r.name)).toEqual([
+        'Alpha',
+        'beta',
+        'Both One',
+        'Charlie',
+      ]);
+
+      const settingsSomeMatches = settingsWith({point: ['zzz', 'b']});
+      const resultSomeMatches = orderPresets({
+        allPresets,
+        settings: settingsSomeMatches,
+        geometry: 'point',
+      });
+      expect(resultSomeMatches.map(r => r.docId)).toEqual(['b']);
+    });
+  });
+
+  describe('geometry is line (tracks)', () => {
+    it('uses defaultPresets.line order when provided', () => {
+      const settings = settingsWith({line: ['l2', 'both-1']});
+      const result = orderPresets({
+        allPresets,
+        settings,
+        geometry: 'line',
+      });
+      expect(result.map(r => r.docId)).toEqual(['l2', 'both-1']);
+    });
+
+    it('falls back to alphabetical for line when defaultPresets.line empty', () => {
+      const settings = settingsWith({line: []});
+      const result = orderPresets({
+        allPresets,
+        settings,
+        geometry: 'line',
+      });
+      expect(result.map(r => r.name)).toEqual([
+        'Both One',
+        'Line One',
+        'Line Two',
+      ]);
+    });
+  });
+});

--- a/src/frontend/lib/orderPresets.ts
+++ b/src/frontend/lib/orderPresets.ts
@@ -1,0 +1,35 @@
+import {Preset, ProjectSettings} from '@comapeo/schema';
+
+type Geometry = 'point' | 'line';
+
+export function orderPresets(opts: {
+  allPresets: Preset[];
+  settings?: Pick<ProjectSettings, 'defaultPresets'> | null;
+  geometry: Geometry;
+}): Preset[] {
+  const {allPresets, settings, geometry} = opts;
+
+  const byGeometry = allPresets.filter(p => p.geometry.includes(geometry));
+
+  const alphaSorted = [...byGeometry].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+  );
+
+  const defaultPresetsExist =
+    settings?.defaultPresets?.[geometry] &&
+    settings.defaultPresets[geometry].length > 0
+      ? settings.defaultPresets[geometry]
+      : null;
+
+  if (!defaultPresetsExist) return alphaSorted;
+
+  const byDefaultPreset = new Map(byGeometry.map(p => [p.docId, p]));
+
+  const orderedByDefaultPresets = defaultPresetsExist
+    .map(id => byDefaultPreset.get(id))
+    .filter((p): p is Preset => Boolean(p));
+
+  return orderedByDefaultPresets.length > 0
+    ? orderedByDefaultPresets
+    : alphaSorted;
+}

--- a/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
@@ -10,6 +10,9 @@ import {WHITE} from '../../lib/styles';
 import {CustomHeaderLeftClose} from '../../sharedComponents/CustomHeaderLeftClose';
 import {Preset} from '@comapeo/schema';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useProjectSettings} from '@comapeo/core-react';
+import {orderPresets} from '../../lib/orderPresets';
 
 const m = defineMessages({
   title: {
@@ -21,16 +24,20 @@ const m = defineMessages({
 export const ObservationCategoryChooser: NativeNavigationComponent<
   'ObservationCategoryChooser'
 > = ({navigation}) => {
+  const {projectId} = useActiveProject();
   const {data: presets} = usePresetsQuery();
   const {updatePreset, usePreset} = useDraftObservation();
+  const {data: settings} = useProjectSettings({projectId});
   const observationId = usePersistedDraftObservation(
     state => state.observationId,
   );
   const currentPreset = usePreset();
 
-  const filteredPresets = Array.from(presets)
-    .filter(p => p.geometry.includes('point'))
-    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  const filteredPresets = orderPresets({
+    allPresets: Array.from(presets),
+    settings,
+    geometry: 'point',
+  });
 
   const handleSelect = (preset: Preset) => {
     updatePreset(preset);

--- a/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
@@ -9,6 +9,9 @@ import {WHITE} from '../../lib/styles';
 import {HeaderLeft} from '../SaveTrack/HeaderLeft';
 import {Preset} from '@comapeo/schema';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useProjectSettings} from '@comapeo/core-react';
+import {orderPresets} from '../../lib/orderPresets';
 
 const m = defineMessages({
   title: {
@@ -22,9 +25,13 @@ export const TrackCategoryChooser: NativeNavigationComponent<
 > = ({navigation}) => {
   const {data: presets} = usePresetsQuery();
   const {setTrackPreset} = useTrackActions();
-  const trackPresets = Array.from(presets)
-    .filter(p => p.geometry.includes('line'))
-    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  const {projectId} = useActiveProject();
+  const {data: settings} = useProjectSettings({projectId});
+  const trackPresets = orderPresets({
+    allPresets: Array.from(presets),
+    settings,
+    geometry: 'line',
+  });
   const existingPreset = useTrackState(state => state.preset);
   const trackId = useTrackState(state => state.docId);
 


### PR DESCRIPTION
closes #1389 

This PR uses the default presets order set in the project settings for ordering the presets for Observations. Currently, they are just put in alphabetical order, but that is not the desired behavior. Also works for Tracks.

To me it made sense to do this in comapeo-mobile, not core, because 
1. Hooks and props should be agnostic; this ordering is UI/presentation logic.
2. It’s derived state (presets + settings → ordered list) and should be calculated when it is needed.
3. Keeps core’s data hooks lean instead of having the two-query coupling
But I could not remember if it was imperative to do this work in comapeo/core-react

It is used in the category choosers.
It has a fallback for Alpha sorting.

I added a jest test for various scenarios as this cannot be tested with E2E.
