### PR TITLE
fix: comapeo updates button

### DIFF
--- a/src/frontend/screens/Settings/About.tsx
+++ b/src/frontend/screens/Settings/About.tsx
@@ -171,19 +171,15 @@ export const AboutSettings = () => {
           />
         </ListItem>
       </List>
-      {isEarly ? (
-        <View style={styles.bottomButton}>
-          <SecondaryButton
-            fullSize
-            text={t(m.seeUpdates)}
-            onPress={() =>
-              Linking.openURL(
-                'https://awana.digital/category/technical-updates',
-              )
-            }
-          />
-        </View>
-      ) : null}
+      <View style={styles.bottomButton}>
+        <SecondaryButton
+          fullSize
+          text={t(m.seeUpdates)}
+          onPress={() =>
+            Linking.openURL('https://awana.digital/category/technical-updates')
+          }
+        />
+      </View>
     </ScrollView>
   );
 };


### PR DESCRIPTION
closes #1529 
Takes out conditional rendering of the Comapeo updates button in the About page so everyone can see and access the blog through the app.

Screenshots
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ce83c980-41aa-4eb1-8ce7-dbd7bc62b5a7" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/6f510e8c-3a29-4d73-817b-1b092b489f7b" />

