### PR TITLE
feat: updates home header

### DIFF
--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -38,7 +38,7 @@ export const HomeTabs = () => {
             <React.Suspense fallback={null}>
               <HomeHeader
                 {...props}
-                toggleDrawer={() => setDrawerOpen(val => !val)}
+                onPress={() => setDrawerOpen(val => !val)}
                 backgroundColor="transparent"
                 showBottomBorder={false}
               />
@@ -61,7 +61,7 @@ export const HomeTabs = () => {
                   {...props}
                   backgroundColor={WHITE}
                   showBottomBorder
-                  toggleDrawer={() => setDrawerOpen(val => !val)}
+                  onPress={() => setDrawerOpen(val => !val)}
                 />
               </React.Suspense>
             ),

--- a/src/frontend/sharedComponents/HomeHeader.lowStorage.test.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.lowStorage.test.tsx
@@ -55,7 +55,7 @@ function HomeHeaderScreen() {
       {...baseHeader}
       backgroundColor="#fff"
       showBottomBorder
-      toggleDrawer={() => {}}
+      onPress={() => {}}
       navigation={{} as BottomTabHeaderProps['navigation']}
     />
   );

--- a/src/frontend/sharedComponents/HomeHeader.lowStorage.test.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.lowStorage.test.tsx
@@ -128,7 +128,7 @@ describe('HomeHeader low storage badge (navigator + AppProviders)', () => {
     mockFreeBytes = 100 * 1024 * 1024;
     renderHeader();
 
-    await screen.findByTestId('drawer-icon-home');
+    await screen.findByTestId('HOME.header-button');
 
     expect(await screen.findByTestId('low-storage-badge')).toBeTruthy();
   });
@@ -137,7 +137,7 @@ describe('HomeHeader low storage badge (navigator + AppProviders)', () => {
     mockFreeBytes = 600 * 1024 * 1024;
     renderHeader();
 
-    await screen.findByTestId('drawer-icon-home');
+    await screen.findByTestId('HOME.header-button');
 
     expect(screen.queryByTestId('low-storage-badge')).toBeNull();
   });

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -14,13 +14,13 @@ import {ExclamationBadge} from './Storage/ExclamationBadge';
 type HomeHeaderProps = BottomTabHeaderProps & {
   backgroundColor: string;
   showBottomBorder: boolean;
-  toggleDrawer: () => void;
+  onPress: () => void;
 };
 
 export function HomeHeader({
   backgroundColor,
   showBottomBorder,
-  toggleDrawer,
+  onPress,
 }: HomeHeaderProps) {
   const {projectId} = useActiveProject();
   const projectDetails = useProjectRoleAndDetails(projectId);
@@ -48,7 +48,7 @@ export function HomeHeader({
             styles.titleBox,
             {backgroundColor: projectDetails.projectColor},
           ]}
-          onPress={toggleDrawer}
+          onPress={onPress}
           accessibilityLabel="Open Menu"
           testID="HOME.header-button">
           <View style={styles.menuIconContainer}>

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -53,11 +53,6 @@ export function HomeHeader({
           testID="HOME.header-button">
           <View style={styles.menuIconContainer}>
             <IonIcon name="menu" size={20} color={DARK_GREY} />
-            {isLow && (
-              <View style={{position: 'absolute', top: -2, right: -2}}>
-                <ExclamationBadge testID="low-storage-badge" />
-              </View>
-            )}
           </View>
           <HeaderText
             testID="HOME.header-title"
@@ -67,6 +62,11 @@ export function HomeHeader({
             ellipsizeMode="tail">
             {projectName}
           </HeaderText>
+          {isLow && (
+            <View style={{position: 'absolute', top: -2, right: -2}}>
+              <ExclamationBadge testID="low-storage-badge" />
+            </View>
+          )}
         </TouchableOpacity>
       </View>
     </View>

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, TouchableOpacity} from 'react-native';
 import {BottomTabHeaderProps} from '@react-navigation/bottom-tabs';
+import IonIcon from 'react-native-vector-icons/Ionicons';
 
-import DeviceIcon from '../images/DeviceIcon.svg';
-import {IconButton} from './IconButton';
 import {HeaderText} from './Text/HeaderText';
 import {BLUE_GREY, DARK_GREY} from '../lib/styles';
 import {useProjectRoleAndDetails} from '../hooks/useProjectRoleAndDetails';
 import {useActiveProject} from '../contexts/ActiveProjectContext';
-import ProjectCoordinatorIcon from '../images/ProjectCoordinator.svg';
-import ProjectParticipantIcon from '../images/ProjectParticipant.svg';
-import NoProjectIcon from '../images/NoProjectIcon.svg';
-import {SvgProps} from 'react-native-svg';
 import {isLowStorage} from '../lib/storage';
 import {useStorageReadingQuery} from '../hooks/useStorageReadingQuery';
 import {ExclamationBadge} from './Storage/ExclamationBadge';
@@ -37,24 +32,6 @@ export function HomeHeader({
       ? projectDetails.projectHeader
       : projectDetails.projectName;
 
-  let RoleIcon: React.FC<SvgProps>;
-  let testID: string;
-
-  switch (projectDetails.role) {
-    case 'coordinator':
-      RoleIcon = ProjectCoordinatorIcon;
-      testID = 'HOME.coordinator-icon';
-      break;
-    case 'participant':
-      RoleIcon = ProjectParticipantIcon;
-      testID = 'HOME.participant-icon';
-      break;
-    default:
-      RoleIcon = NoProjectIcon;
-      testID = 'HOME.no-project-icon';
-      break;
-  }
-
   return (
     <View
       style={[
@@ -66,12 +43,22 @@ export function HomeHeader({
         },
       ]}>
       <View style={styles.headerRow}>
-        <View
+        <TouchableOpacity
           style={[
             styles.titleBox,
             {backgroundColor: projectDetails.projectColor},
-          ]}>
-          <RoleIcon testID={testID} style={{marginRight: 10}} />
+          ]}
+          onPress={toggleDrawer}
+          accessibilityLabel="Open Menu"
+          testID="HOME.header-button">
+          <View style={styles.menuIconContainer}>
+            <IonIcon name="menu" size={20} color={DARK_GREY} />
+            {isLow && (
+              <View style={{position: 'absolute', top: -2, right: -2}}>
+                <ExclamationBadge testID="low-storage-badge" />
+              </View>
+            )}
+          </View>
           <HeaderText
             testID="HOME.header-title"
             variant="header4"
@@ -80,23 +67,7 @@ export function HomeHeader({
             ellipsizeMode="tail">
             {projectName}
           </HeaderText>
-        </View>
-
-        <IconButton style={styles.iconButton} onPress={toggleDrawer}>
-          <View style={styles.deviceWrap} pointerEvents="box-none">
-            <DeviceIcon
-              width={32}
-              height={32}
-              testID="drawer-icon-home"
-              accessibilityLabel="Open Menu"
-            />
-            {isLow && (
-              <View style={{position: 'absolute', top: -2, right: -2}}>
-                <ExclamationBadge testID="low-storage-badge" />
-              </View>
-            )}
-          </View>
-        </IconButton>
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -114,28 +85,24 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   titleBox: {
-    width: '85%',
-    minHeight: 32,
+    height: 40,
+    maxWidth: '100%',
     borderRadius: 6,
+    borderWidth: 0.5,
+    borderColor: BLUE_GREY,
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 5,
+    paddingRight: 10,
   },
-  text: {
-    paddingLeft: 5,
-    color: DARK_GREY,
-  },
-  iconButton: {
+  menuIconContainer: {
     width: 40,
     height: 40,
+    borderRadius: 6,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  deviceWrap: {
-    width: 32,
-    height: 32,
     position: 'relative',
-    justifyContent: 'center',
-    alignItems: 'center',
+  },
+  text: {
+    flexShrink: 1,
   },
 });

--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -30,7 +30,7 @@ describe('Settings - Language Settings Flow', () => {
   });
 
   it('should switch back to English and confirm language revert', async () => {
-    const drawerIcon = await $(byResourceId('drawer-icon-home'));
+    const drawerIcon = await $(byResourceId('HOME.header-button'));
     if (await drawerIcon.isDisplayed()) {
       await drawerIcon.click();
     }

--- a/tests/e2e/specs/solo-project/own-project-headers.test.ts
+++ b/tests/e2e/specs/solo-project/own-project-headers.test.ts
@@ -19,10 +19,7 @@ describe('Project - Solo Project Headers', () => {
 
     await expect($(byTextMatches(output.names.device))).toBeDisplayed();
 
-    const drawerButton = await $(byResourceId('drawer-icon-home'));
+    const drawerButton = await $(byResourceId('HOME.header-button'));
     await expect(drawerButton).toBeDisplayed();
-
-    const soloCardText = await $(byResourceId('HOME.no-project-icon'));
-    await expect(soloCardText).toBeDisplayed();
   });
 });


### PR DESCRIPTION
closes #1408 

Adds updated Home header UI.
I tested with long names and short and with regular screen size and zoomed screen and large font. See screen shots.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4706009c-7f7b-430c-b55f-db43adcbe468" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/3fbaa55b-21c1-4aab-a327-8319560dc914" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/876ed158-60f9-48bb-98b5-b62ac1a37751" />
Project where I am coordinator and changed the color:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/55547cb3-d438-4d68-b967-0afc44b87d95" />

With the low storage icon:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/c3c9f14b-9fd4-42a0-9ac1-37cc09990b6d" />

