### PR TITLE
fix: edit track category

### DIFF
--- a/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
@@ -43,7 +43,7 @@ export const TrackCategoryChooser: NativeNavigationComponent<
   const handleSelect = (preset: Preset) => {
     setTrackPreset(preset);
     if (trackId) {
-      navigation.navigate('TrackEdit', {trackId});
+      navigation.goBack();
     } else {
       navigation.navigate('SaveTrack');
     }

--- a/src/frontend/screens/TrackEdit/index.tsx
+++ b/src/frontend/screens/TrackEdit/index.tsx
@@ -64,12 +64,13 @@ export const TrackEdit: NativeNavigationComponent<'TrackEdit'> = ({
 
   useEffect(() => {
     if (
+      !preset &&
       track?.presetRef?.docId &&
       foundPreset?.docId === track.presetRef.docId
     ) {
       setTrackPreset(foundPreset);
     }
-  }, [track, foundPreset, setTrackPreset]);
+  }, [track, foundPreset, setTrackPreset, preset]);
 
   useEffect(() => {
     if (trackId) {

--- a/src/frontend/screens/TrackEdit/index.tsx
+++ b/src/frontend/screens/TrackEdit/index.tsx
@@ -66,11 +66,13 @@ export const TrackEdit: NativeNavigationComponent<'TrackEdit'> = ({
     if (
       !preset &&
       track?.presetRef?.docId &&
-      foundPreset?.docId === track.presetRef.docId
+      foundPreset?.docId === track.presetRef.docId &&
+      editTrackMutation.status !== 'pending' &&
+      editTrackMutation.status !== 'success'
     ) {
       setTrackPreset(foundPreset);
     }
-  }, [track, foundPreset, setTrackPreset, preset]);
+  }, [track, foundPreset, setTrackPreset, preset, editTrackMutation.status]);
 
   useEffect(() => {
     if (trackId) {


### PR DESCRIPTION
closes #1487 

- The TrackEdit screen has a useEffect that loads the preset from the saved track on mount. However, this useEffect was running after the user selected a new category in CategoryChooser, overwriting their selection with the track's original preset.

So this fix only loads the  preset if we don't already have one.

- This preserves the preset selected in CategoryChooser while still loading the preset on initial mount.
- Also, the mutation status checks prevent loading stale data during the brief moment after save when clearCurrentTrack() clears the preset state.
- Use goBack() in TrackCategoryChooser to preserve the screen state.

Testing

- Create and save a track with category "Boundary" (or whatever)
- Edit the track and change category to "Stream" (or whatever)
- Save
- Track should now show "Stream" category.
- Go to edit it again. It should still be "Stream" (before I added the mutation checks this was not the case)