### PR TITLE
fix: use better-sqlite3 build with 16kb page-size support

### DIFF
--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -21,10 +21,6 @@ export async function downloadPrebuilds(modules, {verbose} = {verbose: false}) {
 
   return Promise.all(
     modules.map(async ({name, usesNapi, version}) => {
-      if (name === 'better-sqlite3') {
-        // We currently use this release suffix for better-sqlite3 prebuilds
-        version += '-bare-make';
-      }
       if (verbose) {
         console.log(`${name}: prebuilds start (${version})`);
       }
@@ -102,7 +98,10 @@ function getArtifactInfo({name, version, target, nodeAbi}) {
   const assetName = nodeAbi
     ? `${name}-${version}-node-${nodeAbi}-${target}.tar.gz`
     : `${name}-${version}-${target}.tar.gz`;
-
+  if (name === 'better-sqlite3') {
+    // We currently use this release suffix for better-sqlite3 prebuilds
+    version += '-bare-make';
+  }
   return {
     name,
     url: `https://github.com/digidem/${name}-nodejs-mobile/releases/download/${version}/${assetName}`,

--- a/scripts/download-prebuilds.mjs
+++ b/scripts/download-prebuilds.mjs
@@ -21,6 +21,10 @@ export async function downloadPrebuilds(modules, {verbose} = {verbose: false}) {
 
   return Promise.all(
     modules.map(async ({name, usesNapi, version}) => {
+      if (name === 'better-sqlite3') {
+        // We currently use this release suffix for better-sqlite3 prebuilds
+        version += '-bare-make';
+      }
       if (verbose) {
         console.log(`${name}: prebuilds start (${version})`);
       }
@@ -55,12 +59,6 @@ export async function downloadPrebuilds(modules, {verbose} = {verbose: false}) {
           })`tar xzf ${artifactInfo.name} --directory .`;
 
           fs.unlinkSync(path.join(targetDir, artifactInfo.name));
-
-          // better-sqlite3 includes an additional native module for testing purposes
-          // removing since it's not needed and also causes issues with nodejs-mobile-react-native
-          if (name === 'better-sqlite3') {
-            fs.unlinkSync(path.join(targetDir, 'test_extension.node'));
-          }
 
           if (verbose) {
             console.log(`${name}: prebuild done (${target})`);


### PR DESCRIPTION
The builds of better-sqlite3 using our new build infra (using bare-make) with support for 16kb page sizes are published with a release suffix `-bare-make`. This updates the downloadPrebuilds function to download this version.

For the other nodejs-mobile native modules, the releases with 16kb page size support overwrote the previous version, so there are no changes needed in mobile - the download function will just download the newer builds. If the CI on this PR passes then we should be all ok.