### PR TITLE
fix: auth screen improperly navigating when authenticated

### DIFF
--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -11,7 +11,6 @@ import {EnterPassToTurnOff} from '../../screens/AppPasscode/EnterPassToTurnOff';
 import {SetPasscode} from '../../screens/AppPasscode/SetPasscode';
 import {TurnOffPasscode} from '../../screens/AppPasscode/TurnOffPasscode';
 import {Security} from '../../screens/Security';
-import {AuthScreen} from '../../screens/AuthScreen';
 import {ObscurePasscode} from '../../screens/ObscurePasscode';
 import {ObservationCategoryChooser} from '../../screens/PresetChooser/ObservationCategoryChooser.tsx';
 import {TrackCategoryChooser} from '../../screens/PresetChooser/TrackCategoryChooser.tsx';
@@ -147,14 +146,6 @@ export const createAppScreens = ({
         name="Home"
         options={{headerShown: false}}
         component={HomeTabs}
-      />
-      <RootStack.Screen
-        name="AuthScreen"
-        component={AuthScreen}
-        options={{
-          headerShown: false,
-          animation: 'fade',
-        }}
       />
       <RootStack.Screen
         name="ObservationEdit"

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {defineMessages, useIntl} from 'react-intl';
 import {ScrollView, StyleSheet, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -13,7 +12,6 @@ import {RED, BLACK} from '../lib/styles';
 import {BodyText} from '../sharedComponents/Text/BodyText';
 import {PasscodeInput} from '../sharedComponents/PasscodeInput';
 import {ScreenContentWithDock} from '../sharedComponents/ScreenContentWithDock';
-import {AppStackParamsList} from '../sharedTypes/navigation';
 import {usePasscodeLockout} from '../hooks/usePasscodeLockout';
 
 const m = defineMessages({
@@ -27,41 +25,14 @@ const m = defineMessages({
   },
 });
 
-export const AuthScreen = ({
-  navigation,
-}: NativeStackScreenProps<AppStackParamsList, 'AuthScreen'>) => {
+export const AuthScreen = () => {
   const {formatMessage: t} = useIntl();
   const [error, setError] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
-  const {authenticate, authState} = useAuthContext();
+  const {authenticate} = useAuthContext();
   const [inputtedPass, setInputtedPass] = React.useState('');
   const scrollViewRef = React.useRef<ScrollView>(null);
   const {isLockedOut, message: lockoutMessage} = usePasscodeLockout();
-
-  React.useEffect(() => {
-    const unsubscribe = navigation.addListener('beforeRemove', event => {
-      if (authState !== 'unauthenticated') return;
-      // Prevent back if unauthenticated
-      event.preventDefault();
-    });
-    return () => unsubscribe();
-  }, [authState, navigation]);
-
-  React.useEffect(() => {
-    if (authState === 'unauthenticated') return;
-
-    if (authState === 'authenticated') {
-      if (navigation.canGoBack()) {
-        navigation.goBack();
-      } else {
-        navigation.popTo('Home', {screen: 'Map'});
-      }
-    }
-
-    if (authState === 'obscured') {
-      navigation.popTo('Home', {screen: 'Map'});
-    }
-  }, [authState, navigation]);
 
   if (error) {
     if (inputtedPass.length === 5) setInputtedPass('');

--- a/tests/e2e/specs/passcode/check-passcode-requirements.test.ts
+++ b/tests/e2e/specs/passcode/check-passcode-requirements.test.ts
@@ -4,6 +4,26 @@ import {byTextMatches, byResourceId} from '../../utils/selectors';
 import {output} from '../../utils/naming';
 
 describe('Passcode - Check Passcode Requirements Flow', () => {
+  it('should allow user into app with correct passcode when app has been background but not terminated', async () => {
+    // presses the home button
+    await driver.pressKeyCode(3);
+    // activates the calendar app
+    await driver.pressKeyCode(208);
+    await driver.pause(1000);
+    // presses Back
+    await driver.pressKeyCode(4);
+    await driver.pressKeyCode(3);
+    await driver.activateApp('com.comapeo.rc');
+
+    await expect($(byTextMatches('Enter your passcode'))).toBeDisplayed();
+
+    await driver.keys(output.passcode.split(''));
+
+    await expect($(byTextMatches('Enter your passcode'))).not.toBeDisplayed();
+
+    await expect($(byResourceId('MAIN.map-screen'))).toBeDisplayed();
+  });
+
   it('should relaunch app and see Passcode entry screen', async () => {
     await driver.terminateApp('com.comapeo.rc');
     await driver.activateApp('com.comapeo.rc');


### PR DESCRIPTION
closes #1541

The Auth had remnants of the old architecture that was causing navigation problems when the user became authenticated. Namely, we introduced conditional rendering for the auth screen, but it still had a `useEffect` that tried manually navigate back after the user was authenticated. This [goes against react navigation's suggested architecture](https://reactnavigation.org/docs/auth-flow/#dont-manually-navigate-when-conditionally-rendering-screens).

I also took the Auth Screen outside of the createAppScreens. Since it is being conditionally rendered, the other screens do not need access to the Auth screen. And when user was being authenticated, it was keeping the user on the Auth screen because the Auth screen existed inside the createAppScreens.