### PR TITLE
feat: uses presets sorted by default order hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@bam.tech/react-native-image-resizer": "3.0.11",
-        "@comapeo/core-react": "6.2.2",
+        "@comapeo/core-react": "6.4.0",
         "@comapeo/ipc": "5.0.0",
         "@expo-google-fonts/rubik": "0.4.1",
         "@formatjs/intl-getcanonicallocales": "2.5.5",
@@ -2981,12 +2981,12 @@
       }
     },
     "node_modules/@comapeo/core-react": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-6.2.2.tgz",
-      "integrity": "sha512-IxuJZSdX8ZIQ0bOm+7DgCHVV7KqL15tzMc4kQjZtgt4RT6YIGfpEYPjXj1cF90lFNR4pwgz30cZ1xed9A5XTMw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-6.4.0.tgz",
+      "integrity": "sha512-bZTAv5bCxsAGDx5WE0rQrjlePZ0rMcOGhMiYgcms8x+shtNHygZwv+72p1q8eR19U+hvm9y2uWtINEs4dVR6eQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@comapeo/core": "^4.3.0",
+        "@comapeo/core": "^4.4.0",
         "@comapeo/ipc": "^5.0.0",
         "@comapeo/schema": "*",
         "@tanstack/react-query": "^5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "3.0.11",
-    "@comapeo/core-react": "6.2.2",
+    "@comapeo/core-react": "6.4.0",
     "@comapeo/ipc": "5.0.0",
     "@expo-google-fonts/rubik": "0.4.1",
     "@formatjs/intl-getcanonicallocales": "2.5.5",

--- a/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {View, StyleSheet} from 'react-native';
 import {defineMessages} from 'react-intl';
-import {usePresetsQuery} from '../../hooks/server/presets';
+import {usePresetsSelection} from '@comapeo/core-react';
 import {useDraftObservation} from '../../hooks/useDraftObservation';
 import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
 import {CategoryGrid} from './CategoryGrid';
@@ -10,6 +10,7 @@ import {WHITE} from '../../lib/styles';
 import {CustomHeaderLeftClose} from '../../sharedComponents/CustomHeaderLeftClose';
 import {Preset} from '@comapeo/schema';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
 const m = defineMessages({
   title: {
@@ -21,16 +22,20 @@ const m = defineMessages({
 export const ObservationCategoryChooser: NativeNavigationComponent<
   'ObservationCategoryChooser'
 > = ({navigation}) => {
-  const {data: presets} = usePresetsQuery();
+  const {projectId} = useActiveProject();
+  const presets = usePresetsSelection({
+    projectId: projectId,
+    dataType: 'observation',
+  });
   const {updatePreset, usePreset} = useDraftObservation();
   const observationId = usePersistedDraftObservation(
     state => state.observationId,
   );
   const currentPreset = usePreset();
 
-  const filteredPresets = Array.from(presets)
-    .filter(p => p.geometry.includes('point'))
-    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  const filteredPresets = Array.from(presets).filter(p =>
+    p.geometry.includes('point'),
+  );
 
   const handleSelect = (preset: Preset) => {
     updatePreset(preset);

--- a/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
@@ -11,6 +11,7 @@ import {CustomHeaderLeftClose} from '../../sharedComponents/CustomHeaderLeftClos
 import {Preset} from '@comapeo/schema';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useAppLanguageTag} from '../../hooks/useAppLanguageTag';
 
 const m = defineMessages({
   title: {
@@ -23,9 +24,11 @@ export const ObservationCategoryChooser: NativeNavigationComponent<
   'ObservationCategoryChooser'
 > = ({navigation}) => {
   const {projectId} = useActiveProject();
+  const languageTag = useAppLanguageTag();
   const presets = usePresetsSelection({
     projectId: projectId,
     dataType: 'observation',
+    lang: languageTag,
   });
   const {updatePreset, usePreset} = useDraftObservation();
   const observationId = usePersistedDraftObservation(

--- a/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
@@ -10,6 +10,7 @@ import {Preset} from '@comapeo/schema';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
 import {usePresetsSelection} from '@comapeo/core-react';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useAppLanguageTag} from '../../hooks/useAppLanguageTag';
 
 const m = defineMessages({
   title: {
@@ -22,9 +23,11 @@ export const TrackCategoryChooser: NativeNavigationComponent<
   'TrackCategoryChooser'
 > = ({navigation}) => {
   const {projectId} = useActiveProject();
+  const languageTag = useAppLanguageTag();
   const presets = usePresetsSelection({
     projectId: projectId,
     dataType: 'observation',
+    lang: languageTag,
   });
   const {setTrackPreset} = useTrackActions();
   const trackPresets = Array.from(presets).filter(p =>

--- a/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {View, StyleSheet} from 'react-native';
 import {defineMessages} from 'react-intl';
-import {usePresetsQuery} from '../../hooks/server/presets';
 import {useTrackActions, useTrackState} from '../../contexts/TrackStoreContext';
 import {CategoryGrid} from './CategoryGrid';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
@@ -9,6 +8,8 @@ import {WHITE} from '../../lib/styles';
 import {HeaderLeft} from '../SaveTrack/HeaderLeft';
 import {Preset} from '@comapeo/schema';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
+import {usePresetsSelection} from '@comapeo/core-react';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
 
 const m = defineMessages({
   title: {
@@ -20,11 +21,15 @@ const m = defineMessages({
 export const TrackCategoryChooser: NativeNavigationComponent<
   'TrackCategoryChooser'
 > = ({navigation}) => {
-  const {data: presets} = usePresetsQuery();
+  const {projectId} = useActiveProject();
+  const presets = usePresetsSelection({
+    projectId: projectId,
+    dataType: 'observation',
+  });
   const {setTrackPreset} = useTrackActions();
-  const trackPresets = Array.from(presets)
-    .filter(p => p.geometry.includes('line'))
-    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  const trackPresets = Array.from(presets).filter(p =>
+    p.geometry.includes('line'),
+  );
   const existingPreset = useTrackState(state => state.preset);
   const trackId = useTrackState(state => state.docId);
 

--- a/tests/e2e/specs/passcode/obscure-mode.test.ts
+++ b/tests/e2e/specs/passcode/obscure-mode.test.ts
@@ -46,8 +46,8 @@ describe('Passcode - Obscure Passcode Mode', () => {
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
-    const animalCategory = await $(byTextMatches('Animal'));
-    await animalCategory.click();
+    await $(byTextMatches('Animal')).scrollIntoView();
+    await $(byTextMatches('Animal')).click();
 
     await driver.pause(1000);
     const saveBtn = await $(byResourceId('OBS.edit-save-btn'));


### PR DESCRIPTION
closes #1389 
Uses the new comapeo/core-react hook as cerated in here: https://github.com/digidem/comapeo-core-react/pull/129
I did not choose to use the server/presets file as it seemed extremely simple to just use the hook from comapeo/core-react and then I didn't have to pass any props.
Adds use of preset chooser to the observation and tracks category choosers. 
No longer sorts them by alpha because all sorting is handled in the backend however all presets are included so they do need to be filtered by line or point.

**Tracks category chooser now**
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e315e386-0a04-477b-9162-4567e863eea9" />

**Observations category chooser now**
https://github.com/user-attachments/assets/612ac4dd-6141-466c-8717-a2a0dfac7c6d

