### PR TITLE
Removes role belonging to device in project from all project headers.

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2203,11 +2203,5 @@
   },
   "soloProject.startNewProject.uniqueProject": {
     "message": "Each project is unique and separate."
-  },
-  "useProjectRoleAndDetails.coordinator": {
-    "message": "Coordinator"
-  },
-  "useProjectRoleAndDetails.participant": {
-    "message": "Participant"
   }
 }

--- a/src/frontend/hooks/useProjectRoleAndDetails.ts
+++ b/src/frontend/hooks/useProjectRoleAndDetails.ts
@@ -9,19 +9,7 @@ import {
   CREATOR_ROLE_ID,
   MEMBER_ROLE_ID,
 } from '../sharedTypes';
-import {defineMessages, useIntl} from 'react-intl';
 import {DEFAULT_PROJECT_COLOR} from '../constants';
-
-const m = defineMessages({
-  coordinator: {
-    id: 'useProjectRoleAndDetails.coordinator',
-    defaultMessage: 'Coordinator',
-  },
-  participant: {
-    id: 'useProjectRoleAndDetails.participant',
-    defaultMessage: 'Participant',
-  },
-});
 
 /**
  * Represents the role of a user within a project, as used in the frontend.
@@ -45,7 +33,6 @@ export type ProjectDetails = {
 };
 
 export function useProjectRoleAndDetails(projectId: string): ProjectDetails {
-  const {formatMessage} = useIntl();
   const {data: projectData} = useProjectSettings({projectId});
   const {
     data: {name: deviceName},
@@ -65,7 +52,7 @@ export function useProjectRoleAndDetails(projectId: string): ProjectDetails {
   if (roleId === COORDINATOR_ROLE_ID || roleId === CREATOR_ROLE_ID) {
     return {
       role: 'coordinator',
-      projectHeader: `${projectData.name} - ${formatMessage(m.coordinator)}`,
+      projectHeader: projectData.name,
       projectName: projectData.name,
       projectColor: projectData.projectColor || DEFAULT_PROJECT_COLOR,
       projectDescription: projectData.projectDescription,
@@ -75,7 +62,7 @@ export function useProjectRoleAndDetails(projectId: string): ProjectDetails {
   if (roleId === MEMBER_ROLE_ID) {
     return {
       role: 'participant',
-      projectHeader: `${projectData.name} - ${formatMessage(m.participant)}`,
+      projectHeader: projectData.name,
       projectName: projectData.name,
       projectColor: projectData.projectColor || DEFAULT_PROJECT_COLOR,
       projectDescription: projectData.projectDescription,

--- a/tests/e2e/specs/multiple-projects/all-projects-screen.test.ts
+++ b/tests/e2e/specs/multiple-projects/all-projects-screen.test.ts
@@ -8,12 +8,8 @@ describe('Multiple Projects - All Projects Screen', () => {
     await $(byText('Switch Project')).click();
 
     const firstCard = await $(byResourceId('project_card_test_phone'));
-    const secondCard = await $(
-      byResourceId('project_card_second_project_-_coordinator'),
-    );
-    const thirdCard = await $(
-      byResourceId('project_card_third_project_-_coordinator'),
-    );
+    const secondCard = await $(byResourceId('project_card_second_project'));
+    const thirdCard = await $(byResourceId('project_card_third_project'));
 
     await firstCard.click();
 
@@ -32,17 +28,13 @@ describe('Multiple Projects - All Projects Screen', () => {
   });
 
   it('should show the selected project on top', async () => {
-    await $(byResourceId('project_card_second_project_-_coordinator')).click();
+    await $(byResourceId('project_card_second_project')).click();
 
     await $(byText('Switch Project')).click();
 
-    const firstCard = await $(
-      byResourceId('project_card_second_project_-_coordinator'),
-    );
+    const firstCard = await $(byResourceId('project_card_second_project'));
     const secondCard = await $(byResourceId('project_card_test_phone'));
-    const thirdCard = await $(
-      byResourceId('project_card_third_project_-_coordinator'),
-    );
+    const thirdCard = await $(byResourceId('project_card_third_project'));
 
     await expect(firstCard).toBeDisplayed();
     await expect(secondCard).toBeDisplayed();

--- a/tests/e2e/specs/multiple-projects/create-and-switch.test.ts
+++ b/tests/e2e/specs/multiple-projects/create-and-switch.test.ts
@@ -30,9 +30,7 @@ describe('Multiple Projects - Create and Switch Between Projects', () => {
   it('should display the project name in the side drawer', async () => {
     const doneBtn = await $(byTextMatches('Done'));
     await doneBtn.click();
-    await expect(
-      $(byText(`${output.names.secondProject} - Coordinator`)),
-    ).toBeDisplayed();
+    await expect($(byText(output.names.secondProject))).toBeDisplayed();
     await expect($(byText('Coordinator'))).toBeDisplayed();
 
     const switchButton = await $(byText('Switch Project'));

--- a/tests/e2e/specs/multiple-projects/project-retention.test.ts
+++ b/tests/e2e/specs/multiple-projects/project-retention.test.ts
@@ -12,7 +12,7 @@ describe('Multiple Projects - Project Data Retention', () => {
     await $('~Open Menu').click();
     await driver.pause(1000);
     await $(byText('Switch Project')).click();
-    await $(byText(`${output.names.secondProject} - Coordinator`)).click();
+    await $(byText(output.names.secondProject)).click();
     await $(byResourceId('MAIN.map-screen')).click();
 
     await $('~Add Observation').click();
@@ -66,18 +66,14 @@ describe('Multiple Projects - Project Data Retention', () => {
     await $(byResourceId('observationsEmptyView')).click();
 
     const header = await $(byResourceId('HOME.header-title'));
-    await expect(header).toHaveText(
-      `${output.names.thirdProject} - Coordinator`,
-    );
+    await expect(header).toHaveText(output.names.thirdProject);
     checkForElementGone(byText('Airstrip'));
   });
 
   it('should confirm the observation still exists in the second project', async () => {
     await $('~Open Menu').click();
     await $(byText('Switch Project')).click();
-    await $(
-      byTextMatches(`${output.names.secondProject} - Coordinator`),
-    ).click();
+    await $(byTextMatches(output.names.secondProject)).click();
     await driver.back();
     await $('~Go to observations list.').click();
 

--- a/tests/e2e/specs/solo-project/helper/minimal-project-creation.test.ts
+++ b/tests/e2e/specs/solo-project/helper/minimal-project-creation.test.ts
@@ -23,8 +23,6 @@ describe('Create Project and land on map screen', () => {
     await $(byResourceId('MAIN.map-screen')).click();
 
     const header = await $(byResourceId('HOME.header-title'));
-    await expect(header).toHaveText(
-      `${output.names.secondProject} - Coordinator`,
-    );
+    await expect(header).toHaveText(output.names.secondProject);
   });
 });

--- a/tests/e2e/specs/solo-project/project-settings-proj.test.ts
+++ b/tests/e2e/specs/solo-project/project-settings-proj.test.ts
@@ -14,9 +14,7 @@ describe('Project - Project Settings Named Project', () => {
     const screenHeader = await $(byText('Coordinator Tools'));
     await expect(screenHeader).toBeDisplayed();
 
-    await expect(
-      $(byText(`${output.names.project} - Coordinator`)),
-    ).toBeDisplayed();
+    await expect($(byText(output.names.project))).toBeDisplayed();
     await expect($(byText('Edit Info'))).toBeDisplayed();
 
     const projectCategories = await $(byText('Project Categories'));


### PR DESCRIPTION
closes #1578 Which reverts https://github.com/digidem/comapeo-mobile/pull/1513
This removes the device role (participant, coordinator) from the headers on projects from all places where those headers live.
Makes changes in tests also.
I am not sure if that is right. It is now not anywhere where it used to be? Which doesn't seem to match Figma, but I guess that is why were confused in the first place 
    ¯\_(ツ)_/¯