### PR TITLE
chore: update project hook

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2159,5 +2159,11 @@
   },
   "soloProject.startNewProject.uniqueProject": {
     "message": "Each project is unique and separate."
+  },
+  "useProjectRoleAndDetails.coordinator": {
+    "message": "Coordinator"
+  },
+  "useProjectRoleAndDetails.participant": {
+    "message": "Participant"
   }
 }

--- a/src/frontend/hooks/useProjectRoleAndDetails.ts
+++ b/src/frontend/hooks/useProjectRoleAndDetails.ts
@@ -8,6 +8,18 @@ import {
   CREATOR_ROLE_ID,
   MEMBER_ROLE_ID,
 } from '../sharedTypes';
+import {defineMessages, useIntl} from 'react-intl';
+
+const m = defineMessages({
+  coordinator: {
+    id: 'useProjectRoleAndDetails.coordinator',
+    defaultMessage: 'Coordinator',
+  },
+  participant: {
+    id: 'useProjectRoleAndDetails.participant',
+    defaultMessage: 'Participant',
+  },
+});
 
 /**
  * Represents the role of a user within a project, as used in the frontend.
@@ -18,31 +30,24 @@ import {
 export type FrontendRole = 'coordinator' | 'participant' | 'solo';
 
 export type ProjectDetails = {
+  role: FrontendRole;
+  projectHeader: string;
+  projectName: string | undefined;
   projectColor: string;
   projectDescription?: string;
-} & (
-  | {
-      role: Extract<FrontendRole, 'solo'>;
-      projectHeader: string;
-      projectName: undefined;
-    }
-  | {
-      role: Exclude<FrontendRole, 'solo'>;
-      projectName: string;
-      projectDescription?: string;
-    }
-);
+};
 
 export function useProjectRoleAndDetails(projectId: string): ProjectDetails {
+  const {formatMessage} = useIntl();
   const {data: projectData} = useProjectSettings({projectId});
   const {
-    data: {name},
+    data: {name: deviceName},
   } = useOwnDeviceInfo();
   const {data: roleData} = useOwnRoleInProject({projectId});
 
   const soloProject: ProjectDetails = {
     role: 'solo',
-    projectHeader: name || '',
+    projectHeader: deviceName || '',
     projectName: undefined,
     projectColor: '#E5F0FF',
   };
@@ -55,6 +60,7 @@ export function useProjectRoleAndDetails(projectId: string): ProjectDetails {
   if (roleId === COORDINATOR_ROLE_ID || roleId === CREATOR_ROLE_ID) {
     return {
       role: 'coordinator',
+      projectHeader: `${projectData.name} - ${formatMessage(m.coordinator)}`,
       projectName: projectData.name,
       projectColor: projectData.projectColor || '#FFF5EB',
       projectDescription: projectData.projectDescription,
@@ -62,6 +68,7 @@ export function useProjectRoleAndDetails(projectId: string): ProjectDetails {
   } else if (roleId === MEMBER_ROLE_ID) {
     return {
       role: 'participant',
+      projectHeader: `${projectData.name} - ${formatMessage(m.participant)}`,
       projectName: projectData.name,
       projectColor: projectData.projectColor || '#FFF5EB',
       projectDescription: projectData.projectDescription,

--- a/src/frontend/screens/AllProjects.tsx
+++ b/src/frontend/screens/AllProjects.tsx
@@ -135,19 +135,14 @@ const ProjectListItem = ({
 }) => {
   const projectInfo = useProjectRoleAndDetails(projectId);
 
-  const header =
-    'projectHeader' in projectInfo
-      ? projectInfo.projectHeader
-      : projectInfo.projectName;
-
   return (
     <ColorCard
-      testID={`project_card_${header?.toLowerCase().replace(/\s+/g, '_')}`}
+      testID={`project_card_${projectInfo.projectHeader?.toLowerCase().replace(/\s+/g, '_')}`}
       onPress={onPress}
       borderColor={isSelected ? COMAPEO_BLUE : undefined}
       backgroundColor={projectInfo.projectColor}>
       <View style={{padding: 20}}>
-        <HeaderText variant="header4">{header}</HeaderText>
+        <HeaderText variant="header4">{projectInfo.projectHeader}</HeaderText>
       </View>
     </ColorCard>
   );

--- a/src/frontend/screens/ObservationCreate/index.tsx
+++ b/src/frontend/screens/ObservationCreate/index.tsx
@@ -87,9 +87,7 @@ export const ObservationCreate = ({
             paddingHorizontal: 20,
           }}>
           <HeaderText variant="header6">
-            {projectDetails.role === 'solo'
-              ? projectDetails.projectHeader
-              : projectDetails.projectName}
+            {projectDetails.projectHeader}
           </HeaderText>
         </View>
         <PresetView

--- a/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
+++ b/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
@@ -53,7 +53,7 @@ export const EditProjectDetails: NativeNavigationComponent<
   }>({
     defaultValues: {
       color: projectDetails.projectColor,
-      projectName: projectDetails.projectName,
+      projectName: projectDetails.projectName!,
       projectDescription: projectDetails.projectDescription,
     },
   });

--- a/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
+++ b/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
@@ -53,7 +53,7 @@ export const EditProjectDetails: NativeNavigationComponent<
   }>({
     defaultValues: {
       color: projectDetails.projectColor,
-      projectName: projectDetails.projectName!,
+      projectName: projectDetails.projectName,
       projectDescription: projectDetails.projectDescription,
     },
   });

--- a/src/frontend/screens/ProjectSettings/index.tsx
+++ b/src/frontend/screens/ProjectSettings/index.tsx
@@ -115,17 +115,13 @@ export const ProjectSettings = () => {
   const participantWithRemote =
     projectInfo.role === 'participant' && remoteArchiveOn;
 
-  const displayTitle = isSolo
-    ? projectInfo.projectHeader
-    : projectInfo.projectName;
-
   const sendStatsOn = configData.sendStats;
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <SettingsCardRow
         icon={<NoProjectIcon width={24} height={24} />}
-        title={displayTitle}
+        title={projectInfo.projectHeader}
         subtitle={
           isSolo
             ? formatMessage(m.soloDescription)
@@ -163,7 +159,7 @@ export const ProjectSettings = () => {
           }
           buttonText={formatMessage(m.viewTeam)}
           onPress={() =>
-            navigate('YourTeam', {projectName: projectInfo.projectName})
+            navigate('YourTeam', {projectName: projectInfo.projectName!})
           }
         />
       )}

--- a/src/frontend/screens/ProjectSettings/index.tsx
+++ b/src/frontend/screens/ProjectSettings/index.tsx
@@ -158,9 +158,7 @@ export const ProjectSettings = () => {
               : formatMessage(m.participant)
           }
           buttonText={formatMessage(m.viewTeam)}
-          onPress={() =>
-            navigate('YourTeam', {projectName: projectInfo.projectName!})
-          }
+          onPress={() => navigate('YourTeam')}
         />
       )}
       {(isCoordinator || participantWithRemote) && (

--- a/src/frontend/screens/TrackEdit/index.tsx
+++ b/src/frontend/screens/TrackEdit/index.tsx
@@ -115,9 +115,7 @@ export const TrackEdit: NativeNavigationComponent<'TrackEdit'> = ({
             paddingHorizontal: 20,
           }}>
           <HeaderText variant="header6">
-            {projectDetails.role === 'solo'
-              ? projectDetails.projectHeader
-              : projectDetails.projectName}
+            {projectDetails.projectHeader}
           </HeaderText>
         </View>
         <PresetView

--- a/src/frontend/sharedComponents/DrawerMenu.tsx
+++ b/src/frontend/sharedComponents/DrawerMenu.tsx
@@ -88,7 +88,8 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
 
   const {projectId} = useActiveProject();
   const projectDetails = useProjectRoleAndDetails(projectId);
-  const {role, projectColor, projectDescription, projectName} = projectDetails;
+  const {role, projectColor, projectDescription, projectName, projectHeader} =
+    projectDetails;
   const {data} = useStorageReadingQuery();
   const {freeBytes, totalBytes} = data;
   const isLow = isLowStorage(freeBytes);
@@ -108,9 +109,7 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
         <View>
           <ColorCard backgroundColor={projectColor}>
             <View style={{padding: 20, gap: 12}}>
-              <HeaderText variant="header2">
-                {role === 'solo' ? projectDetails.projectHeader : projectName}
-              </HeaderText>
+              <HeaderText variant="header2">{projectHeader}</HeaderText>
               <View
                 style={{
                   flexDirection: 'row',
@@ -183,7 +182,7 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
             <TouchableOpacity
               style={styles.menuItem}
               onPress={() => {
-                navigation.navigate('YourTeam', {projectName});
+                navigation.navigate('YourTeam', {projectName: projectName!});
               }}
               accessibilityLabel="Go to your team screen.">
               <MaterialIcon color={NEW_DARK_GREY} size={20} name={'people'} />

--- a/src/frontend/sharedComponents/DrawerMenu.tsx
+++ b/src/frontend/sharedComponents/DrawerMenu.tsx
@@ -88,7 +88,7 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
 
   const {projectId} = useActiveProject();
   const projectDetails = useProjectRoleAndDetails(projectId);
-  const {role, projectColor, projectDescription, projectName, projectHeader} =
+  const {role, projectColor, projectDescription, projectHeader} =
     projectDetails;
   const {data} = useStorageReadingQuery();
   const {freeBytes, totalBytes} = data;
@@ -182,7 +182,7 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
             <TouchableOpacity
               style={styles.menuItem}
               onPress={() => {
-                navigation.navigate('YourTeam', {projectName: projectName!});
+                navigation.navigate('YourTeam');
               }}
               accessibilityLabel="Go to your team screen.">
               <MaterialIcon color={NEW_DARK_GREY} size={20} name={'people'} />

--- a/src/frontend/sharedComponents/Editor/index.tsx
+++ b/src/frontend/sharedComponents/Editor/index.tsx
@@ -92,9 +92,7 @@ export const Editor = ({
             paddingHorizontal: 20,
           }}>
           <HeaderText variant="header6">
-            {projectDetails.role === 'solo'
-              ? projectDetails.projectHeader
-              : projectDetails.projectName}
+            {projectDetails.projectHeader}
           </HeaderText>
         </View>
         <PresetView {...presetProps} />

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -27,11 +27,6 @@ export function HomeHeader({
   const {data} = useStorageReadingQuery();
   const isLow = isLowStorage(data.freeBytes);
 
-  const projectName =
-    'projectHeader' in projectDetails
-      ? projectDetails.projectHeader
-      : projectDetails.projectName;
-
   return (
     <View
       style={[
@@ -60,7 +55,7 @@ export function HomeHeader({
             style={styles.text}
             numberOfLines={1}
             ellipsizeMode="tail">
-            {projectName}
+            {projectDetails.projectHeader}
           </HeaderText>
           {isLow && (
             <View style={{position: 'absolute', top: -2, right: -2}}>

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -103,7 +103,7 @@ export type RootStackParamsList = {
     name: string;
     statsShared: boolean;
   };
-  YourTeam: {projectName: string};
+  YourTeam: undefined;
   SelectDevice: undefined;
   SelectInviteeRole: {name: string; deviceType: DeviceType; deviceId: string};
   ReviewAndInvite: InviteProps;

--- a/tests/e2e/specs/multiple-projects/all-projects-screen.test.ts
+++ b/tests/e2e/specs/multiple-projects/all-projects-screen.test.ts
@@ -8,8 +8,12 @@ describe('Multiple Projects - All Projects Screen', () => {
     await $(byText('Switch Project')).click();
 
     const firstCard = await $(byResourceId('project_card_test_phone'));
-    const secondCard = await $(byResourceId('project_card_second_project'));
-    const thirdCard = await $(byResourceId('project_card_third_project'));
+    const secondCard = await $(
+      byResourceId('project_card_second_project_-_coordinator'),
+    );
+    const thirdCard = await $(
+      byResourceId('project_card_third_project_-_coordinator'),
+    );
 
     await firstCard.click();
 
@@ -28,13 +32,17 @@ describe('Multiple Projects - All Projects Screen', () => {
   });
 
   it('should show the selected project on top', async () => {
-    await $(byResourceId('project_card_second_project')).click();
+    await $(byResourceId('project_card_second_project_-_coordinator')).click();
 
     await $(byText('Switch Project')).click();
 
-    const firstCard = await $(byResourceId('project_card_second_project'));
+    const firstCard = await $(
+      byResourceId('project_card_second_project_-_coordinator'),
+    );
     const secondCard = await $(byResourceId('project_card_test_phone'));
-    const thirdCard = await $(byResourceId('project_card_third_project'));
+    const thirdCard = await $(
+      byResourceId('project_card_third_project_-_coordinator'),
+    );
 
     await expect(firstCard).toBeDisplayed();
     await expect(secondCard).toBeDisplayed();

--- a/tests/e2e/specs/multiple-projects/all-projects-screen.test.ts
+++ b/tests/e2e/specs/multiple-projects/all-projects-screen.test.ts
@@ -1,6 +1,6 @@
 import {expect} from '@wdio/globals';
 import {describe, it} from 'mocha';
-import {byResourceId, byText, byTextMatches} from '../../utils/selectors';
+import {byResourceId, byText} from '../../utils/selectors';
 
 describe('Multiple Projects - All Projects Screen', () => {
   it('should show projects in order of creation when solo project is the selected project', async () => {

--- a/tests/e2e/specs/multiple-projects/create-and-switch.test.ts
+++ b/tests/e2e/specs/multiple-projects/create-and-switch.test.ts
@@ -30,7 +30,9 @@ describe('Multiple Projects - Create and Switch Between Projects', () => {
   it('should display the project name in the side drawer', async () => {
     const doneBtn = await $(byTextMatches('Done'));
     await doneBtn.click();
-    await expect($(byText(`${output.names.secondProject}`))).toBeDisplayed();
+    await expect(
+      $(byText(`${output.names.secondProject} - Coordinator`)),
+    ).toBeDisplayed();
     await expect($(byText('Coordinator'))).toBeDisplayed();
 
     const switchButton = await $(byText('Switch Project'));

--- a/tests/e2e/specs/multiple-projects/project-retention.test.ts
+++ b/tests/e2e/specs/multiple-projects/project-retention.test.ts
@@ -12,7 +12,7 @@ describe('Multiple Projects - Project Data Retention', () => {
     await $('~Open Menu').click();
     await driver.pause(1000);
     await $(byText('Switch Project')).click();
-    await $(byText(output.names.secondProject)).click();
+    await $(byText(`${output.names.secondProject} - Coordinator`)).click();
     await $(byResourceId('MAIN.map-screen')).click();
 
     await $('~Add Observation').click();
@@ -64,14 +64,18 @@ describe('Multiple Projects - Project Data Retention', () => {
     await $(byResourceId('observationsEmptyView')).click();
 
     const header = await $(byResourceId('HOME.header-title'));
-    await expect(header).toHaveText(output.names.thirdProject);
+    await expect(header).toHaveText(
+      `${output.names.thirdProject} - Coordinator`,
+    );
     checkForElementGone(byText('Airstrip'));
   });
 
   it('should confirm the observation still exists in the second project', async () => {
     await $('~Open Menu').click();
     await $(byText('Switch Project')).click();
-    await $(byTextMatches(output.names.secondProject)).click();
+    await $(
+      byTextMatches(`${output.names.secondProject} - Coordinator`),
+    ).click();
     await driver.back();
     await $('~Go to observations list.').click();
 

--- a/tests/e2e/specs/solo-project/helper/minimal-project-creation.test.ts
+++ b/tests/e2e/specs/solo-project/helper/minimal-project-creation.test.ts
@@ -23,6 +23,8 @@ describe('Create Project and land on map screen', () => {
     await $(byResourceId('MAIN.map-screen')).click();
 
     const header = await $(byResourceId('HOME.header-title'));
-    await expect(header).toHaveText(output.names.secondProject);
+    await expect(header).toHaveText(
+      `${output.names.secondProject} - Coordinator`,
+    );
   });
 });

--- a/tests/e2e/specs/solo-project/project-settings-proj.test.ts
+++ b/tests/e2e/specs/solo-project/project-settings-proj.test.ts
@@ -14,7 +14,9 @@ describe('Project - Project Settings Named Project', () => {
     const screenHeader = await $(byText('Project Settings'));
     await expect(screenHeader).toBeDisplayed();
 
-    await expect($(byText(output.names.project))).toBeDisplayed();
+    await expect(
+      $(byText(`${output.names.project} - Coordinator`)),
+    ).toBeDisplayed();
     await expect(
       $(byTextMatches('This device is a coordinator on this project.')),
     ).toBeDisplayed();


### PR DESCRIPTION
closes #1485 

Changed the useProjectRoleandDetails to always return a header.
For a solo user on a default project, it hasn't changed. For other situations, Coordinator or Participant is added behind the project title.
Updates the use of the header throughout the app. See screenshots.


---
**Drawer Menu:**
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4f73b6b0-a06e-4d57-bde9-12df2e53a020" />

**All Projects**
<img width="250" alt="image" src="https://github.com/user-attachments/assets/d58d1893-1a36-470b-88d8-97bbc08abe13" />

**Project Settings**
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ecbcd456-edcd-40fe-ab6c-83d4aaab7b80" />

**Observation Create**
<img width="250" alt="image" src="https://github.com/user-attachments/assets/7c0c7485-e26b-450e-b82d-fde6130a5abb" />

Editor
<img width="250" alt="image" src="https://github.com/user-attachments/assets/29edba89-3288-4189-866e-ea8942af9bee" />

Edit Track
<img width="250" alt="image" src="https://github.com/user-attachments/assets/1bd09e15-c90d-44c5-b35b-104febfefd45" />





