### PR TITLE
chore: mobile can't remove desktop

### DIFF
--- a/src/frontend/screens/YourTeam/CollaboratorInfo.tsx
+++ b/src/frontend/screens/YourTeam/CollaboratorInfo.tsx
@@ -95,7 +95,7 @@ export const CollaboratorInfo: NativeNavigationComponent<
   return (
     <View style={styles.container}>
       <View style={styles.innerBox}>
-        <DeviceIcon deviceType={route.params.deviceType} size={80} />
+        <DeviceIcon deviceType={deviceType} size={80} />
         {name && (
           <HeaderText variant="header2" style={{textAlign: 'center'}}>
             {name}

--- a/src/frontend/screens/YourTeam/CollaboratorInfo.tsx
+++ b/src/frontend/screens/YourTeam/CollaboratorInfo.tsx
@@ -88,6 +88,10 @@ export const CollaboratorInfo: NativeNavigationComponent<
     ownRole.roleId === COORDINATOR_ROLE_ID ||
     ownRole.roleId === CREATOR_ROLE_ID;
 
+  const deviceType = route.params.deviceType;
+  const isDesktop = deviceType === 'desktop';
+  const canShowActionButton = !isCoordinator && !isArchiveServer && !isDesktop;
+
   return (
     <View style={styles.container}>
       <View style={styles.innerBox}>
@@ -122,8 +126,7 @@ export const CollaboratorInfo: NativeNavigationComponent<
           })}
         </BodyText>
       </View>
-      {!isCoordinator &&
-        !isArchiveServer &&
+      {canShowActionButton &&
         (isOwnDevice ? (
           <SecondaryDestructiveButton
             text={formatMessage(m.leaveProject)}


### PR DESCRIPTION
closes #1527 
Adds desktop to list of devices that can't be left or removed from mobile. I consolidated the logic at the top to make it a little more readable. 

I figured a desktop would not/ could not leave a project through the mobile app, so I just default to not showing any buttons for desktop (or a remote archive), and for now, a coordinator.

The logic will have to change slightly when a coordinator can leave a project.

Screen recording:

---

https://github.com/user-attachments/assets/36208a99-f9c1-414c-b6c9-03934c614696

