### PR TITLE
fix: prevent back button track category chooser

### DIFF
--- a/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
@@ -11,6 +11,7 @@ import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
 import {usePresetsSelection} from '@comapeo/core-react';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useAppLanguageTag} from '../../hooks/useAppLanguageTag';
+import {usePreventAndroidBackButton} from '../../hooks/usePreventAndroidBackButton';
 
 const m = defineMessages({
   title: {
@@ -24,6 +25,7 @@ export const TrackCategoryChooser: NativeNavigationComponent<
 > = ({navigation}) => {
   const {projectId} = useActiveProject();
   const languageTag = useAppLanguageTag();
+  usePreventAndroidBackButton();
   const presets = usePresetsSelection({
     projectId: projectId,
     dataType: 'observation',
@@ -35,6 +37,9 @@ export const TrackCategoryChooser: NativeNavigationComponent<
   );
   const existingPreset = useTrackState(state => state.preset);
   const trackId = useTrackState(state => state.docId);
+
+  // const isNewTrack = !existingPreset && !trackId;
+  // usePreventRemove(isNewTrack, () => {});
 
   const handleGoBack = React.useCallback(() => {
     navigation.goBack();

--- a/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/TrackCategoryChooser.tsx
@@ -38,9 +38,6 @@ export const TrackCategoryChooser: NativeNavigationComponent<
   const existingPreset = useTrackState(state => state.preset);
   const trackId = useTrackState(state => state.docId);
 
-  // const isNewTrack = !existingPreset && !trackId;
-  // usePreventRemove(isNewTrack, () => {});
-
   const handleGoBack = React.useCallback(() => {
     navigation.goBack();
   }, [navigation]);


### PR DESCRIPTION
closes #1501 

- Adds prevent back button to track category chooser.
- I tried to use usePreventRemove but that does not work because we do need to navigate away from the screen of course.
- I also thought it was more in keeping with our behavior to just prevent the back button instead of showing the dialogue as was suggested in the issue by Lu. We do show the discard dialogue if someone presses the x.
- I just use the prevent back button all the time and navigation away can be handled with the top left x/ check mark (where it calls the dialogue on a new track or goes back to the previous screen depending on if it is a new track or pre-existing track).
