### PR TITLE
fix: remove useEffect causing loop

### DIFF
--- a/src/frontend/screens/RemovedFromProjectBottomSheet.tsx
+++ b/src/frontend/screens/RemovedFromProjectBottomSheet.tsx
@@ -13,8 +13,6 @@ import {
   useProjectSettings,
 } from '@comapeo/core-react';
 import {useActiveProjectIdActions} from '../contexts/ActiveProjectIdStoreContext';
-import {useEffect, useState} from 'react';
-import {Loading} from '../sharedComponents/Loading';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {ColorCard} from '../sharedComponents/ColorCard';
 import {DEFAULT_PROJECT_COLOR} from '../constants';
@@ -48,72 +46,73 @@ export const RemovedFromProjectBottomSheet = ({
   } = useProjectSettings({projectId});
   const {data: projects} = useManyProjects();
   const defaultProject = projects.find(proj => !proj.name);
-  const [defaultProjectId, setdefaultProjectId] = useState<string | null>(
-    defaultProject ? defaultProject.projectId : null,
-  );
   const {setActiveProjectId} = useActiveProjectIdActions();
   const createProject = useCreateProject();
   const leaveProject = useLeaveProject();
 
-  // The user should ALWAYS have a default (solo) project. This was not implemented until after v6. So this creates one if it does not exist
-  useEffect(() => {
-    if (defaultProjectId) return;
-    createProject.mutate(undefined, {
-      onError: () => {
-        navigation.navigate('ErrorBottomSheet');
-      },
-      onSuccess: projectId => {
-        setdefaultProjectId(projectId);
-      },
-    });
-  }, [createProject, setdefaultProjectId, navigation, defaultProjectId]);
-
   return (
     <BottomSheetWrapper>
-      {!defaultProjectId ? (
-        <Loading />
-      ) : (
-        <View style={styles.container}>
-          <HeaderText variant="header6" style={styles.titleText}>
-            {formatMessage(m.title)}
-          </HeaderText>
+      <View style={styles.container}>
+        <HeaderText variant="header6" style={styles.titleText}>
+          {formatMessage(m.title)}
+        </HeaderText>
 
-          <ColorCard backgroundColor={projectColor || DEFAULT_PROJECT_COLOR}>
-            <View style={{padding: 20, gap: 20}}>
-              <HeaderText variant="header2" style={styles.projectName}>
-                {name}
+        <ColorCard backgroundColor={projectColor || DEFAULT_PROJECT_COLOR}>
+          <View style={{padding: 20, gap: 20}}>
+            <HeaderText variant="header2" style={styles.projectName}>
+              {name}
+            </HeaderText>
+            {reason && (
+              <HeaderText variant="header5">
+                {formatMessage(m.reasonLabel, {reason})}
               </HeaderText>
-              {reason && (
-                <HeaderText variant="header5">
-                  {formatMessage(m.reasonLabel, {reason})}
-                </HeaderText>
-              )}
-            </View>
-          </ColorCard>
-
-          <View style={styles.buttonContainer}>
-            {leaveProject.status === 'pending' ? (
-              <UIActivityIndicator style={{margin: 20}} />
-            ) : (
-              <SecondaryButton
-                fullSize
-                onPress={() => {
-                  leaveProject.mutate(
-                    {projectId},
-                    {
-                      onSuccess: () => {
-                        setActiveProjectId(defaultProjectId);
-                        navigation.popToTop();
-                      },
-                    },
-                  );
-                }}
-                text={formatMessage(m.close)}
-              />
             )}
           </View>
+        </ColorCard>
+
+        <View style={styles.buttonContainer}>
+          {leaveProject.status === 'pending' ||
+          createProject.status === 'pending' ? (
+            <UIActivityIndicator style={{margin: 20}} />
+          ) : (
+            <SecondaryButton
+              fullSize
+              onPress={() => {
+                leaveProject.mutate(
+                  {projectId},
+                  {
+                    onSuccess: () => {
+                      if (!defaultProject) {
+                        // The user should ALWAYS have a default (solo) project. This was not implemented until after v6. So this creates one if it does not exist
+                        createProject.mutate(undefined, {
+                          onError: () => {
+                            const firstProject = projects[0];
+                            //if there is a project just open that project
+                            if (firstProject) {
+                              setActiveProjectId(firstProject.projectId);
+                              navigation.popToTop();
+                              return;
+                            }
+                            navigation.navigate('ErrorBottomSheet');
+                          },
+                          onSuccess: newDefaultProjectId => {
+                            setActiveProjectId(newDefaultProjectId);
+                            navigation.popToTop();
+                          },
+                        });
+                        return;
+                      }
+                      setActiveProjectId(defaultProject.projectId);
+                      navigation.popToTop();
+                    },
+                  },
+                );
+              }}
+              text={formatMessage(m.close)}
+            />
+          )}
         </View>
-      )}
+      </View>
     </BottomSheetWrapper>
   );
 };


### PR DESCRIPTION
Fixes this issue: https://www.notion.so/digidem/From-v6-to-v8-Infinite-solo-project-creation-2bf1b08162d580cea0c9d7425e0bbb63

**Problem:** 

1. User A has to be on v6 and rename there default project (In v6 when renamed the default project we didnt create another one)
2. User B (doesn't matter what version) adds user A to a project 
    1.  then removes user A to a project
3. User A upgrades to v8. User A is notified that it has been removed from a project. When it gets removed from a project it tries to open the default project. The default project doesn't exist so it tries to create. But its getting stuck in an infinite loop and is constantly creating default projects until the user closes the app.
4. When you open the app again, there are tons of new default project because it got stuck in that infinite loop

- The key to recreating is that there is NO default projects when the user gets removed from a project
- the user can be on v7 and this issue can happen.
    - BUT the user has to be on v6 first, rename their default project, and the upgrade to v7. Since there is no default project v7 doesnt try to create one. So it is possible to see this happen with a v7 device, it just had to have been upgraded from v6 with NO default project