### PR TITLE
chore: update name project

### DIFF
--- a/src/frontend/screens/Settings/CreateOrJoinProject/CreateOrNameSoloProject/index.tsx
+++ b/src/frontend/screens/Settings/CreateOrJoinProject/CreateOrNameSoloProject/index.tsx
@@ -126,6 +126,12 @@ export const CreateOrNameSoloProject = ({
         {name: projectName},
         {
           onSuccess: () => {
+            createProjectMutation.mutate(undefined, {
+              onError: err => {
+                Sentry.captureException(err);
+              },
+            });
+
             navigation.replace('ShareProjectStats', {
               projectName,
             });

--- a/tests/e2e/specs/solo-project/rename-project-from-drawer.test.ts
+++ b/tests/e2e/specs/solo-project/rename-project-from-drawer.test.ts
@@ -91,4 +91,14 @@ describe('Project - Rename Project from Drawer while perserving observations', (
     const mapButton = await $('~Go to map.');
     await mapButton.click();
   });
+
+  it('should verify that a new unnamed project was created in the background', async () => {
+    await $('~Open Menu').click();
+    await $('~Go to All Projects Screen').click();
+    await expect($(byTextMatches(output.names.project))).toBeDisplayed();
+    await expect($(byText(output.names.device))).toBeDisplayed();
+    const backButton = $(byResourceId('MAIN.header-back-btn'));
+    await backButton.click();
+    await $(byResourceId('MAIN.map-screen')).click();
+  });
 });


### PR DESCRIPTION
closes #1426 
Creates an unnamed project when a user successfully renames a project. 
Doesn't switch to that project.
Updates the end to end test for a solo project to check for it. 
That test isn't currently running but it will when the menu PR is merged in.
Screen recording attached so you can see it in action.


https://github.com/user-attachments/assets/6f1cfa9b-e021-4b37-b339-5107fa952cb8

