### PR TITLE
feat: updated team member card

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2086,6 +2086,9 @@
   "screens.TrackRecordingActive.warningMessage": {
     "message": "You’re currently recording a track. To join project, stop recording"
   },
+  "screens.YourTeam.TeamMemberCard.thisDevice": {
+    "message": "This device"
+  },
   "shareComponent.KeyboardAccessory.showOptions": {
     "description": "title for observation options",
     "message": "Show Options"

--- a/src/frontend/screens/YourTeam/TeamMemberCard.tsx
+++ b/src/frontend/screens/YourTeam/TeamMemberCard.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import {StyleSheet, View, TouchableOpacity} from 'react-native';
+import {
+  BLUE_GREY,
+  BLACK,
+  LIGHT_GREY,
+  DARK_GREY,
+  MEDIUM_GREY,
+} from '../../lib/styles';
+import MaterialIcons from '@react-native-vector-icons/material-icons';
+import type {DeviceType} from '../../sharedTypes';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
+import {defineMessages, useIntl} from 'react-intl';
+import ShieldIcon from '../../images/BlackShield.svg';
+
+const m = defineMessages({
+  thisDevice: {
+    id: 'screens.YourTeam.TeamMemberCard.thisDevice',
+    defaultMessage: 'This device',
+  },
+});
+
+type TeamMemberCardProps = {
+  deviceType: DeviceType;
+  name: string;
+  onPress?: () => void;
+  thisDevice: boolean;
+};
+
+export const TeamMemberCard = ({
+  deviceType,
+  name,
+  onPress,
+  thisDevice,
+}: TeamMemberCardProps) => {
+  const {formatMessage} = useIntl();
+
+  return (
+    <TouchableOpacity
+      disabled={!onPress}
+      onPress={onPress}
+      style={styles.container}>
+      <DeviceIcon deviceType={deviceType} />
+      <View style={styles.textContainer}>
+        <View style={styles.nameRow}>
+          <HeaderText
+            variant="header6"
+            style={styles.nameText}
+            numberOfLines={2}
+            ellipsizeMode="tail">
+            {name}
+          </HeaderText>
+          {thisDevice && (
+            <BodyText
+              variant="smallMeta"
+              style={styles.thisDeviceText}
+              numberOfLines={2}
+              ellipsizeMode="tail">
+              {formatMessage(m.thisDevice)}
+            </BodyText>
+          )}
+        </View>
+      </View>
+      {onPress && (
+        <MaterialIcons name="chevron-right" size={20} color={BLACK} />
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const DeviceIcon = ({deviceType}: {deviceType: DeviceType}) => {
+  const getIconContent = () => {
+    switch (deviceType) {
+      case 'mobile':
+        return <MaterialIcons name="smartphone" size={15} color={DARK_GREY} />;
+      case 'tablet':
+        return (
+          <MaterialIcons name="tablet-android" size={15} color={DARK_GREY} />
+        );
+      case 'desktop':
+        return <MaterialIcons name="computer" size={15} color={DARK_GREY} />;
+      case 'selfHostedServer':
+        return <ShieldIcon width={15} height={21} />;
+      case 'UNRECOGNIZED':
+      case 'device_type_unspecified':
+      case undefined:
+      default:
+        return (
+          <MaterialIcons name="help-outline" size={15} color={DARK_GREY} />
+        );
+    }
+  };
+
+  return <View style={styles.iconContainer}>{getIconContent()}</View>;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 15,
+    gap: 15,
+    borderWidth: 1,
+    borderColor: BLUE_GREY,
+    borderRadius: 6,
+  },
+  iconContainer: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    backgroundColor: LIGHT_GREY,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  textContainer: {
+    flex: 1,
+    minWidth: 0,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  nameText: {
+    flexShrink: 1,
+    lineHeight: 18,
+    includeFontPadding: false,
+  },
+  thisDeviceText: {
+    color: MEDIUM_GREY,
+    lineHeight: 18,
+    includeFontPadding: false,
+  },
+});

--- a/src/frontend/screens/YourTeam/TeamMemberCard.tsx
+++ b/src/frontend/screens/YourTeam/TeamMemberCard.tsx
@@ -24,7 +24,7 @@ const m = defineMessages({
 type TeamMemberCardProps = {
   deviceType: DeviceType;
   name: string;
-  onPress?: () => void;
+  onPress: () => void;
   thisDevice: boolean;
 };
 
@@ -37,10 +37,7 @@ export const TeamMemberCard = ({
   const {formatMessage} = useIntl();
 
   return (
-    <TouchableOpacity
-      disabled={!onPress}
-      onPress={onPress}
-      style={styles.container}>
+    <TouchableOpacity onPress={onPress} style={styles.container}>
       <DeviceIcon deviceType={deviceType} />
       <View style={styles.textContainer}>
         <View style={styles.nameRow}>
@@ -62,9 +59,7 @@ export const TeamMemberCard = ({
           )}
         </View>
       </View>
-      {onPress && (
-        <MaterialIcons name="chevron-right" size={30} color={BLACK} />
-      )}
+      <MaterialIcons name="chevron-right" size={30} color={BLACK} />
     </TouchableOpacity>
   );
 };

--- a/src/frontend/screens/YourTeam/TeamMemberCard.tsx
+++ b/src/frontend/screens/YourTeam/TeamMemberCard.tsx
@@ -63,7 +63,7 @@ export const TeamMemberCard = ({
         </View>
       </View>
       {onPress && (
-        <MaterialIcons name="chevron-right" size={20} color={BLACK} />
+        <MaterialIcons name="chevron-right" size={30} color={BLACK} />
       )}
     </TouchableOpacity>
   );

--- a/src/frontend/screens/YourTeam/index.tsx
+++ b/src/frontend/screens/YourTeam/index.tsx
@@ -12,13 +12,11 @@ import MaterialIcon from '@react-native-vector-icons/material-icons';
 import type {MaterialIconsIconName} from '@react-native-vector-icons/material-icons';
 import {BLACK} from '../../lib/styles';
 import {DeviceCard} from '../../sharedComponents/DeviceCard';
-import {TeamMemberCard} from './TeamMemberCard';
 import {useOwnDeviceInfo, useManyMembers} from '@comapeo/core-react';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {SecondaryButton} from '../../sharedComponents/Buttons';
-
 const m = defineMessages({
   title: {
     id: 'screens.Setting.ProjectSettings.YourTeam.title',
@@ -55,7 +53,6 @@ const m = defineMessages({
       'Participants can take and share observations. They cannot manage users or project details.',
   },
 });
-
 export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
   navigation,
 }) => {
@@ -63,7 +60,6 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
   const {projectId} = useActiveProject();
   const membersQuery = useManyMembers({projectId});
   const {data: deviceInfo} = useOwnDeviceInfo();
-
   const coordinators = !membersQuery.data
     ? []
     : membersQuery.data.filter(
@@ -71,11 +67,9 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
           member.role.roleId === COORDINATOR_ROLE_ID ||
           member.role.roleId === CREATOR_ROLE_ID,
       );
-
   const participants = !membersQuery.data
     ? []
     : membersQuery.data.filter(member => member.role.roleId === MEMBER_ROLE_ID);
-
   return (
     <ScrollView style={styles.container}>
       {!deviceInfo ||
@@ -102,19 +96,28 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
       />
       <BodyText style={{marginTop: 10}}>{t(m.coordinatorDescription)}</BodyText>
 
-      <View style={{marginTop: 20, gap: 10}}>
-        {coordinators.map(coordinator => (
-          <TeamMemberCard
-            key={coordinator.deviceId}
-            name={coordinator.name || ''}
-            deviceType={coordinator.deviceType}
-            thisDevice={deviceInfo.deviceId === coordinator.deviceId}
-            onPress={() => {
-              console.log('Pressed coordinator:', coordinator.name);
-            }}
-          />
-        ))}
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginTop: 20,
+        }}>
+        <BodyText style={{marginTop: 10}}>{t(m.deviceName)}</BodyText>
+        <BodyText style={{marginTop: 10}}>{t(m.dateAdded)}</BodyText>
       </View>
+
+      {coordinators.map(coordinator => (
+        <DeviceCard
+          key={coordinator.deviceId}
+          style={{marginTop: 10}}
+          name={coordinator.name || ''}
+          deviceId={coordinator.deviceId}
+          dateAdded={coordinator.joinedAt}
+          deviceType={coordinator.deviceType}
+          thisDevice={deviceInfo.deviceId === coordinator.deviceId}
+        />
+      ))}
 
       <IconHeader
         iconName="people"
@@ -122,7 +125,6 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
         style={{marginTop: 20}}
       />
       <BodyText style={{marginTop: 10}}>{t(m.participantDescription)}</BodyText>
-
       {participants.map(participant => (
         <DeviceCard
           key={participant.deviceId}

--- a/src/frontend/screens/YourTeam/index.tsx
+++ b/src/frontend/screens/YourTeam/index.tsx
@@ -12,6 +12,7 @@ import MaterialIcon from '@react-native-vector-icons/material-icons';
 import type {MaterialIconsIconName} from '@react-native-vector-icons/material-icons';
 import {BLACK} from '../../lib/styles';
 import {DeviceCard} from '../../sharedComponents/DeviceCard';
+import {TeamMemberCard} from './TeamMemberCard';
 import {useOwnDeviceInfo, useManyMembers} from '@comapeo/core-react';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
@@ -101,28 +102,19 @@ export const YourTeam: NativeNavigationComponent<'YourTeam'> = ({
       />
       <BodyText style={{marginTop: 10}}>{t(m.coordinatorDescription)}</BodyText>
 
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginTop: 20,
-        }}>
-        <BodyText style={{marginTop: 10}}>{t(m.deviceName)}</BodyText>
-        <BodyText style={{marginTop: 10}}>{t(m.dateAdded)}</BodyText>
+      <View style={{marginTop: 20, gap: 10}}>
+        {coordinators.map(coordinator => (
+          <TeamMemberCard
+            key={coordinator.deviceId}
+            name={coordinator.name || ''}
+            deviceType={coordinator.deviceType}
+            thisDevice={deviceInfo.deviceId === coordinator.deviceId}
+            onPress={() => {
+              console.log('Pressed coordinator:', coordinator.name);
+            }}
+          />
+        ))}
       </View>
-
-      {coordinators.map(coordinator => (
-        <DeviceCard
-          key={coordinator.deviceId}
-          style={{marginTop: 10}}
-          name={coordinator.name || ''}
-          deviceId={coordinator.deviceId}
-          dateAdded={coordinator.joinedAt}
-          deviceType={coordinator.deviceType}
-          thisDevice={deviceInfo.deviceId === coordinator.deviceId}
-        />
-      ))}
 
       <IconHeader
         iconName="people"


### PR DESCRIPTION
closes #1469

- Adds the team member card
- Uses it in a temporary way on the team member page so you can play around with it if you wish.
- Includes props for deviceType, name, onPress, and thisDevice. 
- Creates its own components and styling rather than reusing existing ones because reusing would add too many complications and conditionals.  I can clean up those subcomponents when I do the team member page.
- I made the decision to allow the text to grow to two lines for long device names or people who are using large display and fonts
- I had to add the line height and font padding to get it so that the two text components would line up correctly.
- Does the Chevron look big enough? I wasn't sure. I also made it so the chevron is not there if there is no On Press. Sound good?

Some screen shots:


Largest text and large display
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e6506c7b-cfca-4afc-9168-56617369cbd3" />




regular size text
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e6c04c30-5756-4f6a-8587-a32134c66050" />


