### PR TITLE
chore: adds comapeo website to about page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -521,6 +521,9 @@
     "description": "Label for Android version",
     "message": "Android version"
   },
+  "screens.AboutSettings.comapeoWebsiteLabel": {
+    "message": "CoMapeo Website"
+  },
   "screens.AboutSettings.earlyAccessBanner": {
     "message": "You are in Early Access Mode."
   },

--- a/src/frontend/screens/Settings/About.tsx
+++ b/src/frontend/screens/Settings/About.tsx
@@ -77,6 +77,10 @@ const m = defineMessages({
     id: 'screens.AboutSettings.earlyAccessBanner',
     defaultMessage: 'You are in Early Access Mode.',
   },
+  comapeoWebsiteLabel: {
+    id: 'screens.AboutSettings.comapeoWebsiteLabel',
+    defaultMessage: 'CoMapeo Website',
+  },
 });
 
 const DeviceInfoListItem = ({
@@ -144,7 +148,9 @@ export const AboutSettings = () => {
           label={t(m.phoneModel)}
           deviceInfoMethod="getModel"
         />
-        <ListItem disableGutters>
+        <ListItem
+          disableGutters
+          onPress={() => Linking.openURL('https://openmoji.org/')}>
           <ListItemText
             primary={t(m.emojiSource)}
             secondary="https://openmoji.org/"
@@ -154,6 +160,14 @@ export const AboutSettings = () => {
           <ListItemText
             primary={t(m.releaseNameLabel)}
             secondary={t(m.releaseName)}
+          />
+        </ListItem>
+        <ListItem
+          disableGutters
+          onPress={() => Linking.openURL('https://comapeo.app')}>
+          <ListItemText
+            primary={t(m.comapeoWebsiteLabel)}
+            secondary="comapeo.app"
           />
         </ListItem>
       </List>

--- a/tests/e2e/specs/settings/about-comapeo.test.ts
+++ b/tests/e2e/specs/settings/about-comapeo.test.ts
@@ -24,6 +24,7 @@ describe('Settings - About CoMapeo Flow', () => {
     await expect($(byTextMatches('Phone model'))).toBeDisplayed();
     await expect($(byTextMatches('Emojis source'))).toBeDisplayed();
     await expect($(byTextMatches('Release name'))).toBeDisplayed();
+    await expect($(byTextMatches('CoMapeo Website'))).toBeDisplayed();
   });
 
   it('should navigate back to map screen', async () => {


### PR DESCRIPTION
closes #1450 

- Adds an item on the About CoMapeo page for the coMapeo website. 
- Links to that page. 
- Also added a link to the open emoji source.
- Updated the E2E test for it.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/46b77f20-7e57-4b0e-94a4-2f00233cd700" />

