### PR TITLE
fix: language E2E test

### DIFF
--- a/tests/e2e/specs/settings/language.test.ts
+++ b/tests/e2e/specs/settings/language.test.ts
@@ -48,7 +48,7 @@ describe('Settings - Language Settings Flow', () => {
       await drawerIcon.click();
     }
 
-    const settingsInSpanish = $(byTextMatches('Ajustes de la'));
+    const settingsInSpanish = $(byTextMatches('Ajustes de'));
     await settingsInSpanish.click();
 
     const idiomaOption = await $(byTextMatches('Idioma'));


### PR DESCRIPTION
Checks for Spanish language that is up to date with the new text in the app.
Our settings button label changed, so we have to change what the spanish language check is looking for 
We went from App Settings to Comapeo Settings so the Spanish language text finding has to change a smidge.