### PR TITLE
WIP: use SVG preset icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "expo-document-picker": "13.1.6",
         "expo-file-system": "18.1.11",
         "expo-font": "13.3.2",
-        "expo-image": "2.4.0",
+        "expo-image": "~2.4.1",
         "expo-image-manipulator": "13.1.7",
         "expo-localization": "16.1.6",
         "expo-location": "18.1.6",
@@ -18990,9 +18990,9 @@
       }
     },
     "node_modules/expo-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.4.0.tgz",
-      "integrity": "sha512-TQ/LvrtJ9JBr+Tf198CAqflxcvdhuj7P24n0LQ1jHaWIVA7Z+zYKbYHnSMPSDMul/y0U46Z5bFLbiZiSidgcNw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.4.1.tgz",
+      "integrity": "sha512-yHp0Cy4ylOYyLR21CcH6i70DeRyLRPc0yAIPFPn4BT/BpkJNaX5QMXDppcHa58t4WI3Bb8QRJRLuAQaeCtDF8A==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "expo-document-picker": "13.1.6",
     "expo-file-system": "18.1.11",
     "expo-font": "13.3.2",
-    "expo-image": "2.4.0",
+    "expo-image": "~2.4.1",
     "expo-image-manipulator": "13.1.7",
     "expo-localization": "16.1.6",
     "expo-location": "18.1.6",

--- a/src/backend/loader.js
+++ b/src/backend/loader.js
@@ -40,7 +40,7 @@ let enableLogs = false
 
 if (sentryEnvironment !== 'production') {
   logLevels.push('log', 'warn')
-  enableLogs = true
+  enableLogs = false
 }
 
 const sentryDB = new Database(dbDir)

--- a/src/backend/patches/@comapeo+core+4.4.0.patch
+++ b/src/backend/patches/@comapeo+core+4.4.0.patch
@@ -1,0 +1,34 @@
+diff --git a/node_modules/@comapeo/core/src/config-import.js b/node_modules/@comapeo/core/src/config-import.js
+index fe8be63..5e83465 100644
+--- a/node_modules/@comapeo/core/src/config-import.js
++++ b/node_modules/@comapeo/core/src/config-import.js
+@@ -9,7 +9,7 @@ import { SUPPORTED_CONFIG_VERSION } from './constants.js'
+ // Throw error if a zipfile contains more than 10,000 entries
+ const MAX_ENTRIES = 10_000
+ const MAX_ICON_SIZE = 10_000_000
+-const ICON_NAME_REGEX = /([a-zA-Z0-9-]+)-([a-zA-Z]+)@(\d+)x\.[a-zA-Z]+$/
++const ICON_NAME_REGEX = /([a-zA-Z0-9-]+)-([a-zA-Z]+)(:?@(\d+)x)?\.[a-zA-Z]+$/
+ 
+ /**
+  * @typedef {yauzl.Entry} Entry
+@@ -518,7 +518,7 @@ function parseIcon(filename, buf) {
+   }
+   const [_, name, size, pixelDensityStr] = matches
+   const pixelDensity = Number(pixelDensityStr)
+-  if (!(pixelDensity === 1 || pixelDensity === 2 || pixelDensity === 3)) {
++  if (pixelDensityStr && !(pixelDensity === 1 || pixelDensity === 2 || pixelDensity === 3)) {
+     throw new Error(`Error loading icon. invalid pixel density ${pixelDensity}`)
+   }
+   if (!(size === 'small' || size === 'medium' || size === 'large')) {
+diff --git a/node_modules/@comapeo/core/src/mapeo-project.js b/node_modules/@comapeo/core/src/mapeo-project.js
+index 0bb67b3..2780ca9 100644
+--- a/node_modules/@comapeo/core/src/mapeo-project.js
++++ b/node_modules/@comapeo/core/src/mapeo-project.js
+@@ -1506,6 +1506,7 @@ export class MapeoProject extends TypedEmitter {
+       return config.warnings
+     } catch (e) {
+       this.#l.log('error loading config', e)
++      console.error(e)
+       this.#loadingConfig = false
+       return /** @type Error[] */ []
+     }

--- a/src/frontend/hooks/server/icons.ts
+++ b/src/frontend/hooks/server/icons.ts
@@ -1,17 +1,20 @@
+import type {IconApi} from '@comapeo/core';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useIconUrl} from '@comapeo/core-react';
-import {IconSize} from '../../sharedTypes';
 
 export const ICONS_KEY = 'icons';
 
-export function useProjectIconUrl(iconId: string, size: IconSize) {
+export function useProjectIconUrl(iconId: string, type: 'svg' | 'png' = 'svg') {
   const {projectId} = useActiveProject();
+
+  const iconOpts: IconApi.BitmapOpts | IconApi.SvgOpts =
+    type === 'svg'
+      ? {mimeType: 'image/svg+xml', size: 'medium'}
+      : {mimeType: 'image/png', size: 'medium', pixelDensity: 3};
 
   return useIconUrl({
     projectId,
     iconId,
-    mimeType: 'image/png',
-    pixelDensity: 3,
-    size,
+    ...iconOpts,
   });
 }

--- a/src/frontend/sharedComponents/icons/PresetIcon.tsx
+++ b/src/frontend/sharedComponents/icons/PresetIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Image} from 'react-native';
+import {Image} from 'expo-image';
 import {Circle} from './Circle';
 import {type IconSize} from '../../sharedTypes';
 import {UIActivityIndicator} from 'react-native-indicators';
@@ -30,8 +30,13 @@ const LoadedPresetIcon = ({
   testID,
 }: PresetIconProps & {iconId: string}) => {
   const iconSize = iconSizes[size];
+  const [iconType, setIconType] = React.useState<'svg' | 'png'>('svg');
 
-  const {data: iconUrl, error, isRefetching} = useProjectIconUrl(iconId, size);
+  const {
+    data: iconUrl,
+    error,
+    isRefetching,
+  } = useProjectIconUrl(iconId, iconType);
 
   if (isRefetching) {
     return <UIActivityIndicator size={iconSize} />;
@@ -45,8 +50,15 @@ const LoadedPresetIcon = ({
     <Image
       style={{width: iconSize, height: iconSize}}
       resizeMode="contain"
-      source={{uri: iconUrl}}
+      source={iconUrl}
       testID={testID}
+      onError={e => {
+        if (iconType === 'svg') {
+          // Retry as PNG if SVG fails to load
+          setIconType('png');
+        }
+        console.log('Error loading icon image', e);
+      }}
     />
   );
 };


### PR DESCRIPTION
Proof-of-concept in-progress using SVG preset icons, with fallback to PNG. This required a patch to existing config import code which was throwing an error when importing SVG icons, but this will be fixed with the new category archive format once https://github.com/digidem/comapeo-core/pull/1135 lands.

To actually test with SVG icons, you will need to load this custom version of the default config: [mapeo-default-config-v5.0.0.zip](https://github.com/user-attachments/files/22892635/mapeo-default-config-v5.0.0.zip) (rename it to `.comapeocat` - Github won't allow attachments with that extension).

It does work and renders the icons, but for projects with only PNG icons this will be a bit inefficient, since it tries to load SVG first, then falls back to PNG. This should be addressed with https://github.com/digidem/comapeo-core/issues/1114 which will remove the need to attempt to load SVG first. However the extra request to get the new URL should not have a big overhead due to improvements in @comapeo/core-react to URL get functions.

I don't think this requires additional work now, until https://github.com/digidem/comapeo-core/pull/1135 is merged and released along with a new default categories file with SVG icons only. The goal of this PR is to validate how much work will be needed to use SVG icons once we have them.

