### PR TITLE
fix: speeding up tests

### DIFF
--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -9,8 +9,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: e2e-tests-browserstack
-  cancel-in-progress: false
+  group: e2e-tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-apk:

--- a/wdio.ci.config.js
+++ b/wdio.ci.config.js
@@ -30,7 +30,7 @@ const config = {
       {
         app: process.env.BROWSERSTACK_APP_URL,
         buildIdentifier: '#${DATE_TIME}',
-        browserstackLocal: false,
+        browserstackLocal: true,
         testObservability: true,
         testObservabilityOptions: {
           projectName: 'CoMapeo',
@@ -51,7 +51,7 @@ const config = {
         projectName: 'CoMapeo',
         buildName: `${prTitle || 'Manual Run'} – ${shortSha}`,
         sessionName: `E2E: ${shortSha}`,
-        appiumVersion: '2.19.0',
+        appiumVersion: '2.12.1',
         debug: true,
         networkLogs: true,
         gpsLocation: '0.198214, 78.472225',


### PR DESCRIPTION
Reverts appium version, 
browserstack local is true 
and allows concurrency