### PR TITLE
fix: removes unnecessary translations

### DIFF
--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -70,12 +70,7 @@ export const ObservationCreate = ({
   const projectDetails = useProjectRoleAndDetails(projectId);
   const {updateTags} = useDraftObservation();
 
-  const presetName = preset
-    ? formatMessage({
-        id: `presets.${preset.docId}.name`,
-        defaultMessage: preset.name,
-      })
-    : formatMessage(m.observation);
+  const presetName = preset ? preset.name : formatMessage(m.observation);
 
   return (
     <ScreenContentWithDock

--- a/src/frontend/screens/ObservationEdit/index.tsx
+++ b/src/frontend/screens/ObservationEdit/index.tsx
@@ -77,12 +77,7 @@ export const ObservationEdit: NativeNavigationComponent<'ObservationEdit'> = ({
   const queryClient = useQueryClient();
 
   const notes = value?.tags.notes;
-  const presetName = preset
-    ? formatMessage({
-        id: `presets.${preset.docId}.name`,
-        defaultMessage: preset.name,
-      })
-    : formatMessage(m.observation);
+  const presetName = preset ? preset.name : formatMessage(m.observation);
 
   // TODO: This shouldn't be an effect, the logic should happen when the user
   // presses the edit button.

--- a/src/frontend/screens/ObservationFields/SelectOne.tsx
+++ b/src/frontend/screens/ObservationFields/SelectOne.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {View, StyleSheet} from 'react-native';
 import {Text} from '../../sharedComponents/Text';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
-import {useIntl} from 'react-intl';
 
 import {TouchableNativeFeedback} from '../../sharedComponents/Touchables';
 import {VERY_LIGHT_BLUE} from '../../lib/styles';
@@ -40,8 +39,6 @@ const RadioItem = ({checked, onPress, label, style}: RadioItemProps) => (
 );
 
 export const SelectOne = React.memo<Props>(({field}) => {
-  const {formatMessage: t} = useIntl();
-
   const {updateTags} = useDraftObservation();
   const tags = usePersistedDraftObservation(store => store.value?.tags);
 
@@ -53,10 +50,7 @@ export const SelectOne = React.memo<Props>(({field}) => {
           key={item.label}
           onPress={() => updateTags(field.tagKey, item.value)}
           checked={tags && item.value === tags[field.tagKey] ? true : false}
-          label={t({
-            id: `fields.${field.docId}.options.${JSON.stringify(item.value)}`,
-            defaultMessage: item.label,
-          })}
+          label={item.label}
           style={[styles.radioContainer, index === 0 ? styles.noBorder : {}]}
         />
       ))}

--- a/src/frontend/screens/SaveTrack/SaveTrackScreen.tsx
+++ b/src/frontend/screens/SaveTrack/SaveTrackScreen.tsx
@@ -29,12 +29,7 @@ export const SaveTrackScreen = () => {
 
   const canChoosePreset = trackPresets.length > 0;
 
-  const presetName = preset
-    ? t({
-        id: `presets.${preset.docId}.name`,
-        defaultMessage: preset.name,
-      })
-    : t(m.newTitle);
+  const presetName = preset ? preset.name : t(m.newTitle);
 
   useFocusEffect(
     useCallback(() => {

--- a/src/frontend/screens/TrackEdit/index.tsx
+++ b/src/frontend/screens/TrackEdit/index.tsx
@@ -81,12 +81,7 @@ export const TrackEdit: NativeNavigationComponent<'TrackEdit'> = ({
   }, [trackId, setTrackId]);
 
   const presetName = useMemo(() => {
-    return preset
-      ? formatMessage({
-          id: `presets.${preset.docId}.name`,
-          defaultMessage: preset.name,
-        })
-      : formatMessage(m.presetTitle);
+    return preset ? preset.name : formatMessage(m.presetTitle);
   }, [preset, formatMessage]);
 
   const saveTrack = useCallback(() => {

--- a/src/frontend/sharedComponents/FormattedData.tsx
+++ b/src/frontend/sharedComponents/FormattedData.tsx
@@ -44,11 +44,11 @@ export const FormattedCoords = ({
   return <>{formatCoords({lon, lat, format})}</>;
 };
 
-// Render the translated value of a translatable Field property (one of
-// `label`, `placeholder` or `helperText`). `label` will always render
-// something: if it is undefined or an empty string, then it will use the field
-// key as the label. `placeholder` and `helperText` will render to null if they
-// are not defined.
+// Render the value of a Field property (one of `label`, `placeholder` or
+// `helperText`). Core is responsible for translation, so just uses the plain
+// string value. `label` will always render something: if it is undefined or an
+// empty string, then it will use the field key as the label. `placeholder` and
+// `helperText` will render to null if they are not defined.
 export const FormattedFieldProp = ({
   field,
   propName,
@@ -56,13 +56,9 @@ export const FormattedFieldProp = ({
   field: Field;
   propName: 'label' | 'placeholder' | 'helperText';
 }) => {
-  const {formatMessage: t} = useIntl();
   const fieldKey = field.tagKey;
   const value = field[propName]
-    ? t({
-        id: `fields.${field.docId}.${propName}`,
-        defaultMessage: field[propName],
-      })
+    ? field[propName]
     : // Never show a blank label, fall back to field.key, otherwise return null
       propName === 'label'
       ? fieldKey
@@ -74,7 +70,7 @@ export const FormattedFieldProp = ({
 // Render a field value as a string. If the value is an array, convert to string
 // and join with `, `. If the field is a select_one or select_multiple field,
 // then use `field.option.label` to display the value, if a label is defined.
-// Translate the field value if a translation is defined.
+// Core is responsible for translation, so just uses the plain string value.
 //
 // TODO: Consider an API like
 // https://formatjs.io/docs/react-intl/components#formatteddateparts to enable
@@ -95,12 +91,7 @@ export const FormattedFieldValue = ({
       formattedValue =>
         typeof formattedValue !== 'undefined' && formattedValue !== '',
     )
-    .map(formattedValue =>
-      t({
-        id: `fields.${field.docId}.options.${JSON.stringify(formattedValue)}`,
-        defaultMessage: getValueLabel(formattedValue, field),
-      }).trim(),
-    )
+    .map(formattedValue => getValueLabel(formattedValue, field).trim())
     .join(', ');
   // This will return a noAnswer string if formattedValue is undefined or an
   // empty string

--- a/src/frontend/sharedComponents/FormattedData.tsx
+++ b/src/frontend/sharedComponents/FormattedData.tsx
@@ -124,13 +124,12 @@ export const FormattedObservationDate = React.memo(
   },
 );
 
-// Format the translated preset name, with a fallback to "Observation" if no
-// preset is defined
+// Format the preset name, with a fallback to "Observation" if no preset is
+// defined. Core is responsible for translation, so we just use the plain
+// string value.
 export const FormattedPresetName = ({preset}: {preset?: Preset}) => {
   const {formatMessage: t} = useIntl();
-  const name = preset
-    ? t({id: `presets.${preset.docId}.name`, defaultMessage: preset.name})
-    : t(m.observation);
+  const name = preset ? preset.name : t(m.observation);
 
   return <React.Fragment>{name}</React.Fragment>;
 };


### PR DESCRIPTION
closes #1404 
Fixes the issue where components were attempting to translate already-translated strings from Core, resulting in noisy react-intl error logs.
The client-side code was incorrectly attempting to re-translate these values using react-intl with dynamic translation IDs, which would never have corresponding translations since these values are only known at runtime.
This should eliminates the react-intl "[missing translation]" error logs that were appearing.