### PR TITLE
chore: new default config

### DIFF
--- a/scripts/build-backend.mjs
+++ b/scripts/build-backend.mjs
@@ -111,7 +111,7 @@ const KEEP_THESE = [
   // Static folders referenced by @comapeo/core code
   'node_modules/@comapeo/core/drizzle',
   // zip file that is the default config
-  'node_modules/@mapeo/default-config/dist/mapeo-default-config.comapeocat',
+  'node_modules/@comapeo/default-categories/dist/comapeo-default-categories.comapeocat',
   // Offline fallback map
   'node_modules/@comapeo/fallback-smp',
   // Bare's require.addon() needs the package.json present for native modules

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -10,7 +10,7 @@ const MIGRATIONS_FOLDER_PATH = new URL(
 ).pathname
 
 const DEFAULT_CONFIG_PATH = new URL(
-  './node_modules/@mapeo/default-config/dist/mapeo-default-config.comapeocat',
+  'node_modules/@comapeo/default-categories/dist/comapeo-default-categories.comapeocat',
   import.meta.url,
 ).pathname
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -10,7 +10,7 @@ const MIGRATIONS_FOLDER_PATH = new URL(
 ).pathname
 
 const DEFAULT_CONFIG_PATH = new URL(
-  'node_modules/@comapeo/default-categories/dist/comapeo-default-categories.comapeocat',
+  './node_modules/@comapeo/default-categories/dist/comapeo-default-categories.comapeocat',
   import.meta.url,
 ).pathname
 

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -11,8 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/core": "5.1.2",
+        "@comapeo/default-categories": "1.0.0",
         "@comapeo/ipc": "6.0.1",
-        "@mapeo/default-config": "6.0.0",
         "@sentry/node": "9.28.0",
         "@sentry/rollup-plugin": "^3.5.0",
         "debug": "^4.3.4",
@@ -400,6 +400,12 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "license": "MIT"
+    },
+    "node_modules/@comapeo/default-categories": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/default-categories/-/default-categories-1.0.0.tgz",
+      "integrity": "sha512-VpY+pF9wgPGAaN+vjHhNWSUWjNpeQhEnPfVXHCqRqNy7GLL8GSgOEchQdS/QbbldTtho2BoCEpfg0+xrN8Fo0Q==",
+      "license": "CC-BY-NC-4.0"
     },
     "node_modules/@comapeo/fallback-smp": {
       "version": "1.0.0",
@@ -1070,12 +1076,6 @@
         "sodium-universal": "^4.0.0",
         "z32": "^1.0.0"
       }
-    },
-    "node_modules/@mapeo/default-config": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@mapeo/default-config/-/default-config-6.0.0.tgz",
-      "integrity": "sha512-nAnTbcKQRntsExuQAsAHal+EOd2OkDWrsl0ewcic/yVo+WpJ25ZTryKSPMVyFyHLihElX1cUH2r8C3YkZMoClA==",
-      "license": "CC-BY-NC-4.0"
     },
     "node_modules/@mapeo/sqlite-indexer": {
       "version": "1.0.2",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -14,8 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "@comapeo/core": "5.1.2",
+    "@comapeo/default-categories": "1.0.0",
     "@comapeo/ipc": "6.0.1",
-    "@mapeo/default-config": "6.0.0",
     "@sentry/node": "9.28.0",
     "@sentry/rollup-plugin": "^3.5.0",
     "debug": "^4.3.4",

--- a/tests/e2e/specs/audio/audio-add-additional.test.ts
+++ b/tests/e2e/specs/audio/audio-add-additional.test.ts
@@ -6,7 +6,9 @@ import {handleGPSAlert} from '../../utils/alerts';
 describe('Audio - Two Recordings Show in Thumbnails', () => {
   it('creates observation and records first audio', async () => {
     await $('~Add Observation').click();
-    await $(byTextMatches('Community')).click();
+    const community = await $(byTextMatches('Community'));
+    await community.scrollIntoView();
+    await community.click();
     await $(byResourceId('OBS.add-audio-btn')).click();
     await driver.pause(3000);
     await $('~Stop recording audio.').click();

--- a/tests/e2e/specs/audio/audio-recording.test.ts
+++ b/tests/e2e/specs/audio/audio-recording.test.ts
@@ -8,6 +8,7 @@ describe('Audio - Recording Flow', () => {
     await addObsBtn.click();
 
     const airstripCategory = await $(byTextMatches('Airstrip'));
+    await airstripCategory.scrollIntoView();
     await airstripCategory.click();
 
     const micButton = await $(byResourceId('OBS.add-audio-btn'));

--- a/tests/e2e/specs/multiple-projects/project-retention.test.ts
+++ b/tests/e2e/specs/multiple-projects/project-retention.test.ts
@@ -16,7 +16,9 @@ describe('Multiple Projects - Project Data Retention', () => {
     await $(byResourceId('MAIN.map-screen')).click();
 
     await $('~Add Observation').click();
-    await $(byTextMatches('Airstrip')).click();
+    const airstripCategory = await $(byTextMatches('Airstrip'));
+    await airstripCategory.scrollIntoView();
+    await airstripCategory.click();
     const descriptionInput = await $(byResourceId('OBS.description-inp'));
     await descriptionInput.click();
     await descriptionInput.setValue(UNIQUE_DESCRIPTION);

--- a/tests/e2e/specs/observations/add-details.test.ts
+++ b/tests/e2e/specs/observations/add-details.test.ts
@@ -91,5 +91,8 @@ describe('Observations - Add Details Flow', () => {
     );
     await culturalNameElem.scrollIntoView();
     await expect(culturalNameElem).toBeDisplayed();
+
+    await $(byResourceId('MAIN.header-back-btn')).click();
+    await driver.back();
   });
 });

--- a/tests/e2e/specs/observations/add-details.test.ts
+++ b/tests/e2e/specs/observations/add-details.test.ts
@@ -2,53 +2,94 @@ import {expect} from '@wdio/globals';
 import {describe, it} from 'mocha';
 import {byResourceId, byTextMatches} from '../../utils/selectors';
 import {handleGPSAlert} from '../../utils/alerts';
+import {output} from '../../utils/naming';
 
 describe('Observations - Add Details Flow', () => {
-  it('should create a new observation with Gathering Site category and open Details screen', async () => {
+  it('should create a new observation with Body of water category and open Details screen', async () => {
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
-    const gatherSite = await $(byTextMatches('Gathering Site'));
-    await gatherSite.click();
+    const bodyOfWaterCategory = await $(byTextMatches('Body of water'));
+    await bodyOfWaterCategory.click();
 
     const addDetailsBtn = await $(byResourceId('OBS.add-details-btn'));
     await addDetailsBtn.click();
 
     await expect($(byResourceId('OBS.add-details-scrn'))).toBeDisplayed();
 
-    const backArrow = await $(byResourceId('MAIN.header-back-btn'));
-    await expect(backArrow).toBeDisplayed();
-
     await expect($(byTextMatches('Question [0-9] of [0-9]'))).toBeDisplayed();
-    await expect($(byTextMatches('(Next|Done)'))).toBeDisplayed();
-    await expect($(byTextMatches('What is gathered here?'))).toBeDisplayed();
-
-    const detailsInp = await $(byResourceId('OBS.details-inp'));
-    const isFocused = await detailsInp.getAttribute('focused');
-    expect(isFocused).toBe('true');
-  });
-
-  it('should return to create new Observation screen via back arrow, then re-open Details', async () => {
-    const backArrow = await $(byResourceId('MAIN.header-back-btn'));
-    await backArrow.click();
-    await expect($(byTextMatches('New Observation'))).toBeDisplayed();
-
-    const addDetailsBtn = await $(byResourceId('OBS.add-details-btn'));
-    await addDetailsBtn.click();
+    const nextBtn = await $(byTextMatches('Next'));
+    await expect(nextBtn).toBeDisplayed();
+    await expect($(byTextMatches('Name'))).toBeDisplayed();
 
     const detailsInp = await $(byResourceId('OBS.details-inp'));
     await detailsInp.click();
-    await detailsInp.setValue('Some details');
+    await detailsInp.setValue(output.observationDetails.name);
+
+    await nextBtn.click();
+
+    await expect($(byTextMatches('Type of body of water'))).toBeDisplayed();
+    await $(byTextMatches(output.observationDetails.type)).click();
+
+    await nextBtn.click();
+    await expect($(byTextMatches('Condition'))).toBeDisplayed();
+    await $(byTextMatches(output.observationDetails.condition)).click();
+
+    await nextBtn.click();
+
+    await expect($(byTextMatches('Natural Resource Type'))).toBeDisplayed();
+    for (const type of output.observationDetails.natResourceType) {
+      await $(byTextMatches(type)).click();
+    }
+
+    await nextBtn.click();
+
+    await expect($(byTextMatches('Cultural Name'))).toBeDisplayed();
+    const culturalNameInp = await $(byResourceId('OBS.details-inp'));
+    await culturalNameInp.click();
+    await culturalNameInp.setValue(output.observationDetails.culturalName);
+
     const doneBtn = await $(byTextMatches('Done'));
     await doneBtn.click();
   });
 
-  it('should confirm we are back on the New Observation screen, then save & go back', async () => {
-    await expect($(byTextMatches('New Observation'))).toBeDisplayed();
-
+  it('should create observation and determine if details were properly saved', async () => {
     const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
     await saveBtn.click();
     await driver.pause(1000);
     await handleGPSAlert();
+
+    //navigate to observation list screen
+    const obsListTab = await $('~Go to observations list.');
+    await obsListTab.click();
+
+    //click on body of water observation
+    const createdObs = await $(byTextMatches('Body of water'));
+    await createdObs.click();
+
+    //scroll down verify details
+    await expect(
+      $(byTextMatches(output.observationDetails.name)),
+    ).toBeDisplayed();
+    await expect(
+      $(byTextMatches(output.observationDetails.type)),
+    ).toBeDisplayed();
+    const conditions = await $(
+      byTextMatches(output.observationDetails.condition),
+    );
+    await conditions.scrollIntoView();
+    await expect(conditions).toBeDisplayed();
+
+    for (const type of output.observationDetails.natResourceType) {
+      const typeElem = await $(byTextMatches(type));
+      await typeElem.scrollIntoView();
+      await expect(typeElem).toBeDisplayed();
+    }
+
+    const culturalNameElem = await $(
+      byTextMatches(output.observationDetails.culturalName),
+    );
+    await culturalNameElem.scrollIntoView();
+    await expect(culturalNameElem).toBeDisplayed();
   });
 });

--- a/tests/e2e/specs/observations/create-observation.test.ts
+++ b/tests/e2e/specs/observations/create-observation.test.ts
@@ -10,7 +10,8 @@ describe('Observations - Create Observation Flow', () => {
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
     await expect($(byTextMatches('Choose a category'))).toBeDisplayed();
-    await expect($(byTextMatches('Airstrip'))).toBeDisplayed();
+    const animalCategory = await $(byTextMatches('Animal'));
+    await expect(animalCategory).toBeDisplayed();
   });
 
   it('should discard observation and return to the map screen', async () => {
@@ -30,12 +31,12 @@ describe('Observations - Create Observation Flow', () => {
     await expect($(byResourceId('MAIN.mapbox-map-view'))).toBeDisplayed();
   });
 
-  it('should pick House category and display New Observation screen', async () => {
+  it('should pick Tree category and display New Observation screen', async () => {
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
-    const houseCategory = await $(byTextMatches('House'));
-    await houseCategory.click();
+    const treeCategory = await $(byTextMatches('Tree'));
+    await treeCategory.click();
 
     await expect($(byTextMatches('New Observation'))).toBeDisplayed();
     await expect($(byResourceId('close-icon'))).toBeDisplayed();
@@ -53,18 +54,17 @@ describe('Observations - Create Observation Flow', () => {
       await expect($(byTextMatches('Searching'))).toBeDisplayed();
     }
 
-    await expect($(byResourceId('OBS.House-icon'))).toBeDisplayed();
-    await expect(houseCategory).toBeDisplayed();
+    await expect($(byResourceId('OBS.Tree-icon'))).toBeDisplayed();
+    await expect(treeCategory).toBeDisplayed();
   });
 
-  it('should change category to Threat and add a description', async () => {
+  it('should change category to Fungi and add a description', async () => {
     const changeBtn = await $(byTextMatches('Change'));
     await changeBtn.click();
     await expect($(byResourceId('MAIN.categories-scrn'))).toBeDisplayed();
 
-    const threatOption = await $(byTextMatches('Threat'));
-    await threatOption.scrollIntoView();
-    await threatOption.click();
+    const fungiOption = await $(byTextMatches('Fungi'));
+    await fungiOption.click();
 
     const descriptionInput = await $(byResourceId('OBS.description-inp'));
     await descriptionInput.click();

--- a/tests/e2e/specs/observations/delete-observation.test.ts
+++ b/tests/e2e/specs/observations/delete-observation.test.ts
@@ -4,13 +4,15 @@ import {byResourceId, byTextMatches, byText} from '../../utils/selectors';
 import {checkForElementGone} from '../../utils/checkForGone';
 
 describe('Observations - Delete Observation Flow', () => {
-  it('should open "Threat" observation and verify it is editable', async () => {
-    const threatItem = await $(byTextMatches('Threat'));
-    await threatItem.click();
+  it('should open "Fungi" observation and verify it is editable', async () => {
+    const fungiItem = await $(byTextMatches('Fungi'));
+    await fungiItem.click();
 
-    await expect($(byTextMatches('Threat'))).toBeDisplayed();
+    await expect($(byTextMatches('Fungi'))).toBeDisplayed();
+    const deleteBtn = await $(byText('Delete'));
+    await deleteBtn.scrollIntoView();
     await expect($(byText('Share'))).toBeDisplayed();
-    await expect($(byText('Delete'))).toBeDisplayed();
+    await expect(deleteBtn).toBeDisplayed();
   });
 
   it('should open delete dialog and then cancel', async () => {
@@ -22,7 +24,7 @@ describe('Observations - Delete Observation Flow', () => {
     const cancelBtn = await $(byTextMatches('Cancel'));
     await cancelBtn.click();
 
-    await expect($(byTextMatches('Threat'))).toBeDisplayed();
+    await expect($(byTextMatches('Fungi'))).toBeDisplayed();
   });
 
   it('should delete the observation and confirm it is gone', async () => {
@@ -33,7 +35,7 @@ describe('Observations - Delete Observation Flow', () => {
     await confirmDelete.click();
 
     await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
-    checkForElementGone(byTextMatches('Threat'));
+    checkForElementGone(byTextMatches('Fungi'));
     await $('~Go to map.').click();
   });
 });

--- a/tests/e2e/specs/observations/edit-observation.test.ts
+++ b/tests/e2e/specs/observations/edit-observation.test.ts
@@ -7,9 +7,9 @@ import {handleGPSAlert} from '../../utils/alerts';
 
 describe('Observations - Edit Observation Flow', () => {
   it('should open editable observation and navigate to edit screen', async () => {
-    const lakeItem = await $(byTextMatches('Lake'));
-    await lakeItem.click();
-    await expect($(byTextMatches('Lake'))).toBeDisplayed();
+    const caveItem = await $(byTextMatches('Cave'));
+    await caveItem.click();
+    await expect($(byTextMatches('Cave'))).toBeDisplayed();
 
     const editBtn = await $(byResourceId('editButton'));
     await editBtn.click();
@@ -35,8 +35,8 @@ describe('Observations - Edit Observation Flow', () => {
 
     const detailInput = await $(byResourceId('OBS.details-inp'));
     await detailInput.setValue('New detail');
-    const doneBtn = await $(byTextMatches('Done'));
-    await doneBtn.click();
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
   });
 
   it('should save updated observation and return to view screen', async () => {
@@ -45,7 +45,7 @@ describe('Observations - Edit Observation Flow', () => {
     await driver.pause(1000);
     await handleGPSAlert();
 
-    await expect($(byTextMatches('Lake'))).toBeDisplayed();
+    await expect($(byTextMatches('Cave'))).toBeDisplayed();
     await expect($(byTextMatches('Updated description'))).toBeDisplayed();
     await expect($(byTextMatches('New detail'))).toBeDisplayed();
     await $(byResourceId('MAIN.header-back-btn')).click();

--- a/tests/e2e/specs/observations/observation-metadata.test.ts
+++ b/tests/e2e/specs/observations/observation-metadata.test.ts
@@ -4,10 +4,10 @@ import {byResourceId, byTextMatches} from '../../utils/selectors';
 
 describe('Observation - Metadata View Flow', () => {
   it('should open Observation from list and view metadata via date bar', async () => {
-    const obsItem = await $(byTextMatches('Clay'));
+    const obsItem = await $(byTextMatches('Tree'));
     await obsItem.click();
 
-    await expect($(byTextMatches('Clay'))).toBeDisplayed();
+    await expect($(byTextMatches('Tree'))).toBeDisplayed();
 
     const dateBar = await $('~Open Observation Metadata');
     await dateBar.click();

--- a/tests/e2e/specs/observations/restart-navigation.test.ts
+++ b/tests/e2e/specs/observations/restart-navigation.test.ts
@@ -15,7 +15,6 @@ describe('MAIN - Observation Navigation Flow', () => {
     await addObsBtn.click();
 
     await expect($(byTextMatches('Choose a category'))).toBeDisplayed();
-    await expect($(byTextMatches('Airstrip'))).toBeDisplayed();
   });
 
   it('should navigate to PresetChooser if an observation exists but no preset selected', async () => {
@@ -26,8 +25,8 @@ describe('MAIN - Observation Navigation Flow', () => {
   });
 
   it('should navigate to ObservationCreate when a preset is selected', async () => {
-    const houseCategory = await $(byTextMatches('House'));
-    await houseCategory.click();
+    const animalCategory = await $(byTextMatches('Animal'));
+    await animalCategory.click();
 
     await expect($(byTextMatches('New Observation'))).toBeDisplayed();
   });

--- a/tests/e2e/specs/observations/view-observations.test.ts
+++ b/tests/e2e/specs/observations/view-observations.test.ts
@@ -4,12 +4,12 @@ import {byResourceId, byTextMatches} from '../../utils/selectors';
 import {handleGPSAlert} from '../../utils/alerts';
 
 describe('Observations - View Observations Flow', () => {
-  it('should create observation with "Lake" category', async () => {
+  it('should create observation with "Cave" category', async () => {
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
-    const lakeCategory = await $(byTextMatches('Lake'));
-    await lakeCategory.click();
+    const caveCategory = await $(byTextMatches('Cave'));
+    await caveCategory.click();
 
     try {
       await $(byTextMatches('UTM')).waitForExist({
@@ -25,12 +25,12 @@ describe('Observations - View Observations Flow', () => {
     await handleGPSAlert();
   });
 
-  it('should create observation with "Clay" category', async () => {
+  it('should create observation with "Tree" category', async () => {
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
-    const clayCategory = await $(byTextMatches('Clay'));
-    await clayCategory.click();
+    const treeCategory = await $(byTextMatches('Tree'));
+    await treeCategory.click();
     try {
       await $(byTextMatches('UTM')).waitForExist({
         timeout: 10000,
@@ -61,31 +61,30 @@ describe('Observations - View Observations Flow', () => {
   });
 
   it('should confirm newly-created observations appear in the list', async () => {
-    await expect($(byTextMatches('Lake'))).toBeDisplayed();
-    await expect($(byTextMatches('Clay'))).toBeDisplayed();
-    await expect($(byTextMatches('Gathering Site'))).toBeDisplayed();
-    await expect($(byTextMatches('Threat'))).toBeDisplayed();
+    await expect($(byTextMatches('Cave'))).toBeDisplayed();
+    await expect($(byTextMatches('Tree'))).toBeDisplayed();
+    await expect($(byTextMatches('Body of water'))).toBeDisplayed();
+    await expect($(byTextMatches('Fungi'))).toBeDisplayed();
 
-    await expect($(byResourceId('OBS.Clay-list-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.Tree-list-icon'))).toBeDisplayed();
     await expect(
-      $(byResourceId('OBS.Gathering Site-list-icon')),
+      $(byResourceId('OBS.Body of water-list-icon')),
     ).toBeDisplayed();
-    await expect($(byResourceId('OBS.Threat-list-icon'))).toBeDisplayed();
-    await expect($(byResourceId('OBS.Lake-list-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.Fungi-list-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.Cave-list-icon'))).toBeDisplayed();
   });
 
-  it('should open "Clay" observation, check details, and go back to map', async () => {
-    const clayItem = await $(byTextMatches('Clay'));
-    await clayItem.click();
+  it('should open "Tree" observation, check details, and go back to map', async () => {
+    const treeItem = await $(byTextMatches('Tree'));
+    await treeItem.click();
 
-    await expect($(byTextMatches('Clay'))).toBeDisplayed();
-
+    await expect($(byTextMatches('Tree'))).toBeDisplayed();
     // Check date format: e.g. "Oct 25, 2024"
     const dateRegex =
       '^[A-Z][a-z]{2} (0?[1-9]|[12][0-9]|3[01]), (20[2-9][4-9]|2[1-9][0-9]{2})';
     await expect($(byTextMatches(dateRegex))).toBeDisplayed();
 
-    await expect($(byResourceId('OBS.Clay-view-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.Tree-view-icon'))).toBeDisplayed();
 
     const backBtn = await $(byResourceId('MAIN.header-back-btn'));
     await backBtn.click();

--- a/tests/e2e/specs/passcode/obscure-mode.test.ts
+++ b/tests/e2e/specs/passcode/obscure-mode.test.ts
@@ -9,6 +9,7 @@ describe('Passcode - Obscure Passcode Mode', () => {
   it('should show an observations before going into obscure mode', async () => {
     await $('~Add Observation').click();
     const airstripCategory = await $(byTextMatches('Airstrip'));
+    await airstripCategory.scrollIntoView();
     await airstripCategory.click();
     await driver.pause(1000);
     const saveBtn = await $(byResourceId('OBS.edit-save-btn'));

--- a/tests/e2e/specs/passcode/obscure-mode.test.ts
+++ b/tests/e2e/specs/passcode/obscure-mode.test.ts
@@ -8,17 +8,16 @@ import {handleGPSAlert} from '../../utils/alerts';
 describe('Passcode - Obscure Passcode Mode', () => {
   it('should show an observations before going into obscure mode', async () => {
     await $('~Add Observation').click();
-    const airstripCategory = await $(byTextMatches('Airstrip'));
-    await airstripCategory.scrollIntoView();
-    await airstripCategory.click();
+    const treeCategory = await $(byTextMatches('Tree'));
+    await treeCategory.click();
     await driver.pause(1000);
     const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
     await saveBtn.click();
     await handleGPSAlert();
 
     await $('~Go to observations list.').click();
-    const airstrip = await $(byText('Airstrip'));
-    await expect(airstrip).toBeDisplayed();
+    const tree = await $(byText('Tree'));
+    await expect(tree).toBeDisplayed();
   });
 
   it('should show a blank Observations screen after entering obscure passcode', async () => {
@@ -85,7 +84,7 @@ describe('Passcode - Obscure Passcode Mode', () => {
 
     const obsListTab = await $('~Go to observations list.');
     await obsListTab.click();
-    await expect($(byTextMatches('Airstrip'))).toBeDisplayed();
+    await expect($(byTextMatches('Tree'))).toBeDisplayed();
     checkForElementGone(byText('Animal'));
   });
 });

--- a/tests/e2e/specs/solo-project/project-settings-proj.test.ts
+++ b/tests/e2e/specs/solo-project/project-settings-proj.test.ts
@@ -22,7 +22,9 @@ describe('Project - Project Settings Named Project', () => {
     const projectCategories = await $(byText('Project Categories'));
     await projectCategories.scrollIntoView();
     await expect(projectCategories).toBeDisplayed();
-    await expect($(byTextMatches('CoMapeo Default Config'))).toBeDisplayed();
+    await expect(
+      $(byTextMatches('CoMapeo Default Categories')),
+    ).toBeDisplayed();
     await expect($(byText('Update Set'))).toBeDisplayed();
 
     await $(byTextMatches('Project Statistics')).scrollIntoView();

--- a/tests/e2e/specs/solo-project/rename-project-from-drawer.test.ts
+++ b/tests/e2e/specs/solo-project/rename-project-from-drawer.test.ts
@@ -9,11 +9,11 @@ describe('Project - Rename Project from Drawer while perserving observations', (
     const addObsBtn = await $('~Add Observation');
     await addObsBtn.click();
 
-    const houseCategory = await $(byTextMatches('House'));
+    const houseCategory = await $(byTextMatches('Animal'));
     await houseCategory.click();
 
     await expect($(byTextMatches('New Observation'))).toBeDisplayed();
-    await expect($(byResourceId('OBS.House-icon'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.Animal-icon'))).toBeDisplayed();
     await expect(houseCategory).toBeDisplayed();
     await driver.pause(1000);
     const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
@@ -86,7 +86,7 @@ describe('Project - Rename Project from Drawer while perserving observations', (
     const obsListTab = await $('~Go to observations list.');
     await obsListTab.click();
     await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
-    await expect($(byText('House'))).toBeDisplayed();
+    await expect($(byText('Animal'))).toBeDisplayed();
     const mapButton = await $('~Go to map.');
     await mapButton.click();
   });

--- a/tests/e2e/utils/naming.ts
+++ b/tests/e2e/utils/naming.ts
@@ -10,4 +10,11 @@ export const output = {
   newpasscode: '23456',
   obscurepasscode: '00000',
   remoteServer: 'https://comapeo-mobile-e2e-01.fly.dev/',
+  observationDetails: {
+    name: 'Some body of Water',
+    type: 'Stream',
+    condition: 'Expected',
+    natResourceType: ['Water', 'Medicine'],
+    culturalName: 'Some Cultural Name',
+  },
 };


### PR DESCRIPTION
Updates `@mapeo/default-config` to `@comapeo/default-categories`. This includes updating the build scripts in the backend to point to the new categories.

The majority of the files changed are e2e test which create observations that use the new default categories