### PR TITLE
chore: refactor create observation screen

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1245,6 +1245,34 @@
   "screens.ObservationCategoryChooser.title": {
     "message": "Choose a category"
   },
+  "screens.ObservationCreate.SaveButton.keepWaiting": {
+    "description": "Button to cancel save and continue waiting for GPS",
+    "message": "Continue waiting"
+  },
+  "screens.ObservationCreate.SaveButton.manualEntry": {
+    "description": "Button to manually enter GPS coordinates",
+    "message": "Manual Coords"
+  },
+  "screens.ObservationCreate.SaveButton.noGpsDesc": {
+    "description": "Description in dialog when trying to save with no GPS coords",
+    "message": "This observation does not have a location. You can continue waiting for a GPS signal, save the observation without a location, or enter coordinates manually"
+  },
+  "screens.ObservationCreate.SaveButton.noGpsTitle": {
+    "description": "Title of dialog when trying to save with no GPS coords",
+    "message": "No GPS signal"
+  },
+  "screens.ObservationCreate.SaveButton.saveAnyway": {
+    "description": "Button to save regardless of GPS state",
+    "message": "Save"
+  },
+  "screens.ObservationCreate.SaveButton.weakGpsDesc": {
+    "description": "Description in dialog when trying to save with low GPS accuracy.",
+    "message": "GPS accuracy is low. You can continue waiting for better accuracy, save the observation with low accuracy, or enter coordinates manually"
+  },
+  "screens.ObservationCreate.SaveButton.weakGpsTitle": {
+    "description": "Title of dialog when trying to save with low GPS accuracy.",
+    "message": "Weak GPS signal"
+  },
   "screens.ObservationCreate.changePreset": {
     "message": "Change"
   },
@@ -1252,41 +1280,13 @@
     "description": "Placeholder for description/notes field",
     "message": "What is happening here?"
   },
-  "screens.ObservationCreate.keepWaiting": {
-    "description": "Button to cancel save and continue waiting for GPS",
-    "message": "Continue waiting"
-  },
-  "screens.ObservationCreate.manualEntry": {
-    "description": "Button to manually enter GPS coordinates",
-    "message": "Manual Coords"
-  },
   "screens.ObservationCreate.navTitle": {
     "description": "screen title for new observation screen",
     "message": "New Observation"
   },
-  "screens.ObservationCreate.noGpsDesc": {
-    "description": "Description in dialog when trying to save with no GPS coords",
-    "message": "This observation does not have a location. You can continue waiting for a GPS signal, save the observation without a location, or enter coordinates manually"
-  },
-  "screens.ObservationCreate.noGpsTitle": {
-    "description": "Title of dialog when trying to save with no GPS coords",
-    "message": "No GPS signal"
-  },
   "screens.ObservationCreate.observation": {
     "description": "Default name of observation with no matching preset",
     "message": "Observation"
-  },
-  "screens.ObservationCreate.saveAnyway": {
-    "description": "Button to save regardless of GPS state",
-    "message": "Save"
-  },
-  "screens.ObservationCreate.weakGpsDesc": {
-    "description": "Description in dialog when trying to save with low GPS accuracy.",
-    "message": "GPS accuracy is low. You can continue waiting for better accuracy, save the observation with low accuracy, or enter coordinates manually"
-  },
-  "screens.ObservationCreate.weakGpsTitle": {
-    "description": "Title of dialog when trying to save with low GPS accuracy.",
-    "message": "Weak GPS signal"
   },
   "screens.ObservationDetails.done": {
     "description": "Button text when all questions are complete",

--- a/src/frontend/screens/ObservationCreate/LiveLocationView.tsx
+++ b/src/frontend/screens/ObservationCreate/LiveLocationView.tsx
@@ -1,0 +1,22 @@
+import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
+import {Divider} from '../../sharedComponents/Divider';
+import {LocationView} from '../../sharedComponents/Editor/LocationView';
+import {useMostAccurateLocationForObservation} from './useMostAccurateLocationForObservation';
+
+export const LiveLocationView = () => {
+  useMostAccurateLocationForObservation();
+  const position = usePersistedDraftObservation(
+    store => store.value?.metadata?.position,
+  );
+
+  return position ? (
+    <>
+      <Divider />
+      <LocationView
+        lat={position?.coords?.latitude}
+        lon={position?.coords?.longitude}
+        accuracy={position?.coords?.accuracy}
+      />
+    </>
+  ) : null;
+};

--- a/src/frontend/screens/ObservationCreate/LiveLocationView.tsx
+++ b/src/frontend/screens/ObservationCreate/LiveLocationView.tsx
@@ -5,18 +5,16 @@ import {useMostAccurateLocationForObservation} from './useMostAccurateLocationFo
 
 export const LiveLocationView = () => {
   useMostAccurateLocationForObservation();
-  const position = usePersistedDraftObservation(
-    store => store.value?.metadata?.position,
+  const lat = usePersistedDraftObservation(store => store.value?.lat);
+  const lon = usePersistedDraftObservation(store => store.value?.lon);
+  const accuracy = usePersistedDraftObservation(
+    store => store.value?.metadata?.position?.coords.accuracy,
   );
 
-  return position ? (
+  return lat && lon ? (
     <>
       <Divider />
-      <LocationView
-        lat={position?.coords?.latitude}
-        lon={position?.coords?.longitude}
-        accuracy={position?.coords?.accuracy}
-      />
+      <LocationView lat={lat} lon={lon} accuracy={accuracy} />
     </>
   ) : null;
 };

--- a/src/frontend/screens/ObservationCreate/ObservationCreateSaveButton.tsx
+++ b/src/frontend/screens/ObservationCreate/ObservationCreateSaveButton.tsx
@@ -1,0 +1,259 @@
+import {useCreateDocument} from '@comapeo/core-react';
+import {Observation} from '@comapeo/schema';
+import {useAuthContext} from '../../contexts/AuthContext';
+import {
+  usePersistedDraftObservation,
+  usePreset,
+} from '../../hooks/persistedState/usePersistedDraftObservation';
+import {
+  useCreatePhotoAttachment,
+  useCreateAudioAttachment,
+} from '../../hooks/server/media';
+import {useDraftObservation} from '../../hooks/useDraftObservation';
+import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
+import {STORAGE_QUERY_KEY} from '../../hooks/useStorageReadingQuery';
+import SaveCheck from '../../images/CheckMark.svg';
+import {
+  isProcessedDraftPhoto,
+  isUnsavedAudio,
+} from '../../lib/attachmentTypeChecks';
+import {IconButton} from '../../sharedComponents/IconButton';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {
+  Attachment,
+  ClientGeneratedObservation,
+  Position,
+} from '../../sharedTypes';
+import * as Sentry from '@sentry/react-native';
+import {useTrackActions, useTrackState} from '../../contexts/TrackStoreContext';
+import {Alert, AlertButton, View} from 'react-native';
+import {UIActivityIndicator} from 'react-native-indicators';
+import {useQueryClient} from '@tanstack/react-query';
+import {defineMessages, useIntl} from 'react-intl';
+
+const MAXIMUM_ACCURACY = 10;
+
+const m = defineMessages({
+  noGpsTitle: {
+    id: 'screens.ObservationCreate.SaveButton.noGpsTitle',
+    defaultMessage: 'No GPS signal',
+    description: 'Title of dialog when trying to save with no GPS coords',
+  },
+  noGpsDesc: {
+    id: 'screens.ObservationCreate.SaveButton.noGpsDesc',
+    defaultMessage:
+      'This observation does not have a location. You can continue waiting for a GPS signal, save the observation without a location, or enter coordinates manually',
+    description: 'Description in dialog when trying to save with no GPS coords',
+  },
+  weakGpsTitle: {
+    id: 'screens.ObservationCreate.SaveButton.weakGpsTitle',
+    defaultMessage: 'Weak GPS signal',
+    description: 'Title of dialog when trying to save with low GPS accuracy.',
+  },
+  weakGpsDesc: {
+    id: 'screens.ObservationCreate.SaveButton.weakGpsDesc',
+    defaultMessage:
+      'GPS accuracy is low. You can continue waiting for better accuracy, save the observation with low accuracy, or enter coordinates manually',
+    description:
+      'Description in dialog when trying to save with low GPS accuracy.',
+  },
+  saveAnyway: {
+    id: 'screens.ObservationCreate.SaveButton.saveAnyway',
+    defaultMessage: 'Save',
+    description: 'Button to save regardless of GPS state',
+  },
+  manualEntry: {
+    id: 'screens.ObservationCreate.SaveButton.manualEntry',
+    defaultMessage: 'Manual Coords',
+    description: 'Button to manually enter GPS coordinates',
+  },
+  keepWaiting: {
+    id: 'screens.ObservationCreate.SaveButton.keepWaiting',
+    defaultMessage: 'Continue waiting',
+    description: 'Button to cancel save and continue waiting for GPS',
+  },
+});
+
+export const ObservationCreateSaveButton = () => {
+  const value = usePersistedDraftObservation(store => store.value);
+  const attachments = usePersistedDraftObservation(store => store.attachments);
+  const {authState} = useAuthContext();
+  const {clearDraft} = useDraftObservation();
+  const navigation = useNavigationFromRoot();
+  const {projectId} = useActiveProject();
+  const isTracking = useTrackState(state => state.isTracking);
+  const preset = usePreset();
+  const queryClient = useQueryClient();
+  const {formatMessage} = useIntl();
+
+  const {
+    mutateAsync: createPhotoAttachmentAsync,
+    status: photoAttachmentStatus,
+  } = useCreatePhotoAttachment({projectId});
+
+  const {
+    mutateAsync: createAudioAttachmentAsync,
+    status: audioAttachmentStatus,
+  } = useCreateAudioAttachment({projectId});
+
+  const {mutateAsync: createObservationAsync, status: observationStatus} =
+    useCreateDocument({
+      docType: 'observation',
+      projectId,
+    });
+
+  const {
+    addNewLocations: addNewTrackLocations,
+    addNewObservation: addNewTrackObservation,
+  } = useTrackActions();
+
+  const isLoading =
+    photoAttachmentStatus === 'pending' ||
+    audioAttachmentStatus === 'pending' ||
+    observationStatus === 'pending';
+
+  const finalizeSave = () => {
+    queryClient.invalidateQueries({queryKey: STORAGE_QUERY_KEY});
+    clearDraft();
+    navigation.popTo('Home', {screen: 'Map'});
+  };
+
+  const addObservationRefToTrack = (observation: Observation) => {
+    if (observation.lat && observation.lon) {
+      addNewTrackLocations([
+        {
+          timestamp: Date.now(),
+          latitude: observation.lat,
+          longitude: observation.lon,
+        },
+      ]);
+    }
+    addNewTrackObservation({
+      docId: observation.docId,
+      versionId: observation.versionId,
+    });
+  };
+
+  function checkAccuracyAndLocation(
+    position: Position | undefined,
+  ): 'low' | 'noPosition' | 'satisfactory' {
+    if (!position) {
+      return 'noPosition';
+    }
+
+    const accuracy = position.coords.accuracy;
+
+    if (!accuracy || accuracy >= MAXIMUM_ACCURACY) {
+      return 'low';
+    }
+
+    return 'satisfactory';
+  }
+
+  async function saveObservation(value: ClientGeneratedObservation) {
+    if (authState === 'obscured') {
+      clearDraft();
+      navigation.popTo('Home', {screen: 'Map'});
+      return;
+    }
+
+    const unsavedPhotos = attachments.filter(isProcessedDraftPhoto);
+    const unsavedAudio = attachments.filter(isUnsavedAudio);
+
+    try {
+      let newAttachments: Attachment[] = [];
+
+      if (unsavedPhotos.length > 0 || unsavedAudio.length > 0) {
+        const photoPromises = unsavedPhotos.map(p =>
+          createPhotoAttachmentAsync(p),
+        );
+        const audioPromises = unsavedAudio.map(a =>
+          createAudioAttachmentAsync(a),
+        );
+        newAttachments = await Promise.all([
+          ...photoPromises,
+          ...audioPromises,
+        ]);
+      }
+
+      const createdObservation = await createObservationAsync({
+        value: {
+          ...value,
+          attachments: [...value.attachments, ...newAttachments],
+          presetRef: preset
+            ? {docId: preset.docId, versionId: preset.versionId}
+            : undefined,
+        },
+      });
+
+      if (isTracking) {
+        addObservationRefToTrack(createdObservation);
+      }
+
+      finalizeSave();
+    } catch (err) {
+      Sentry.captureException(err);
+      navigation.navigate('ErrorBottomSheet');
+    }
+  }
+
+  function handlePressSave() {
+    if (!value) throw new Error('No observation saved in persisted state');
+
+    if (value.metadata?.manualLocation) {
+      saveObservation(value);
+      return;
+    }
+
+    const accuracy = checkAccuracyAndLocation(value.metadata?.position);
+
+    if (accuracy === 'satisfactory') {
+      saveObservation(value);
+      return;
+    }
+
+    const confirmationOptions: AlertButton[] = [
+      {
+        text: formatMessage(m.saveAnyway),
+        onPress: () => saveObservation(value),
+        style: 'default',
+      },
+      {
+        text: formatMessage(m.manualEntry),
+        onPress: () => navigation.navigate('ManualGpsScreen'),
+        style: 'cancel',
+      },
+      {
+        text: formatMessage(m.keepWaiting),
+        onPress: () => {},
+      },
+    ];
+
+    if (accuracy === 'noPosition') {
+      Alert.alert(
+        formatMessage(m.noGpsTitle),
+        formatMessage(m.noGpsDesc),
+        confirmationOptions,
+      );
+      return;
+    }
+
+    if (accuracy === 'low') {
+      Alert.alert(
+        formatMessage(m.weakGpsTitle),
+        formatMessage(m.weakGpsDesc),
+        confirmationOptions,
+      );
+      return;
+    }
+  }
+  return isLoading ? (
+    <View style={{marginRight: 10}}>
+      <UIActivityIndicator size={30} />
+    </View>
+  ) : (
+    <IconButton onPress={handlePressSave} testID="OBS.edit-save-btn">
+      <SaveCheck />
+    </IconButton>
+  );
+};

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -80,7 +80,7 @@ export const ObservationCreate = ({
   return (
     <ScreenContentWithDock
       dockContainerStyle={{padding: 0}}
-      dockContent={<ActionsRow />}>
+      dockContent={<ActionsRow fieldRefs={preset?.fieldRefs} />}>
       <View style={styles.container}>
         <View
           style={{
@@ -98,6 +98,9 @@ export const ObservationCreate = ({
           </HeaderText>
         </View>
         <PresetView
+          onPressPreset={() =>
+            navigation.navigate('ObservationCategoryChooser')
+          }
           PresetIcon={
             <PresetCircleIcon
               size="medium"

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -1,33 +1,39 @@
 import * as React from 'react';
 import {useDraftObservation} from '../../hooks/useDraftObservation';
 import {MessageDescriptor, defineMessages, useIntl} from 'react-intl';
-import {Editor} from '../../sharedComponents/Editor';
 import {PresetCircleIcon} from '../../sharedComponents/icons/PresetIcon';
 import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
-import {useCreateDocument} from '@comapeo/core-react';
-import {SaveButton} from '../../sharedComponents/SaveButton';
-import {useMostAccurateLocationForObservation} from './useMostAccurateLocationForObservation';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import {HeaderLeft} from './HeaderLeft';
 import {ActionsRow} from '../../sharedComponents/ActionsRow';
-import {Alert, type AlertButton} from 'react-native';
-import {Observation} from '@comapeo/schema';
+import {ObservationCreateSaveButton} from './ObservationCreateSaveButton';
+import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
+import {StyleSheet, View} from 'react-native';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useProjectRoleAndDetails} from '../../hooks/useProjectRoleAndDetails';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {PresetView} from '../../sharedComponents/Editor/PresetView';
+import {DescriptionField} from '../../sharedComponents/Editor/DescriptionField';
+import {HorizontalScrollView} from '../../sharedComponents/HorizontalScrollView';
 import {
-  useCreateAudioAttachment,
-  useCreatePhotoAttachment,
-} from '../../hooks/server/media';
-import * as Sentry from '@sentry/react-native';
-
-import {useTrackActions, useTrackState} from '../../contexts/TrackStoreContext';
+  GAP,
+  MIN_WIDTH,
+  ThumbnailContainer,
+  ThumbnailLoader,
+} from '../../sharedComponents/Thumbnails/ThumbnailContainer';
 import {
-  isProcessedDraftPhoto,
+  isDraftPhoto,
+  isUnprocessedDraftPhoto,
   isUnsavedAudio,
 } from '../../lib/attachmentTypeChecks';
-import {useAuthContext} from '../../contexts/AuthContext';
-import {useQueryClient} from '@tanstack/react-query';
-import {STORAGE_QUERY_KEY} from '../../hooks/useStorageReadingQuery';
+import {ThumbnailImage} from '../../sharedComponents/Thumbnails/PhotoThumbnail';
+import {COMAPEO_BLUE, DARK_GREY, LIGHT_GREY, WHITE} from '../../lib/styles';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
+import {millisecondsToMMSS} from '../../lib/millisecondsToFormattedTime';
+import {DateDistance} from '../../sharedComponents/DateDistance';
+import PlayArrow from '../../images/PlayArrow.svg';
+import {LiveLocationView} from './LiveLocationView';
 
 const m = defineMessages({
   observation: {
@@ -49,97 +55,21 @@ const m = defineMessages({
     defaultMessage: 'What is happening here?',
     description: 'Placeholder for description/notes field',
   },
-  noGpsTitle: {
-    id: 'screens.ObservationCreate.noGpsTitle',
-    defaultMessage: 'No GPS signal',
-    description: 'Title of dialog when trying to save with no GPS coords',
-  },
-  noGpsDesc: {
-    id: 'screens.ObservationCreate.noGpsDesc',
-    defaultMessage:
-      'This observation does not have a location. You can continue waiting for a GPS signal, save the observation without a location, or enter coordinates manually',
-    description: 'Description in dialog when trying to save with no GPS coords',
-  },
-  weakGpsTitle: {
-    id: 'screens.ObservationCreate.weakGpsTitle',
-    defaultMessage: 'Weak GPS signal',
-    description: 'Title of dialog when trying to save with low GPS accuracy.',
-  },
-  weakGpsDesc: {
-    id: 'screens.ObservationCreate.weakGpsDesc',
-    defaultMessage:
-      'GPS accuracy is low. You can continue waiting for better accuracy, save the observation with low accuracy, or enter coordinates manually',
-    description:
-      'Description in dialog when trying to save with low GPS accuracy.',
-  },
-  saveAnyway: {
-    id: 'screens.ObservationCreate.saveAnyway',
-    defaultMessage: 'Save',
-    description: 'Button to save regardless of GPS state',
-  },
-  manualEntry: {
-    id: 'screens.ObservationCreate.manualEntry',
-    defaultMessage: 'Manual Coords',
-    description: 'Button to manually enter GPS coordinates',
-  },
-  keepWaiting: {
-    id: 'screens.ObservationCreate.keepWaiting',
-    defaultMessage: 'Continue waiting',
-    description: 'Button to cancel save and continue waiting for GPS',
-  },
 });
-
-const MAXIMUM_ACCURACY = 10;
 
 export const ObservationCreate = ({
   navigation,
 }: NativeRootNavigationProps<'ObservationCreate'>) => {
   const {formatMessage} = useIntl();
-  const {projectId} = useActiveProject();
   const {usePreset} = useDraftObservation();
   const preset = usePreset();
-  const value = usePersistedDraftObservation(store => store.value);
+
   const attachments = usePersistedDraftObservation(store => store.attachments);
-  const {updateTags, clearDraft} = useDraftObservation();
-  const queryClient = useQueryClient();
+  const notes = usePersistedDraftObservation(store => store.value?.tags.notes);
+  const {projectId} = useActiveProject();
+  const projectDetails = useProjectRoleAndDetails(projectId);
+  const {updateTags} = useDraftObservation();
 
-  const {
-    mutateAsync: createPhotoAttachmentAsync,
-    status: photoAttachmentStatus,
-  } = useCreatePhotoAttachment({projectId});
-
-  const {
-    mutateAsync: createAudioAttachmentAsync,
-    status: audioAttachmentStatus,
-  } = useCreateAudioAttachment({projectId});
-
-  const {mutateAsync: createObservationAsync, status: observationStatus} =
-    useCreateDocument({
-      docType: 'observation',
-      projectId,
-    });
-
-  const isTracking = useTrackState(state => state.isTracking);
-  const {
-    addNewLocations: addNewTrackLocations,
-    addNewObservation: addNewTrackObservation,
-  } = useTrackActions();
-  const liveLocation = useMostAccurateLocationForObservation();
-  const {authState} = useAuthContext();
-
-  const coordinateInfo = value?.metadata?.manualLocation
-    ? {
-        lat: value.lat,
-        lon: value.lon,
-        accuracy: liveLocation?.coords?.accuracy,
-      }
-    : {
-        lat: liveLocation?.coords?.latitude,
-        lon: liveLocation?.coords?.longitude,
-        accuracy: liveLocation?.coords?.accuracy,
-      };
-
-  const notes = value?.tags.notes;
   const presetName = preset
     ? formatMessage({
         id: `presets.${preset.docId}.name`,
@@ -147,215 +77,123 @@ export const ObservationCreate = ({
       })
     : formatMessage(m.observation);
 
-  const addObservationRefToTrack = React.useCallback(
-    (obs: Observation) => {
-      if (value?.lat && value?.lon) {
-        addNewTrackLocations([
-          {
-            timestamp: new Date().getTime(),
-            latitude: value.lat,
-            longitude: value.lon,
-          },
-        ]);
-      }
-      addNewTrackObservation({
-        docId: obs.docId,
-        versionId: obs.versionId,
-      });
-    },
-    [addNewTrackLocations, addNewTrackObservation, value],
-  );
-
-  const createObservation = React.useCallback(() => {
-    if (!value) throw new Error('no observation saved in persisted state ');
-    if (authState === 'obscured') {
-      clearDraft();
-      navigation.popTo('Home', {screen: 'Map'});
-      return;
-    }
-
-    const unsavedPhotos = attachments.filter(isProcessedDraftPhoto);
-    const unsavedAudioRecordings = attachments.filter(isUnsavedAudio);
-
-    if (unsavedPhotos.length === 0 && unsavedAudioRecordings.length === 0) {
-      createObservationAsync({
-        value: {
-          ...value,
-          presetRef: preset
-            ? {docId: preset.docId, versionId: preset.versionId}
-            : undefined,
-        },
-      })
-        .then(observation => {
-          clearDraft();
-
-          navigation.popTo('Home', {screen: 'Map'});
-
-          if (isTracking) {
-            addObservationRefToTrack(observation);
-          }
-        })
-        .catch(err => {
-          Sentry.captureException(err);
-          navigation.navigate('ErrorBottomSheet');
-        });
-
-      return;
-    }
-
-    (async () => {
-      let observation: Observation;
-
-      try {
-        // Currently, we abort the process of saving an observation if saving any number of photos fails to save,
-        // but this approach is prone to creating "orphaned" blobs.
-        // The alternative is to save the observation but excluding photos that failed to save, which is prone to an odd UX of an observation "missing" some attachments.
-        // This could potentially be alleviated by a more granular and informative UI about the photo-saving state, but currently there is nothing in place.
-        // Basically, which is worse: orphaned attachments or saving observations that seem to be missing attachments?
-        const newAttachments = await Promise.all([
-          ...unsavedPhotos.map(p => {
-            return createPhotoAttachmentAsync(p);
-          }),
-          ...unsavedAudioRecordings.map(a => {
-            return createAudioAttachmentAsync(a);
-          }),
-        ]);
-
-        observation = await createObservationAsync({
-          value: {
-            ...value,
-            attachments: [...value.attachments, ...newAttachments],
-            presetRef: preset
-              ? {docId: preset.docId, versionId: preset.versionId}
-              : undefined,
-          },
-        });
-      } catch (err) {
-        Sentry.captureException(err);
-        navigation.navigate('ErrorBottomSheet');
-        return;
-      }
-      queryClient.invalidateQueries({queryKey: STORAGE_QUERY_KEY});
-      clearDraft();
-      navigation.popTo('Home', {screen: 'Map'});
-      if (isTracking) {
-        addObservationRefToTrack(observation);
-      }
-    })();
-  }, [
-    addObservationRefToTrack,
-    clearDraft,
-    createPhotoAttachmentAsync,
-    createAudioAttachmentAsync,
-    createObservationAsync,
-    isTracking,
-    navigation,
-    attachments,
-    value,
-    preset,
-    authState,
-    queryClient,
-  ]);
-
-  const checkAccuracyAndLocation = React.useCallback(() => {
-    const confirmationOptions: AlertButton[] = [
-      {
-        text: formatMessage(m.saveAnyway),
-        onPress: createObservation,
-        style: 'default',
-      },
-      {
-        text: formatMessage(m.manualEntry),
-        onPress: () => navigation.navigate('ManualGpsScreen'),
-        style: 'cancel',
-      },
-      {
-        text: formatMessage(m.keepWaiting),
-        onPress: () => {},
-      },
-    ];
-
-    if (!value) {
-      return;
-    }
-
-    // If the user has already inputted a manual location, do not check if location is accurate
-    if (value.metadata?.manualLocation) {
-      createObservation();
-      return;
-    }
-
-    const accuracy = value.metadata?.position?.coords?.accuracy;
-
-    if (!liveLocation) {
-      Alert.alert(
-        formatMessage(m.noGpsTitle),
-        formatMessage(m.noGpsDesc),
-        confirmationOptions,
-      );
-      return;
-    }
-
-    // If we don't have accuracy, allow save anyway (this is a remnant from mapeo: https://github.com/digidem/mapeo-mobile/blob/0c0ebbb9ef2261e21cd1d1c8bd5ab2fe42017ea3/src/frontend/screens/ObservationEdit/SaveButton.js#L125C3-L125C50)
-    if (
-      accuracy &&
-      typeof accuracy === 'number' &&
-      accuracy >= MAXIMUM_ACCURACY
-    ) {
-      Alert.alert(
-        formatMessage(m.weakGpsTitle),
-        formatMessage(m.weakGpsDesc),
-        confirmationOptions,
-      );
-      return;
-    }
-
-    createObservation();
-  }, [createObservation, formatMessage, navigation, liveLocation, value]);
-
-  React.useEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <SaveButton
-          onPress={checkAccuracyAndLocation}
-          isLoading={
-            photoAttachmentStatus === 'pending' ||
-            audioAttachmentStatus === 'pending' ||
-            observationStatus === 'pending'
-          }
-        />
-      ),
-    });
-  }, [
-    navigation,
-    audioAttachmentStatus,
-    photoAttachmentStatus,
-    observationStatus,
-    checkAccuracyAndLocation,
-  ]);
-
   return (
-    <Editor
-      presetName={presetName}
-      PresetIcon={
-        <PresetCircleIcon
-          size="medium"
-          iconId={preset?.iconRef?.docId}
-          testID={`OBS.${preset?.name}-icon`}
-          color={preset?.color}
+    <ScreenContentWithDock
+      dockContainerStyle={{padding: 0}}
+      dockContent={<ActionsRow />}>
+      <View style={styles.container}>
+        <View
+          style={{
+            backgroundColor: projectDetails.projectColor,
+            paddingVertical: 10,
+            // without this the parent container border does not properly show
+            borderTopLeftRadius: 12,
+            borderTopRightRadius: 12,
+            paddingHorizontal: 20,
+          }}>
+          <HeaderText variant="header6">
+            {projectDetails.role === 'solo'
+              ? projectDetails.projectHeader
+              : projectDetails.projectName}
+          </HeaderText>
+        </View>
+        <PresetView
+          PresetIcon={
+            <PresetCircleIcon
+              size="medium"
+              iconId={preset?.iconRef?.docId}
+              testID={`OBS.${preset?.name}-icon`}
+              color={preset?.color}
+            />
+          }
+          presetName={presetName}
         />
-      }
-      onPressPreset={() => navigation.navigate('ObservationCategoryChooser')}
-      notes={typeof notes !== 'string' ? '' : notes}
-      updateNotes={newVal => {
-        updateTags('notes', newVal);
-      }}
-      attachments={attachments}
-      location={coordinateInfo}
-      actionsRow={<ActionsRow fieldRefs={preset?.fieldRefs} />}
-    />
+
+        <LiveLocationView />
+      </View>
+      <DescriptionField
+        notes={typeof notes !== 'string' ? '' : notes}
+        updateNotes={newVal => {
+          updateTags('notes', newVal);
+        }}
+      />
+      {attachments && attachments.length > 0 && (
+        <HorizontalScrollView
+          shouldShowLastItems={true}
+          minItemWidth={MIN_WIDTH}
+          gap={GAP}
+          renderChildren={size => (
+            <>
+              {attachments.map(att => {
+                if (isUnprocessedDraftPhoto(att)) {
+                  return <ThumbnailLoader size={size} key={att.draftPhotoId} />;
+                }
+                if (isDraftPhoto(att)) {
+                  return (
+                    <ThumbnailContainer
+                      key={att.draftPhotoId}
+                      accessibilityLabel="View draft photo."
+                      size={size}
+                      onPress={() =>
+                        navigation.navigate('DraftPhotoPreviewModal', {
+                          photo: att,
+                        })
+                      }>
+                      <ThumbnailImage uri={att.thumbnailUri} />
+                    </ThumbnailContainer>
+                  );
+                }
+
+                if (isUnsavedAudio(att)) {
+                  return (
+                    <ThumbnailContainer
+                      key={att.uri}
+                      size={size}
+                      onPress={() =>
+                        navigation.navigate('AudioDraftPlaybackScreen', {
+                          uri: att.uri,
+                          createdAt: att.createdAt,
+                          showRecordingSavedText: false,
+                        })
+                      }
+                      containerStyle={{
+                        backgroundColor: WHITE,
+                        borderColor: COMAPEO_BLUE,
+                        borderWidth: 2,
+                        paddingVertical: 8,
+                      }}
+                      accessibilityLabel="Play audio recording.">
+                      <PlayArrow width={48} height={48} />
+                      <BodyText variant="tinyMeta" style={{fontWeight: '500'}}>
+                        {millisecondsToMMSS(att.duration)}
+                      </BodyText>
+                      <DateDistance
+                        date={new Date(att.createdAt)}
+                        style={{
+                          fontSize: 12,
+                          fontWeight: '400',
+                          color: DARK_GREY,
+                        }}
+                      />
+                    </ThumbnailContainer>
+                  );
+                }
+              })}
+            </>
+          )}
+        />
+      )}
+    </ScreenContentWithDock>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: LIGHT_GREY,
+  },
+});
 
 export function createNavigationOptions({
   intl,
@@ -365,7 +203,7 @@ export function createNavigationOptions({
   return (): NativeStackNavigationOptions => {
     return {
       headerTitle: intl(m.navTitle),
-      headerRight: () => <SaveButton onPress={() => {}} isLoading={false} />,
+      headerRight: () => <ObservationCreateSaveButton />,
       headerLeft: props => <HeaderLeft headerBackButtonProps={props} />,
     };
   };

--- a/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
+++ b/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
@@ -1,6 +1,5 @@
-import {useFocusEffect} from '@react-navigation/native';
 import mapObject, {mapObjectSkip} from 'map-obj';
-import {useCallback, useEffect} from 'react';
+import {useEffect} from 'react';
 import {
   watchPositionAsync,
   useForegroundPermissions,

--- a/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
+++ b/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
@@ -1,5 +1,5 @@
 import mapObject, {mapObjectSkip} from 'map-obj';
-import {useEffect} from 'react';
+import {useCallback} from 'react';
 import {
   watchPositionAsync,
   useForegroundPermissions,
@@ -8,7 +8,7 @@ import {
 } from 'expo-location';
 import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
 import {useDraftObservation} from '../../hooks/useDraftObservation';
-import {useLocationState} from '../../contexts/LocationContext';
+import {useFocusEffect} from '@react-navigation/native';
 
 export function useMostAccurateLocationForObservation() {
   const value = usePersistedDraftObservation(store => store.value);
@@ -16,56 +16,44 @@ export function useMostAccurateLocationForObservation() {
 
   const [permissions] = useForegroundPermissions();
 
-  const providerStatus = useLocationState(store => store.providerStatus);
-  const locationServicesTurnedOff =
-    providerStatus && !providerStatus.locationServicesEnabled;
-
   const isLocationManuallySet = !!value?.metadata?.manualLocation;
 
-  // If location services are turned off (and the observation location is not manually set),
-  // we want to immediately update the draft so that this hook does not return a stale position
-  if (
-    locationServicesTurnedOff &&
-    value?.metadata?.position &&
-    !isLocationManuallySet
-  ) {
-    updateObservationPosition({position: undefined, manualLocation: false});
-  }
+  useFocusEffect(
+    useCallback(() => {
+      if (!permissions || !permissions.granted || isLocationManuallySet) return;
 
-  useEffect(() => {
-    if (!permissions || !permissions.granted || isLocationManuallySet) return;
+      let ignore = false;
+      const locationSubscriptionProm = watchPositionAsync(
+        {
+          accuracy: Accuracy.BestForNavigation,
+        },
+        debounceLocation()(location => {
+          if (ignore) return;
+          updateObservationPosition({
+            position: {
+              mocked: location.mocked,
+              coords: mapObject(location.coords, (key, val) =>
+                val == null ? mapObjectSkip : [key, val],
+              ),
+              timestamp: new Date(location.timestamp).toISOString(),
+            },
+            manualLocation: false,
+          });
+        }),
+      );
 
-    let ignore = false;
-    const locationSubscriptionProm = watchPositionAsync(
-      {
-        accuracy: Accuracy.BestForNavigation,
-      },
-      debounceLocation()(location => {
+      // Should not happen because we are checking permissions above, but just in case
+      locationSubscriptionProm.catch(() => {
         if (ignore) return;
-        updateObservationPosition({
-          position: {
-            mocked: location.mocked,
-            coords: mapObject(location.coords, (key, val) =>
-              val == null ? mapObjectSkip : [key, val],
-            ),
-            timestamp: new Date(location.timestamp).toISOString(),
-          },
-          manualLocation: false,
-        });
-      }),
-    );
+        // TODO: We should probably set up an error boundary and throw
+      });
 
-    // Should not happen because we are checking permissions above, but just in case
-    locationSubscriptionProm.catch(() => {
-      if (ignore) return;
-      // TODO: We should probably set up an error boundary and throw
-    });
-
-    return () => {
-      ignore = true;
-      locationSubscriptionProm.then(sub => sub.remove());
-    };
-  }, [permissions, updateObservationPosition, isLocationManuallySet]);
+      return () => {
+        ignore = true;
+        locationSubscriptionProm.then(sub => sub.remove());
+      };
+    }, [permissions, updateObservationPosition, isLocationManuallySet]),
+  );
 }
 
 function debounceLocation() {

--- a/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
+++ b/src/frontend/screens/ObservationCreate/useMostAccurateLocationForObservation.ts
@@ -1,6 +1,6 @@
 import {useFocusEffect} from '@react-navigation/native';
 import mapObject, {mapObjectSkip} from 'map-obj';
-import {useCallback} from 'react';
+import {useCallback, useEffect} from 'react';
 import {
   watchPositionAsync,
   useForegroundPermissions,
@@ -33,44 +33,40 @@ export function useMostAccurateLocationForObservation() {
     updateObservationPosition({position: undefined, manualLocation: false});
   }
 
-  useFocusEffect(
-    useCallback(() => {
-      if (!permissions || !permissions.granted || isLocationManuallySet) return;
+  useEffect(() => {
+    if (!permissions || !permissions.granted || isLocationManuallySet) return;
 
-      let ignore = false;
-      const locationSubscriptionProm = watchPositionAsync(
-        {
-          accuracy: Accuracy.BestForNavigation,
-        },
-        debounceLocation()(location => {
-          if (ignore) return;
-          updateObservationPosition({
-            position: {
-              mocked: location.mocked,
-              coords: mapObject(location.coords, (key, val) =>
-                val == null ? mapObjectSkip : [key, val],
-              ),
-              timestamp: new Date(location.timestamp).toISOString(),
-            },
-            manualLocation: false,
-          });
-        }),
-      );
-
-      // Should not happen because we are checking permissions above, but just in case
-      locationSubscriptionProm.catch(() => {
+    let ignore = false;
+    const locationSubscriptionProm = watchPositionAsync(
+      {
+        accuracy: Accuracy.BestForNavigation,
+      },
+      debounceLocation()(location => {
         if (ignore) return;
-        // TODO: We should probably set up an error boundary and throw
-      });
+        updateObservationPosition({
+          position: {
+            mocked: location.mocked,
+            coords: mapObject(location.coords, (key, val) =>
+              val == null ? mapObjectSkip : [key, val],
+            ),
+            timestamp: new Date(location.timestamp).toISOString(),
+          },
+          manualLocation: false,
+        });
+      }),
+    );
 
-      return () => {
-        ignore = true;
-        locationSubscriptionProm.then(sub => sub.remove());
-      };
-    }, [permissions, updateObservationPosition, isLocationManuallySet]),
-  );
+    // Should not happen because we are checking permissions above, but just in case
+    locationSubscriptionProm.catch(() => {
+      if (ignore) return;
+      // TODO: We should probably set up an error boundary and throw
+    });
 
-  return value?.metadata?.position;
+    return () => {
+      ignore = true;
+      locationSubscriptionProm.then(sub => sub.remove());
+    };
+  }, [permissions, updateObservationPosition, isLocationManuallySet]);
 }
 
 function debounceLocation() {

--- a/wdio.ci.config.js
+++ b/wdio.ci.config.js
@@ -30,7 +30,7 @@ const config = {
       {
         app: process.env.BROWSERSTACK_APP_URL,
         buildIdentifier: '#${DATE_TIME}',
-        browserstackLocal: false,
+        browserstackLocal: true,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',
@@ -51,7 +51,7 @@ const config = {
         projectName: 'CoMapeo',
         buildName: `${prTitle || 'Manual Run'} – ${shortSha}`,
         sessionName: `E2E: ${shortSha}`,
-        appiumVersion: '2.19.0',
+        appiumVersion: '2.12.1',
         debug: true,
         networkLogs: true,
         gpsLocation: '0.198214, 78.472225',

--- a/wdio.ci.config.js
+++ b/wdio.ci.config.js
@@ -30,7 +30,7 @@ const config = {
       {
         app: process.env.BROWSERSTACK_APP_URL,
         buildIdentifier: '#${DATE_TIME}',
-        browserstackLocal: true,
+        browserstackLocal: false,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',


### PR DESCRIPTION
Towards #1430 

With the e2e test we noticed that the "No GPS" alert was being prompted when there clearly was a GPS signal. This Pr attempts to address that

First, we removed the useEffect that was updating the save button. On every change of location (which is often), we were running a use effect to update the save button because the save button was found in the header-the header is only able to updated via a use effect. Instead the save button is just accessing the values directly from the persisted store

Secondly, I simplified the location hooks. Previously the useMostAccurateLocationforObservation hook was returning the location being used as well as updating the location in the persisted store. We are now just using the location from the store everwhere.

Lastly, I removed the `Editor` component from the observation create. Instead i took the individual pieces from the editor component and put the directly in Observation Create so that the code would not have deeply nested logic that made it difficult to debug. 