### PR TITLE
fix: menu cleanup

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -64,8 +64,8 @@
   "Navigation.Menu.Settings": {
     "message": "CoMapeo Settings"
   },
-  "Navigation.Menu.bgMaps": {
-    "message": "Background Maps"
+  "Navigation.Menu.bgMap": {
+    "message": "Background Map"
   },
   "Navigation.Menu.collaborate": {
     "message": "Collaborate"
@@ -244,20 +244,11 @@
   "Screens.ProjectSettings.configTitle": {
     "message": "Project Categories"
   },
-  "Screens.ProjectSettings.coordinator": {
-    "message": "This device is a coordinator on this project."
-  },
   "Screens.ProjectSettings.editInfo": {
     "message": "Edit Info"
   },
   "Screens.ProjectSettings.invite": {
     "message": "Invite Collaborators"
-  },
-  "Screens.ProjectSettings.participant": {
-    "message": "This device is a participant on this project."
-  },
-  "Screens.ProjectSettings.projectCollaborators": {
-    "message": "Project Collaborators"
   },
   "Screens.ProjectSettings.projectStatsOff": {
     "message": "Project Statistics | OFF"
@@ -284,7 +275,7 @@
     "message": "You’re mapping on your own."
   },
   "Screens.ProjectSettings.title": {
-    "message": "Project Settings"
+    "message": "Coordinator Tools"
   },
   "Screens.ProjectSettings.update": {
     "message": "Update"
@@ -297,9 +288,6 @@
   },
   "Screens.ProjectSettings.viewDetails": {
     "message": "View Details"
-  },
-  "Screens.ProjectSettings.viewTeam": {
-    "message": "View Team"
   },
   "Screens.Settings.AppSettings.Drawer.security": {
     "message": "Security"
@@ -316,29 +304,17 @@
   "Screens.Settings.AppSettings.deviceName": {
     "message": "Device Name"
   },
-  "Screens.Settings.AppSettings.earlyAccess": {
-    "message": "Early Access Mode"
-  },
-  "Screens.Settings.AppSettings.earlyAccess.off": {
-    "message": "Early Access is OFF"
-  },
-  "Screens.Settings.AppSettings.earlyAccess.on": {
-    "message": "Early Access is ON"
-  },
   "Screens.Settings.AppSettings.language": {
     "message": "Language"
   },
   "Screens.Settings.AppSettings.languageDesc": {
     "message": "Display language for app"
   },
-  "Screens.Settings.AppSettings.mapManagement": {
-    "message": "Background Map"
-  },
   "Screens.Settings.AppSettings.privacyPolicy": {
     "message": "Data & Privacy"
   },
   "Screens.Settings.AppSettings.title": {
-    "message": "App Settings"
+    "message": "CoMapeo Settings"
   },
   "Settings.ProjectSettings.RemoteArchive.RemoveRemoteArchive.cancel": {
     "description": "Text for cancel action button.",
@@ -1801,7 +1777,7 @@
     "message": "Devices no longer contributing to this project."
   },
   "screens.Setting.ProjectSettings.YourTeam.title": {
-    "message": "Your Team"
+    "message": "Team"
   },
   "screens.Settings.Collaborate.inviteDevices": {
     "message": "Invite Devices"

--- a/src/frontend/screens/ProjectSettings/index.tsx
+++ b/src/frontend/screens/ProjectSettings/index.tsx
@@ -8,7 +8,6 @@ import {useProjectRoleAndDetails} from '../../hooks/useProjectRoleAndDetails';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import NoProjectIcon from '../../images/NoProjectIcon.svg';
-import ProjectParticipantIcon from '../../images/ProjectParticipant.svg';
 import ExchangeIcon from '../../images/Exchange.svg';
 import GraphIcon from '../../images/Graph.svg';
 import {
@@ -27,31 +26,15 @@ import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 const m = defineMessages({
   title: {
     id: 'Screens.ProjectSettings.title',
-    defaultMessage: 'Project Settings',
+    defaultMessage: 'Coordinator Tools',
   },
   soloDescription: {
     id: 'Screens.ProjectSettings.soloDescription',
     defaultMessage: 'You’re mapping on your own.',
   },
-  coordinator: {
-    id: 'Screens.ProjectSettings.coordinator',
-    defaultMessage: 'This device is a coordinator on this project.',
-  },
-  participant: {
-    id: 'Screens.ProjectSettings.participant',
-    defaultMessage: 'This device is a participant on this project.',
-  },
   invite: {
     id: 'Screens.ProjectSettings.invite',
     defaultMessage: 'Invite Collaborators',
-  },
-  projectCollaborators: {
-    id: 'Screens.ProjectSettings.projectCollaborators',
-    defaultMessage: 'Project Collaborators',
-  },
-  viewTeam: {
-    id: 'Screens.ProjectSettings.viewTeam',
-    defaultMessage: 'View Team',
   },
   configTitle: {
     id: 'Screens.ProjectSettings.configTitle',
@@ -142,25 +125,6 @@ export const ProjectSettings = () => {
             : undefined
         }
       />
-      {!isSolo && (
-        <SettingsCardRow
-          icon={
-            <ProjectParticipantIcon
-              width={24}
-              height={24}
-              color={NEW_DARK_GREY}
-            />
-          }
-          title={formatMessage(m.projectCollaborators)}
-          subtitle={
-            isCoordinator
-              ? formatMessage(m.coordinator)
-              : formatMessage(m.participant)
-          }
-          buttonText={formatMessage(m.viewTeam)}
-          onPress={() => navigate('YourTeam')}
-        />
-      )}
       {(isCoordinator || participantWithRemote) && (
         <SettingsCardRow
           icon={<ExchangeIcon width={24} height={24} color={NEW_DARK_GREY} />}

--- a/src/frontend/screens/Settings/AppSettings/index.tsx
+++ b/src/frontend/screens/Settings/AppSettings/index.tsx
@@ -4,13 +4,12 @@ import {NativeNavigationComponent} from '../../../sharedTypes/navigation';
 import {useAuthContext} from '../../../contexts/AuthContext';
 import {FullScreenMenuList} from '../../../sharedComponents/MenuList/FullScreenMenuList';
 import {MenuListItemType} from '../../../sharedComponents/MenuList/MenuListItem';
-import {useEarlyAccessState} from '../../../contexts/EarlyAccessContext';
 import BlackShieldIcon from '../../../images/BlackShield.svg';
 
 const m = defineMessages({
   title: {
     id: 'Screens.Settings.AppSettings.title',
-    defaultMessage: 'App Settings',
+    defaultMessage: 'CoMapeo Settings',
   },
   language: {
     id: 'Screens.Settings.AppSettings.language',
@@ -28,10 +27,6 @@ const m = defineMessages({
     id: 'Screens.Settings.AppSettings.coordinateSystemDesc',
     defaultMessage: 'UTM,Lat/Lon,DMS',
   },
-  mapManagement: {
-    id: 'Screens.Settings.AppSettings.mapManagement',
-    defaultMessage: 'Background Map',
-  },
   security: {
     id: 'Screens.Settings.AppSettings.Drawer.security',
     defaultMessage: 'Security',
@@ -39,18 +34,6 @@ const m = defineMessages({
   deviceName: {
     id: 'Screens.Settings.AppSettings.deviceName',
     defaultMessage: 'Device Name',
-  },
-  earlyAccessTitle: {
-    id: 'Screens.Settings.AppSettings.earlyAccess',
-    defaultMessage: 'Early Access Mode',
-  },
-  earlyAccessOn: {
-    id: 'Screens.Settings.AppSettings.earlyAccess.on',
-    defaultMessage: 'Early Access is ON',
-  },
-  earlyAccessOff: {
-    id: 'Screens.Settings.AppSettings.earlyAccess.off',
-    defaultMessage: 'Early Access is OFF',
   },
   privacyPolicy: {
     id: 'Screens.Settings.AppSettings.privacyPolicy',
@@ -67,7 +50,6 @@ export const AppSettings: NativeNavigationComponent<'AppSettings'> = ({
 }) => {
   const {authState} = useAuthContext();
   const {formatMessage} = useIntl();
-  const isEarlyAccess = useEarlyAccessState(s => s.isEarlyAccessEnabled);
   const MenuItems: MenuListItemType[] = [
     {
       onPress: () => {
@@ -93,25 +75,6 @@ export const AppSettings: NativeNavigationComponent<'AppSettings'> = ({
       primaryText: formatMessage(m.coordinateSystem),
       secondaryText: formatMessage(m.coordinateSystemDesc),
       materialIconName: 'explore',
-    },
-    {
-      onPress: () => {
-        navigation.navigate('BackgroundMaps');
-      },
-      testID: 'mapManagementButton',
-      primaryText: formatMessage(m.mapManagement),
-      materialIconName: 'map',
-    },
-    {
-      onPress: () => {
-        navigation.navigate('EarlyAccess');
-      },
-      testID: 'earlyAccessFlag',
-      primaryText: formatMessage(m.earlyAccessTitle),
-      secondaryText: isEarlyAccess
-        ? formatMessage(m.earlyAccessOn)
-        : formatMessage(m.earlyAccessOff),
-      materialIconName: 'flag',
     },
     {
       onPress: () => {

--- a/src/frontend/screens/YourTeam/index.tsx
+++ b/src/frontend/screens/YourTeam/index.tsx
@@ -23,7 +23,7 @@ import {DeviceIcon} from '../../sharedComponents/DeviceIcon';
 const m = defineMessages({
   title: {
     id: 'screens.Setting.ProjectSettings.YourTeam.title',
-    defaultMessage: 'Your Team',
+    defaultMessage: 'Team',
   },
   inviteDevice: {
     id: 'screens.Setting.ProjectSettings.YourTeam.inviteDevice',

--- a/src/frontend/sharedComponents/DrawerMenu.tsx
+++ b/src/frontend/sharedComponents/DrawerMenu.tsx
@@ -28,8 +28,8 @@ const m = defineMessages({
     defaultMessage: 'CoMapeo Settings',
   },
   bgMap: {
-    id: 'Navigation.Menu.bgMaps',
-    defaultMessage: 'Background Maps',
+    id: 'Navigation.Menu.bgMap',
+    defaultMessage: 'Background Map',
   },
   gatherObservations: {
     id: 'Navigation.Menu.gatherObservations',

--- a/tests/e2e/specs/menu/universal-menu-test.test.ts
+++ b/tests/e2e/specs/menu/universal-menu-test.test.ts
@@ -9,7 +9,7 @@ describe('Menu - basic functionality of the menu', () => {
     await header.click();
 
     const gatherObservations = await $(byText('Gather Observations'));
-    const backgroundMaps = await $(byText('Background Maps'));
+    const backgroundMaps = await $(byText('Background Map'));
     const coMapeoSettings = await $(byText('CoMapeo Settings'));
 
     await expect(gatherObservations).toBeDisplayed();
@@ -20,7 +20,7 @@ describe('Menu - basic functionality of the menu', () => {
   it('Should close menu on back button', async () => {
     await driver.back();
     const gatherObservations = await $(byText('Gather Observations'));
-    const backgroundMaps = await $(byText('Background Maps'));
+    const backgroundMaps = await $(byText('Background Map'));
     const coMapeoSettings = await $(byText('CoMapeo Settings'));
 
     await expect(gatherObservations).not.toBeDisplayed();
@@ -33,7 +33,7 @@ describe('Menu - basic functionality of the menu', () => {
     const header = await $('~Open Menu');
     await header.click();
 
-    const backgroundMaps = await $(byText('Background Maps'));
+    const backgroundMaps = await $(byText('Background Map'));
     await backgroundMaps.click();
 
     await expect(await $(byText('Background Map'))).toBeDisplayed();
@@ -46,7 +46,7 @@ describe('Menu - basic functionality of the menu', () => {
     const coMapeoSettings = await $(byTextMatches('CoMapeo Settings'));
     await coMapeoSettings.click();
 
-    await expect(await $(byText('App Settings'))).toBeDisplayed();
+    await expect(await $(byText('CoMapeo Settings'))).toBeDisplayed();
     await expect(await $(byText('Device Name'))).toBeDisplayed();
     await expect(await $(byText('Language'))).toBeDisplayed();
 

--- a/tests/e2e/specs/remote-archive/add-remote-success-and-removal.test.ts
+++ b/tests/e2e/specs/remote-archive/add-remote-success-and-removal.test.ts
@@ -77,7 +77,7 @@ describe('Remote Archive - Add Success Flow', () => {
     const backButton = await $(byResourceId('MAIN.header-back-btn'));
     await backButton.click();
 
-    await expect($(byText('Project Settings'))).toBeDisplayed();
+    await expect($(byText('Coordinator Tools'))).toBeDisplayed();
     await expect($(byTextMatches('Remote Archive \\| ON'))).toBeDisplayed();
   });
 

--- a/tests/e2e/specs/settings/coordinates.test.ts
+++ b/tests/e2e/specs/settings/coordinates.test.ts
@@ -29,7 +29,7 @@ describe('Settings - Coordinates Settings Flow', () => {
     const backBtn = await $(byResourceId('MAIN.header-back-btn'));
     await backBtn.click();
 
-    await expect($(byTextMatches('App Settings'))).toBeDisplayed();
+    await expect($(byTextMatches('CoMapeo Settings'))).toBeDisplayed();
 
     await backBtn.click();
     await $(byResourceId('MAIN.map-screen')).click();

--- a/tests/e2e/specs/settings/index.test.ts
+++ b/tests/e2e/specs/settings/index.test.ts
@@ -6,5 +6,5 @@ describe('Settings', function () {
   require('./coordinates.test');
   require('./language.test');
   require('./about-comapeo.test');
-  require('./early-access.test');
+  // require('./early-access.test');
 });

--- a/tests/e2e/specs/solo-project/project-settings-proj.test.ts
+++ b/tests/e2e/specs/solo-project/project-settings-proj.test.ts
@@ -17,16 +17,7 @@ describe('Project - Project Settings Named Project', () => {
     await expect(
       $(byText(`${output.names.project} - Coordinator`)),
     ).toBeDisplayed();
-    await expect(
-      $(byTextMatches('This device is a coordinator on this project.')),
-    ).toBeDisplayed();
     await expect($(byText('Edit Info'))).toBeDisplayed();
-
-    await expect($(byText('Project Collaborators'))).toBeDisplayed();
-    await expect(
-      $(byTextMatches('This device is a coordinator on this project.')),
-    ).toBeDisplayed();
-    await expect($(byText('View Team'))).toBeDisplayed();
 
     const projectCategories = await $(byText('Project Categories'));
     await projectCategories.scrollIntoView();

--- a/tests/e2e/specs/solo-project/project-settings-proj.test.ts
+++ b/tests/e2e/specs/solo-project/project-settings-proj.test.ts
@@ -11,7 +11,7 @@ describe('Project - Project Settings Named Project', () => {
     const viewSettings = await $('~Go to project settings screen.');
     await viewSettings.click();
 
-    const screenHeader = await $(byText('Project Settings'));
+    const screenHeader = await $(byText('Coordinator Tools'));
     await expect(screenHeader).toBeDisplayed();
 
     await expect(


### PR DESCRIPTION
closes #1522 
Updates menu items, titles, and spelling.
Had to update some tests also for the different wording
### Main Menu

**“Background Maps” renamed “Background Map”**

<img width="250" alt="image" src="https://github.com/user-attachments/assets/445aefdf-0a8a-4b18-9c46-d2dd46b76e01" />


### Sub-menus

**“Your Team” rename to “Team” (in the page title)** 

<img width="250" alt="image" src="https://github.com/user-attachments/assets/19c75792-39dc-44e8-b090-70192792448b" />


---

**“Project Settings” renamed to “Coordinator Tools” (in the page title)
"Coordinator Tools" remove "Project Collaborators"**

<img width="250" alt="image" src="https://github.com/user-attachments/assets/c42bb3c8-fa02-49e8-90fc-f4202a5db88f" />


---

**“App Settings” renamed to “CoMapeo Settings” (in the page title)
"CoMapeo Settings" remove “Background map”
"CoMapeo Settings" remove "Early Access"**

<img width="250" alt="image" src="https://github.com/user-attachments/assets/800777ac-f3b2-4826-854a-831eacd89842" />
