### PR TITLE
fix: removes shutter sound

### DIFF
--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -80,6 +80,7 @@ export const CameraView = ({onAddPress}: Props) => {
         base64: false,
         exif: true,
         skipProcessing: false,
+        shutterSound: false,
         quality: 0.75,
         imageType: 'jpg',
       })


### PR DESCRIPTION
closes #1532 
Disables camera shutter sound.
Just a simple expo setting to change... it defaults to true for the sound, so I changed to false.
I tested it out and all is quiet!
https://docs.expo.dev/versions/latest/sdk/camera/