### PR TITLE
chore: add Release name

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -523,10 +523,6 @@
     "description": "Label for phone model",
     "message": "Phone model"
   },
-  "screens.AboutSettings.releaseName": {
-    "description": "The CoMapeo chosen release name for the version of the app",
-    "message": "Preview"
-  },
   "screens.AboutSettings.releaseNameLabel": {
     "description": "Label for the release name",
     "message": "Release name"

--- a/src/frontend/screens/Settings/About.tsx
+++ b/src/frontend/screens/Settings/About.tsx
@@ -64,11 +64,6 @@ const m = defineMessages({
     defaultMessage: 'Release name',
     description: 'Label for the release name',
   },
-  releaseName: {
-    id: 'screens.AboutSettings.releaseName',
-    defaultMessage: 'Preview',
-    description: 'The CoMapeo chosen release name for the version of the app',
-  },
   seeUpdates: {
     id: 'screens.AboutSettings.seeUpdates',
     defaultMessage: 'See CoMapeo Updates',
@@ -157,10 +152,7 @@ export const AboutSettings = () => {
           />
         </ListItem>
         <ListItem disableGutters>
-          <ListItemText
-            primary={t(m.releaseNameLabel)}
-            secondary={t(m.releaseName)}
-          />
+          <ListItemText primary={t(m.releaseNameLabel)} secondary="Abare" />
         </ListItem>
         <ListItem
           disableGutters


### PR DESCRIPTION
closes #1466.  Adds "Abare" as the release name. 

<img width="281" height="627" alt="image" src="https://github.com/user-attachments/assets/0155d3b4-074d-42b7-b7cf-773d573bc586" />
