### PR TITLE
chore: warn track discard on press of back button

### DIFF
--- a/src/frontend/screens/SaveTrack/HeaderLeft.tsx
+++ b/src/frontend/screens/SaveTrack/HeaderLeft.tsx
@@ -77,13 +77,7 @@ export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
         onPress={openSheet}
         headerBackButtonProps={headerBackButtonProps}
       />
-      <BottomSheetModal
-        onBack={() => {
-          openSheet();
-          return true;
-        }}
-        isOpen={isOpen}
-        ref={sheetRef}>
+      <BottomSheetModal isOpen={isOpen} ref={sheetRef}>
         <BottomSheetModalContent
           buttonConfigs={[
             {

--- a/src/frontend/screens/SaveTrack/HeaderLeft.tsx
+++ b/src/frontend/screens/SaveTrack/HeaderLeft.tsx
@@ -12,6 +12,8 @@ import {useTrackActions} from '../../contexts/TrackStoreContext';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import DiscardIcon from '../../images/delete.svg';
 import ErrorIcon from '../../images/Error.svg';
+import {useFocusEffect} from '@react-navigation/native';
+import {BackHandler} from 'react-native';
 
 const m = defineMessages({
   discardTitle: {
@@ -47,6 +49,22 @@ export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
   const {clearCurrentTrack} = useTrackActions();
   const navigation = useNavigationFromRoot();
 
+  useFocusEffect(
+    React.useCallback(() => {
+      const onBackPress = () => {
+        openSheet();
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        onBackPress,
+      );
+
+      return () => subscription.remove();
+    }, [openSheet]),
+  );
+
   function handleDiscard() {
     clearCurrentTrack();
     closeSheet();
@@ -59,7 +77,13 @@ export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
         onPress={openSheet}
         headerBackButtonProps={headerBackButtonProps}
       />
-      <BottomSheetModal isOpen={isOpen} ref={sheetRef}>
+      <BottomSheetModal
+        onBack={() => {
+          openSheet();
+          return true;
+        }}
+        isOpen={isOpen}
+        ref={sheetRef}>
         <BottomSheetModalContent
           buttonConfigs={[
             {


### PR DESCRIPTION
closes #1501.

Also closes #1503 as a an alternative pr.

This Pr prompts the user to confirm that they want to navigate away from the tracks preset page (and discard their track).

This behaviour mimics the behaviour seen in the observation preset page