### PR TITLE
fix: Fix translations of category names in obs list

### DIFF
--- a/src/frontend/hooks/server/track.ts
+++ b/src/frontend/hooks/server/track.ts
@@ -8,6 +8,7 @@ import {
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useAppLanguageTag} from '../useAppLanguageTag';
+import {usePresetsQuery} from './presets';
 
 export function useTracks() {
   const {projectId} = useActiveProject();
@@ -54,8 +55,7 @@ export function useTrackPresets() {
 }
 
 export function useGetPresetById(presetRefId: string | undefined) {
-  const {projectId} = useActiveProject();
-  const {data: allPresets} = useManyDocs({projectId, docType: 'preset'});
+  const {data: allPresets} = usePresetsQuery();
 
   if (!presetRefId || !allPresets) return null;
 

--- a/src/frontend/screens/ObservationsList/ObservationListItem.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationListItem.tsx
@@ -9,8 +9,6 @@ import {
   FormattedPresetName,
 } from '../../sharedComponents/FormattedData';
 import {PhotoAttachmentView} from '../../sharedComponents/PhotoAttachmentView.tsx';
-import {useManyDocs} from '@comapeo/core-react';
-import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {isSavedPhoto} from '../../lib/attachmentTypeChecks.ts';
 import {matchPreset} from '../../lib/utils';
 import {sharedStyles} from './SharedStyle.ts';
@@ -18,6 +16,7 @@ import {HeaderText} from '../../sharedComponents/Text/HeaderText.tsx';
 import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
 import {useIsMyDocument} from '../../hooks/server/useIsMyDocument.ts';
 import {UIActivityIndicator} from 'react-native-indicators';
+import {usePresetsQuery} from '../../hooks/server/presets.ts';
 
 interface ObservationListItemProps {
   style?: ViewStyleProp;
@@ -64,8 +63,7 @@ function ObservationListItemInner({
   style?: ViewStyleProp;
   observation: Observation;
 }) {
-  const {projectId} = useActiveProject();
-  const {data: allPresets} = useManyDocs({projectId, docType: 'preset'});
+  const {data: allPresets} = usePresetsQuery();
   const preset = matchPreset(observation.tags, allPresets);
   const photos = observation.attachments.filter(isSavedPhoto);
   const isMine = useIsMyDocument(observation.originalVersionId);

--- a/src/frontend/screens/ObservationsList/TrackListItem.tsx
+++ b/src/frontend/screens/ObservationsList/TrackListItem.tsx
@@ -10,8 +10,7 @@ import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText.tsx';
 import {useIsMyDocument} from '../../hooks/server/useIsMyDocument.ts';
 import {PresetCircleIcon} from '../../sharedComponents/icons/PresetIcon';
-import {useManyDocs} from '@comapeo/core-react';
-import {useActiveProject} from '../../contexts/ActiveProjectContext.tsx';
+import {usePresetsQuery} from '../../hooks/server/presets.ts';
 
 const m = defineMessages({
   track: {
@@ -35,9 +34,7 @@ const TrackObservationItemNotMemoized = ({
 }: ObservationListItemProps) => {
   const {formatMessage} = useIntl();
   const isMine = useIsMyDocument(track.originalVersionId);
-  const projectId = useActiveProject().projectId;
-  const {data: allPresets} = useManyDocs({projectId, docType: 'preset'});
-
+  const {data: allPresets} = usePresetsQuery();
   const matchedPreset =
     track.presetRef && allPresets.find(p => p.docId === track.presetRef?.docId);
 


### PR DESCRIPTION
The ObservationsList component was not using translated presets, resulting in the English names showing up.