### PR TITLE
fix: browserstack-parallel-tests

### DIFF
--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -9,8 +9,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: e2e-tests-${{ github.ref }}
-  cancel-in-progress: true
+  group: e2e-tests-browserstack
+  cancel-in-progress: false
 
 jobs:
   build-apk:

--- a/tests/e2e/specs/passcode/set-passcode.test.ts
+++ b/tests/e2e/specs/passcode/set-passcode.test.ts
@@ -129,8 +129,9 @@ describe('Passcode - setPasscode', () => {
     if (await backBtn.isDisplayed()) {
       await backBtn.click();
     }
-    if (await backBtn.isDisplayed()) {
-      await backBtn.click();
+    const backButtonAgain = await $(byResourceId('MAIN.header-back-btn'));
+    if (await backButtonAgain.isDisplayed()) {
+      await backButtonAgain.click();
     }
     const drawerIcon = await $('~Close Menu');
     if (await drawerIcon.isDisplayed()) {

--- a/wdio.ci.config.js
+++ b/wdio.ci.config.js
@@ -30,7 +30,7 @@ const config = {
       {
         app: process.env.BROWSERSTACK_APP_URL,
         buildIdentifier: '#${DATE_TIME}',
-        browserstackLocal: true,
+        browserstackLocal: false,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',


### PR DESCRIPTION
Fixes for possible changes in Browserstack that were causing automatic failures in our tests. 
Uses non local tunnel. 
Only runs one set of tests at a time so as not to exceed our device limit.