### PR TITLE
fix: checkmark selected project

### DIFF
--- a/src/frontend/screens/AllProjects.tsx
+++ b/src/frontend/screens/AllProjects.tsx
@@ -14,6 +14,7 @@ import {ColorCard} from '../sharedComponents/ColorCard';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {COMAPEO_BLUE} from '../lib/styles';
 import {BottomSheetWrapper} from '../sharedComponents/BottomSheetWrapper';
+import CheckMark from '../images/CheckMark.svg';
 
 const m = defineMessages({
   newCollab: {
@@ -141,8 +142,17 @@ const ProjectListItem = ({
       onPress={onPress}
       borderColor={isSelected ? COMAPEO_BLUE : undefined}
       backgroundColor={projectInfo.projectColor}>
-      <View style={{padding: 20}}>
-        <HeaderText variant="header4">{projectInfo.projectHeader}</HeaderText>
+      <View
+        style={{
+          padding: 20,
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 20,
+        }}>
+        <View style={{flex: 1}}>
+          <HeaderText variant="header4">{projectInfo.projectHeader}</HeaderText>
+        </View>
+        {isSelected && <CheckMark width={24} height={24} />}
       </View>
     </ColorCard>
   );


### PR DESCRIPTION
closes #1524 
Adds checkmark to the selected project in the all projects switcher modal.

**Screenshots:**
<img width="250" alt="image" src="https://github.com/user-attachments/assets/3a6c7a17-3dc6-42b4-b866-2e4d1d805ba2" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/9b833f06-c316-44ea-bb0f-8779664c273f" />





