### PR TITLE
fix: tracks crash on error

### DIFF
--- a/src/frontend/contexts/TrackStoreContext.tsx
+++ b/src/frontend/contexts/TrackStoreContext.tsx
@@ -82,7 +82,20 @@ export function createTrackStore({persist} = {persist: false}) {
     store = createStore(
       createPersistedState(createInitialState, {
         name: STORAGE_KEY,
-        storage: createJSONStorage(() => MMKVStoreInitializer),
+        storage: createJSONStorage(() => MMKVStoreInitializer, {
+          // When deserializing from JSON, convert trackingSince back to a Date object
+          // This handles app reloads, crashes, updates, and any scenario where persisted state is restored
+          reviver: (key, value) => {
+            if (
+              key === 'trackingSince' &&
+              value !== null &&
+              (typeof value === 'string' || typeof value === 'number')
+            ) {
+              return new Date(value);
+            }
+            return value;
+          },
+        }),
         version: 1,
         migrate: (persistedState, version): TrackState => {
           const newState = createInitialState();

--- a/src/frontend/hooks/useFormattedTimeSince.ts
+++ b/src/frontend/hooks/useFormattedTimeSince.ts
@@ -4,8 +4,10 @@ import {useCurrentTime} from './useCurrentTime';
 export const useFormattedTimeSince = (start: Date | null, interval: number) => {
   const currentTime = useCurrentTime(interval);
 
-  const millisPassed = start
-    ? Math.abs(currentTime.getTime() - start.getTime())
+  const startDate = start instanceof Date ? start : null;
+
+  const millisPassed = startDate
+    ? Math.abs(currentTime.getTime() - startDate.getTime())
     : 0;
   return millisecondsToHHMMSS(millisPassed);
 };


### PR DESCRIPTION
closes #1498  
Puts date back to date object of it gets out of format during a crash.
### The Problem
When you record a track, the app stores trackingSince as a Date object. But when the app crashes and restarts, that Date gets saved to storage as JSON text (like "2025-10-28T12:34:56.789Z"). When the app loads it back, it's still text, not a Date object anymore. Then when the code tries to call trackingSince.getTime(), it crashes because text strings don't have a .getTime() function - only Date objects do.

### The Fix
I Added a reviver function to the Zustand context that automatically converts the text back into a Date object when loading from storage. Also, there is a backup fix in the method where the crash was throwing: Added a safety check in useFormattedTimeSince that says "if this isn't a Date object, just show 00:00:00 instead of crashing."

[I used the reviver from Zustand.](https://zustand.docs.pmnd.rs/integrations/persisting-store-data#createjsonstorage)

### Why It Matters
This fixes the unrecoverable crash. Now if ANY error happens while tracking, the app can restart and the track will still work correctly. I _think_ it will also help in the situation where If the app is backgrounded and Android kills it to save memory, when it restarts it should reload from persisted state (fingers crossed) or if someone force closes the app.


How to throw an error:
Modify `UserTooltipMarker.tsx`

add:
```

let hasAlreadyCrashed = false;

export const UserTooltipMarker = () => {
  useEffect(() => {
    if (!hasAlreadyCrashed) {
      const timeout = setTimeout(() => {
        hasAlreadyCrashed = true;
        throw new Error('Test crash during tracking');
      }, 3000);
      return () => clearTimeout(timeout);
    }
  }, []);
```

Start recording a track. It will crash. Dismiss the error. You will see that the Track is still recording.




