### PR TITLE
fix: observation edit with photo category change

### DIFF
--- a/src/frontend/sharedComponents/Editor/index.tsx
+++ b/src/frontend/sharedComponents/Editor/index.tsx
@@ -143,10 +143,7 @@ export const Editor = ({
                   );
                 }
                 // observationId must exist if there is a saved photo
-                if (isSavedPhoto(att)) {
-                  if (!observationId) {
-                    return <ThumbnailLoader size={size} key={att.hash} />;
-                  }
+                if (isSavedPhoto(att) && observationId) {
                   return (
                     <React.Suspense
                       key={att.driveDiscoveryId + att.hash + att.type}
@@ -165,10 +162,7 @@ export const Editor = ({
                   );
                 }
 
-                if (isAudioAttachment(att)) {
-                  if (!observationId) {
-                    return <ThumbnailLoader size={size} key={att.name} />;
-                  }
+                if (isAudioAttachment(att) && observationId) {
                   return (
                     <AudioSavedThumbnail
                       size={size}

--- a/src/frontend/sharedComponents/Editor/index.tsx
+++ b/src/frontend/sharedComponents/Editor/index.tsx
@@ -144,10 +144,9 @@ export const Editor = ({
                 }
                 // observationId must exist if there is a saved photo
                 if (isSavedPhoto(att)) {
-                  if (!observationId)
-                    throw new Error(
-                      'Observation ID is required for saved photos',
-                    );
+                  if (!observationId) {
+                    return <ThumbnailLoader size={size} key={att.hash} />;
+                  }
                   return (
                     <React.Suspense
                       key={att.driveDiscoveryId + att.hash + att.type}
@@ -166,7 +165,10 @@ export const Editor = ({
                   );
                 }
 
-                if (isAudioAttachment(att) && observationId) {
+                if (isAudioAttachment(att)) {
+                  if (!observationId) {
+                    return <ThumbnailLoader size={size} key={att.name} />;
+                  }
                   return (
                     <AudioSavedThumbnail
                       size={size}


### PR DESCRIPTION
closes #1486 and 
closes #1492
The problem was that after saving, the category chooser was still in the navigation stack and it rerenders when clearDraft() is called, which clears the observationId from persisted state. This causes both CategoryChooser and Editor to re-render with observationId: undefined before navigation completes.
So, to fix this issue of temporary missing observation id, Show a loader during navigation transitions when it might be temporarily undefined
Handles the root cause, which is the components rendering with temporarily undefined state
Works for any scenario where the Editor renders during state transitions (not just category changes)

https://github.com/user-attachments/assets/fac6d847-4b6b-4688-a8ee-8d3084228dd5

Alternatively, we could instead change the Observation Category Chooser in here:
```
const handleSelect = (preset: Preset) => {
    updatePreset(preset);
    if (observationId) {
       navigation.goBack()
    // get rid of the below
    //  navigation.navigate('ObservationEdit', {observationId});
    } else {
      navigation.navigate('ObservationCreate');
    }
  };
```
I didn't test this way very much, so if you prefer that method, one of us should do some thorough testing.
Whatever you prefer.

