### PR TITLE
fix: new project invite back flow

### DIFF
--- a/src/frontend/hooks/usePreventAndroidBackButton.ts
+++ b/src/frontend/hooks/usePreventAndroidBackButton.ts
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {BackHandler} from 'react-native';
 
 export const usePreventAndroidBackButton = () => {
-  return useFocusEffect(
+  useFocusEffect(
     useCallback(() => {
       const onBackPress = () => true;
 

--- a/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/ProjectCreated.tsx
+++ b/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/ProjectCreated.tsx
@@ -59,7 +59,7 @@ export const ProjectCreated = ({
     navigation.popToTop();
   }
   function handleGoToInviteScreen() {
-    navigation.replace('SelectDevice');
+    navigation.navigate('SelectDevice');
   }
 
   return (

--- a/src/frontend/screens/ProjectCreation/ShareProjectStats.tsx
+++ b/src/frontend/screens/ProjectCreation/ShareProjectStats.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {StyleSheet, View, BackHandler} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import MaterialIcons from '@react-native-vector-icons/material-icons';
 import {defineMessages, useIntl} from 'react-intl';
 import * as Sentry from '@sentry/react-native';
@@ -14,7 +14,7 @@ import {Loading} from '../../sharedComponents/Loading';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useUpdateProjectSettings} from '@comapeo/core-react';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
-import {useFocusEffect} from '@react-navigation/native';
+import {usePreventAndroidBackButton} from '../../hooks/usePreventAndroidBackButton';
 
 const m = defineMessages({
   shareProjectStats: {
@@ -54,17 +54,7 @@ export const ShareProjectStats = ({
   const {projectId} = useActiveProject();
   const updateSettings = useUpdateProjectSettings({projectId});
 
-  // disables back button
-  useFocusEffect(
-    React.useCallback(() => {
-      const subscription = BackHandler.addEventListener(
-        'hardwareBackPress',
-        () => true,
-      );
-
-      return () => subscription.remove();
-    }, []),
-  );
+  usePreventAndroidBackButton();
 
   const goToSuccess = React.useCallback(
     (statsShared: boolean) => {

--- a/src/frontend/screens/ProjectCreation/ShareProjectStats.tsx
+++ b/src/frontend/screens/ProjectCreation/ShareProjectStats.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, View, BackHandler} from 'react-native';
 import MaterialIcons from '@react-native-vector-icons/material-icons';
 import {defineMessages, useIntl} from 'react-intl';
 import * as Sentry from '@sentry/react-native';
@@ -14,6 +14,7 @@ import {Loading} from '../../sharedComponents/Loading';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useUpdateProjectSettings} from '@comapeo/core-react';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
+import {useFocusEffect} from '@react-navigation/native';
 
 const m = defineMessages({
   shareProjectStats: {
@@ -52,6 +53,18 @@ export const ShareProjectStats = ({
 
   const {projectId} = useActiveProject();
   const updateSettings = useUpdateProjectSettings({projectId});
+
+  // disables back button
+  useFocusEffect(
+    React.useCallback(() => {
+      const subscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        () => true,
+      );
+
+      return () => subscription.remove();
+    }, []),
+  );
 
   const goToSuccess = React.useCallback(
     (statsShared: boolean) => {

--- a/tests/e2e/specs/team/collaborator-info-coordinator.test.ts
+++ b/tests/e2e/specs/team/collaborator-info-coordinator.test.ts
@@ -11,8 +11,8 @@ describe('Team - Collaborator Info as Coordinator', () => {
     deviceTimezone = await getDeviceTimezone();
   });
   it('should navigate to collaborator info screen and display own device details', async () => {
-    const viewTeamButton = await $(byText('View Team'));
-    await viewTeamButton.click();
+    const teamSettings = await $('~Go to your team screen.');
+    await teamSettings.click();
     const deviceName = await $(byTextMatches(output.names.device));
     await deviceName.click();
     const thisDeviceHeader = await $(byText('This Device'));
@@ -38,10 +38,7 @@ describe('Team - Collaborator Info as Coordinator', () => {
   it('should navigate back to map screen', async () => {
     let backButton = await $(byResourceId('MAIN.header-back-btn'));
     await backButton.click();
-    await expect($(byText('Your Team'))).toBeDisplayed();
-    backButton = await $(byResourceId('MAIN.header-back-btn'));
-    await backButton.click();
-    await expect($(byText('Project Settings'))).toBeDisplayed();
+    await expect($(byText('Team'))).toBeDisplayed();
     backButton = await $(byResourceId('MAIN.header-back-btn'));
     await backButton.click();
     await $(byResourceId('MAIN.map-screen')).click();

--- a/tests/e2e/specs/team/team-screen-coordinator.test.ts
+++ b/tests/e2e/specs/team/team-screen-coordinator.test.ts
@@ -7,19 +7,11 @@ describe('Team - Team Screen as Coordinator', () => {
   it('should navigate to team screen from project settings', async () => {
     const drawerIcon = await $('~Open Menu');
     await drawerIcon.click();
-    const viewSettings = await $('~Go to project settings screen.');
-    await viewSettings.click();
+    const teamSettings = await $('~Go to your team screen.');
+    await teamSettings.click();
 
-    const screenHeader = await $(byText('Project Settings'));
+    const screenHeader = await $(byText('Team'));
     await expect(screenHeader).toBeDisplayed();
-
-    const viewTeamButton = await $(byText('View Team'));
-    await viewTeamButton.click();
-  });
-
-  it('should display Your Team header', async () => {
-    const teamHeader = await $(byText('Your Team'));
-    await expect(teamHeader).toBeDisplayed();
   });
 
   it('should display Invite Device button as coordinator', async () => {
@@ -68,11 +60,8 @@ describe('Team - Team Screen as Coordinator', () => {
     await expect(pastCollaboratorsDescription).toBeDisplayed();
   });
 
-  it('should navigate back to project settings', async () => {
+  it('should navigate back to drawer menu', async () => {
     const backButton = await $(byResourceId('MAIN.header-back-btn'));
     await backButton.click();
-
-    const screenHeader = await $(byText('Project Settings'));
-    await expect(screenHeader).toBeDisplayed();
   });
 });


### PR DESCRIPTION
closes #1519
Updates navigation actions to make project creation flow handle back arrows and back button correctly.
This PR fixes two things.
1. This was caused by some behavior that got changed with the new project creation flow that we didn't update correctly. We had done this -- replacing many of the screens when navigating:
https://github.com/digidem/comapeo-mobile/pull/1259/files
But with the change in flow it was no longer necessary to replace the invite screen when going there from the Success screen. Now, with straight navigation, we can go back to the success screen from the select devices to invite screen.
Since the back button is disabled on the success screen, we can't go back from there, which makes sense and now everything works as expected. Simple and effective fix!

2. Also, while I was debugging, I noticed you can go back with the Android back button from the Project Stats sharing screen, which is not desirable as it takes you to the create project screen and you can end up creating two projects. So this PR also prevents the Android back button on the Project Stats sharing screen.

