### PR TITLE
fix: updates data to metadata

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1380,8 +1380,8 @@
   "screens.ObservationMetadataVerified.altitudeAccuracy": {
     "message": "Altitude Accuracy"
   },
-  "screens.ObservationMetadataVerified.coMapeoData": {
-    "message": "CoMapeo Data"
+  "screens.ObservationMetadataVerified.coMapeoMetadata": {
+    "message": "CoMapeo Metadata"
   },
   "screens.ObservationMetadataVerified.dataEntered": {
     "message": "This data was manually entered."
@@ -1414,7 +1414,7 @@
     "message": "Sent by CoMapeo"
   },
   "screens.ObservationMetadataVerified.sentFrom": {
-    "message": "CoMapeo Data sent from"
+    "message": "CoMapeo Metadata sent from"
   },
   "screens.ObservationMetadataVerified.speed": {
     "message": "Speed"

--- a/src/frontend/screens/ObservationMetadata.tsx
+++ b/src/frontend/screens/ObservationMetadata.tsx
@@ -66,7 +66,7 @@ const m = defineMessages({
   },
   sentFrom: {
     id: 'screens.ObservationMetadataVerified.sentFrom',
-    defaultMessage: 'CoMapeo Data sent from',
+    defaultMessage: 'CoMapeo Metadata sent from',
   },
   fallbackPresetName: {
     id: 'screens.Observation.fallbackPresetName',
@@ -74,9 +74,9 @@ const m = defineMessages({
     description:
       'Fallback name used when category name cannot be determined for observation',
   },
-  coMapeoData: {
-    id: 'screens.ObservationMetadataVerified.coMapeoData',
-    defaultMessage: 'CoMapeo Data',
+  coMapeoMetadata: {
+    id: 'screens.ObservationMetadataVerified.coMapeoMetadata',
+    defaultMessage: 'CoMapeo Metadata',
   },
   date: {
     id: 'screens.ObservationMetadataVerified.date',
@@ -262,7 +262,7 @@ export const ObservationMetadata: NativeNavigationComponent<
       : `-${formatMessage(m.locationManuallyEntered)}-\n-${formatMessage(m.sentByComapeo)}-`;
 
     const projectName = !name
-      ? formatMessage(m.coMapeoData)
+      ? formatMessage(m.coMapeoMetadata)
       : formatMessage(m.sentFrom) + ' ' + name;
 
     const categoryName = preset


### PR DESCRIPTION
closes #1441 
Changes to word data to metadata when sharing metadata.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e5e4f89c-f1e0-48ed-81e4-8833999f9752" />
