### PR TITLE
fix: return to ongoing track

### DIFF
--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -42,6 +42,7 @@ import {isLowStorage} from '../../lib/storage';
 import {LowStorageBanner} from '../../sharedComponents/Storage/LowStorageBanner';
 import {useAppUsageStatsStore} from '../../contexts/AppUsageStatsContext';
 import {useShouldShowAppUsagePrompt} from '../../hooks/useShouldShowAppUsagePrompt';
+import {useTrackState} from '../../contexts/TrackStoreContext';
 
 // This is the default zoom used when the map first loads, and also the zoom
 // that the map will zoom to if the user clicks the "Locate" button and the
@@ -93,6 +94,7 @@ export const MapScreen = ({
   const BANNER_TOP = insets.top + 75;
 
   useCheckDraftObservationAndNavigate({authState});
+  useCheckUnsavedTrackAndNavigate({authState});
 
   useShouldShowAppUsagePrompt();
 
@@ -255,6 +257,31 @@ function useCheckDraftObservationAndNavigate({
         navigate('ObservationCreate');
       }
     }, [existingObservation, navigate, presets, authState]),
+  );
+}
+
+function useCheckUnsavedTrackAndNavigate({authState}: {authState: AuthState}) {
+  const {navigate} = useNavigationFromHomeTabs();
+  const hasUnsavedTrack = useTrackState(
+    state => !state.isTracking && state.locationHistory.length > 0,
+  );
+  const trackPreset = useTrackState(state => state.preset);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      // if no unsaved track or auth is obscured, stay home
+      if (!hasUnsavedTrack || authState === 'obscured') {
+        return;
+      }
+
+      // if no preset chosen, navigate to category chooser
+      if (!trackPreset) {
+        navigate('TrackCategoryChooser');
+      } else {
+        // if preset chosen, navigate to save track screen
+        navigate('SaveTrack');
+      }
+    }, [hasUnsavedTrack, trackPreset, navigate, authState]),
   );
 }
 


### PR DESCRIPTION
closes #1504 

- When someone navigates away from an ongoing track that is in the saving flow, they need a way to get back to it.
- This PR adds a focus effect for the map screen for an in-progress track.
- Adds automatic navigation back to the track save flow when users have stopped recording a track but haven't completed the save process
- Prevents users from being stuck with an unsaved track after accidentally navigating away from the save flow
- I used this check `isTracking === false but locationHistory.length > 0` as we discussed
- Follows the same pattern as useCheckDraftObservationAndNavigate for consistency
- I repeated the check for authState is obscured, which I think is necessary for each useEffect? But I am not sure...

To test:

- [ ]  Record a track and stop recording
- [ ]  Press back button from category chooser → verify you're taken back to category chooser, or force close the app and reopen it and should be on the category chooser screen
- [ ]  Choose a category, and reload the app from the save screen →  you should be taken to the save track screen
- [ ]  Complete the save flow successfully → verify you can navigate normally
- [ ]  Discard a track → verify you can navigate normally
- [ ]  Close app during save flow → verify on app reopen you're taken back to the save flow