### PR TITLE
fix: button width drawer menu

### DIFF
--- a/src/frontend/sharedComponents/DrawerMenu.tsx
+++ b/src/frontend/sharedComponents/DrawerMenu.tsx
@@ -240,24 +240,30 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
           </TouchableOpacity>
         </View>
       </ScrollView>
-      <PrimaryButton
-        testID="MENU.main-action-button"
-        style={{alignSelf: 'center', marginBottom: 20}}
-        onPress={() => {
-          if (role === 'solo') {
-            navigation.navigate('Collaborate');
-            return;
+      <View style={{marginBottom: 20, marginHorizontal: 20}}>
+        <PrimaryButton
+          testID="MENU.main-action-button"
+          style={{
+            alignSelf: 'center',
+            width: '100%',
+            maxWidth: 280,
+          }}
+          onPress={() => {
+            if (role === 'solo') {
+              navigation.navigate('Collaborate');
+              return;
+            }
+            navigation.navigate('Sync');
+          }}
+          fullSize={false}
+          text={formatMessage(role === 'solo' ? m.collaborate : m.exchange)}
+          renderIcon={
+            role === 'solo'
+              ? () => <CollaborateIcon color={WHITE} />
+              : () => <Exchange color={WHITE} />
           }
-          navigation.navigate('Sync');
-        }}
-        fullSize
-        text={formatMessage(role === 'solo' ? m.collaborate : m.exchange)}
-        renderIcon={
-          role === 'solo'
-            ? () => <CollaborateIcon color={WHITE} />
-            : () => <Exchange color={WHITE} />
-        }
-      />
+        />
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
closes #1530 
Style adjustments for button in drawer menu. Took out the fullSize (this removing the fixed width of 280).
Instead made the button responsive with a maxWidth.
This was only necessary here because of the drawer not being the entire width of the screen. The buttons are fine elsewhere.

I was able to sort of replicate the issue by using a Google Pixel 2 on my emulator and zooming the screen as big as possible (and the font).

I was able to replicate on my Samsung device by changing the minimum width in the developer options to 360.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/9ea219ba-726e-40e4-bdaf-6957a0222b5e" />

This is how the button looks after the changes.
**On Samsung:**

---

Zoomed screen

---

<img width="250" alt="image" src="https://github.com/user-attachments/assets/96e9b444-cb35-49e3-b024-cb89e676f65e" />

Regular (for me) screen zoom:

---

<img width="250" alt="image" src="https://github.com/user-attachments/assets/3ea42f48-6ede-488e-85b8-eb07a14c9b9c" />


**Google Pixel 2 Emulator:**

---


<img width="250" alt="menubutton" src="https://github.com/user-attachments/assets/37f91733-3e3a-47e3-b680-384d23a9f999" />

<img width="250" alt="menubuttonsmalldisplay" src="https://github.com/user-attachments/assets/be18796c-a46b-44b2-a0da-e41dcd3f9694" />
