### PR TITLE
chore: bottom sheets background maps

### DIFF
--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -134,6 +134,8 @@ import {LeaveProject} from '../../screens/YourTeam/LeaveProject.tsx';
 import {LeaveProjectWarning} from '../../screens/YourTeam/LeaveProjectWarning.tsx';
 import {LeftProjectConfirmation} from '../../screens/YourTeam/LeftProjectConfirmation.tsx';
 import {ConfirmDiscardBottomSheet} from '../../screens/TrackEdit/ConfirmDiscardBottomSheet.tsx';
+import {MapAddedBottomSheet} from '../../screens/BackgroundMaps/MapAddedBottomSheet.tsx';
+import {DeleteCustomMapBottomSheet} from '../../screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx';
 
 export const TAB_BAR_HEIGHT = 70;
 
@@ -605,6 +607,14 @@ export const createAppScreens = ({
       <RootStack.Screen
         name="ConfirmTrackDiscardBottomSheet"
         component={ConfirmDiscardBottomSheet}
+      />
+      <RootStack.Screen
+        name="DeleteCustomMapBottomSheet"
+        component={DeleteCustomMapBottomSheet}
+      />
+      <RootStack.Screen
+        name="MapAddedBottomSheet"
+        component={MapAddedBottomSheet}
       />
     </RootStack.Group>
   </>

--- a/src/frontend/screens/BackgroundMaps/BackgroundMaps.tsx
+++ b/src/frontend/screens/BackgroundMaps/BackgroundMaps.tsx
@@ -10,22 +10,14 @@ import {
   useImportCustomMapFile,
   useRemoveCustomMapFile,
 } from '../../hooks/server/maps';
-import ErrorSvg from '../../images/Error.svg';
-import GreenCheckSvg from '../../images/Success.svg';
 import StackSvg from '../../images/Stack.svg';
 import {
   RED,
-  WHITE,
   DARK_GREY,
   NEW_DARK_GREY,
   VERY_LIGHT_GREY,
   BLUE_GREY,
 } from '../../lib/styles';
-import {
-  BottomSheetModal,
-  BottomSheetModalContent,
-  useBottomSheetModal,
-} from '../../sharedComponents/BottomSheetModal';
 import {Loading} from '../../sharedComponents/Loading';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
@@ -151,8 +143,6 @@ export function createNavigationOptions({
 export function BackgroundMapsScreen() {
   const {formatMessage: t} = useIntl();
   const {navigate} = useNavigationFromRoot();
-  const mapAddedBottomSheet = useBottomSheetModal({openOnMount: false});
-  const removeMapBottomSheet = useBottomSheetModal({openOnMount: false});
 
   const selectFileMutation = useSelectFile();
   const importCustomMapMutation = useImportCustomMapFile();
@@ -175,7 +165,7 @@ export function BackgroundMapsScreen() {
             },
             {
               onSuccess: () => {
-                mapAddedBottomSheet.openSheet();
+                navigate('MapAddedBottomSheet');
               },
               onError: err => {
                 Sentry.captureException(err);
@@ -199,7 +189,7 @@ export function BackgroundMapsScreen() {
   };
 
   const handleRemoveMap = () => {
-    removeMapBottomSheet.openSheet();
+    navigate('DeleteCustomMapBottomSheet');
   };
 
   return (
@@ -227,67 +217,6 @@ export function BackgroundMapsScreen() {
           />
         )}
       </ScrollView>
-
-      <BottomSheetModal
-        ref={removeMapBottomSheet.sheetRef}
-        isOpen={removeMapBottomSheet.isOpen}>
-        <BottomSheetModalContent
-          loading={removeCustomMapMutation.isPending}
-          icon={<ErrorSvg />}
-          title={t(m.deleteCustomMapTitle)}
-          description={
-            t(m.deleteCustomMapDescription) + '\n\n' + t(m.cannotBeUndone)
-          }
-          buttonConfigs={[
-            {
-              dangerous: true,
-              variation: 'filled',
-              text: t(m.deleteMapButtonText),
-              icon: <MaterialIcon size={30} name="delete" color={WHITE} />,
-              onPress: () => {
-                removeCustomMapMutation.mutate(undefined, {
-                  onSuccess: () => {
-                    removeMapBottomSheet.closeSheet();
-                  },
-                });
-              },
-            },
-            {
-              variation: 'outlined',
-              text: t(m.close),
-              onPress: () => {
-                removeMapBottomSheet.closeSheet();
-              },
-            },
-          ]}
-        />
-      </BottomSheetModal>
-
-      <BottomSheetModal
-        fullScreen
-        ref={mapAddedBottomSheet.sheetRef}
-        isOpen={mapAddedBottomSheet.isOpen}>
-        <BottomSheetModalContent
-          icon={
-            <GreenCheckSvg
-              style={{
-                marginTop: 80,
-              }}
-            />
-          }
-          title={t(m.customMapAddedTitle)}
-          description={t(m.customMapAddedDescription)}
-          buttonConfigs={[
-            {
-              variation: 'outlined',
-              text: t(m.close),
-              onPress: () => {
-                mapAddedBottomSheet.closeSheet();
-              },
-            },
-          ]}
-        />
-      </BottomSheetModal>
     </>
   );
 }

--- a/src/frontend/screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx
+++ b/src/frontend/screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx
@@ -32,7 +32,7 @@ const m = defineMessages({
   },
   deleteMapButtonText: {
     id: 'screens.Settings.MapManagement.BackgroundMaps.deleteMapButtonText',
-    defaultMessage: 'Delete Map test',
+    defaultMessage: 'Delete Map',
   },
   close: {
     id: 'screens.Settings.MapManagement.BackgroundMaps.close',

--- a/src/frontend/screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx
+++ b/src/frontend/screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import {StyleSheet, View} from 'react-native';
+import {defineMessages, useIntl} from 'react-intl';
+import MaterialIcon from '@react-native-vector-icons/material-icons';
+import * as Sentry from '@sentry/react-native';
+
+import ErrorSvg from '../../images/Error.svg';
+import {BottomSheetWrapper} from '../../sharedComponents/BottomSheetWrapper';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
+import {
+  DestructiveButton,
+  SecondaryButton,
+} from '../../sharedComponents/Buttons';
+import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
+import {useRemoveCustomMapFile} from '../../hooks/server/maps';
+import {UIActivityIndicator} from 'react-native-indicators';
+
+const m = defineMessages({
+  deleteCustomMapTitle: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.deleteCustomMapTitle',
+    defaultMessage: 'Delete Custom Map?',
+  },
+  deleteCustomMapDescription: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.deleteCustomMapDescription',
+    defaultMessage:
+      'This will delete the map and its offline areas. No collected observation data will be deleted.',
+  },
+  cannotBeUndone: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.cannotBeUndone',
+    defaultMessage: 'This cannot be undone.',
+  },
+  deleteMapButtonText: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.deleteMapButtonText',
+    defaultMessage: 'Delete Map test',
+  },
+  close: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.close',
+    defaultMessage: 'Close',
+  },
+});
+
+export const DeleteCustomMapBottomSheet = () => {
+  const {formatMessage: t} = useIntl();
+  const navigation = useNavigationFromRoot();
+  const removeCustomMapMutation = useRemoveCustomMapFile();
+
+  return (
+    <BottomSheetWrapper>
+      <View style={styles.container}>
+        <View style={styles.icon}>
+          <ErrorSvg />
+        </View>
+
+        <HeaderText variant="header2" style={styles.title}>
+          {t(m.deleteCustomMapTitle)}
+        </HeaderText>
+
+        <BodyText variant="large" style={styles.description}>
+          {t(m.deleteCustomMapDescription)}
+          {'\n\n'}
+          {t(m.cannotBeUndone)}
+        </BodyText>
+
+        {removeCustomMapMutation.isPending ? (
+          <View style={styles.loading}>
+            <UIActivityIndicator size={40} />
+          </View>
+        ) : (
+          <View style={styles.buttonsContainer}>
+            <DestructiveButton
+              fullSize
+              text={t(m.deleteMapButtonText)}
+              renderIcon={({color, size}) => (
+                <MaterialIcon size={size} name="delete" color={color} />
+              )}
+              onPress={() => {
+                removeCustomMapMutation.mutate(undefined, {
+                  onSuccess: () => {
+                    navigation.goBack();
+                  },
+                  onError: err => {
+                    Sentry.captureException(err);
+                    navigation.navigate('ErrorBottomSheet');
+                  },
+                });
+              }}
+            />
+            <SecondaryButton
+              fullSize
+              text={t(m.close)}
+              onPress={() => navigation.goBack()}
+            />
+          </View>
+        )}
+      </View>
+    </BottomSheetWrapper>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+    minHeight: 400,
+    paddingTop: 20,
+    alignItems: 'center',
+  },
+  icon: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    textAlign: 'center',
+  },
+  description: {
+    textAlign: 'center',
+  },
+  buttonsContainer: {
+    width: '100%',
+    gap: 16,
+    alignItems: 'center',
+  },
+  loading: {
+    height: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/frontend/screens/BackgroundMaps/MapAddedBottomSheet.tsx
+++ b/src/frontend/screens/BackgroundMaps/MapAddedBottomSheet.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import {StyleSheet, View} from 'react-native';
+import {defineMessages, useIntl} from 'react-intl';
+
+import GreenCheckSvg from '../../images/Success.svg';
+import {BottomSheetWrapper} from '../../sharedComponents/BottomSheetWrapper';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
+import {SecondaryButton} from '../../sharedComponents/Buttons';
+import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
+
+const m = defineMessages({
+  customMapAddedTitle: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.customMapAddedTitle',
+    defaultMessage: 'Custom Map Added',
+  },
+  customMapAddedDescription: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.customMapAddedDescription',
+    defaultMessage:
+      'You will see this map when you are offline, but you will not see a map outside the area defined in your custom map.',
+  },
+  close: {
+    id: 'screens.Settings.MapManagement.BackgroundMaps.close',
+    defaultMessage: 'Close',
+  },
+});
+
+export const MapAddedBottomSheet = () => {
+  const {formatMessage: t} = useIntl();
+  const navigation = useNavigationFromRoot();
+
+  return (
+    <BottomSheetWrapper>
+      <View style={styles.container}>
+        <View style={styles.iconContainer}>
+          <GreenCheckSvg />
+        </View>
+
+        <HeaderText variant="header2" style={styles.title}>
+          {t(m.customMapAddedTitle)}
+        </HeaderText>
+
+        <BodyText variant="large" style={styles.description}>
+          {t(m.customMapAddedDescription)}
+        </BodyText>
+
+        <View style={styles.buttonsContainer}>
+          <SecondaryButton
+            fullSize
+            text={t(m.close)}
+            onPress={() => navigation.goBack()}
+          />
+        </View>
+      </View>
+    </BottomSheetWrapper>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+    paddingTop: 20,
+  },
+  iconContainer: {
+    alignItems: 'center',
+  },
+  title: {
+    textAlign: 'center',
+  },
+  description: {
+    textAlign: 'center',
+  },
+  buttonsContainer: {
+    alignItems: 'center',
+  },
+});

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -184,6 +184,8 @@ export type RootStackParamsList = {
     memberType: 'coordinator' | 'participant';
   };
   ConfirmTrackDiscardBottomSheet: {trackId: string};
+  MapAddedBottomSheet: undefined;
+  DeleteCustomMapBottomSheet: undefined;
 };
 
 export type OnboardingParamsList = {


### PR DESCRIPTION
closes #1627 
Adds bottom sheets to navigate to for map adding and removal.

Screenshots

---

### Custom Map Added:
| Before | After |
|--------|-------|
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/12dc3181-3d6e-4438-9f44-cdf6cb1ee85b" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/5cc008b5-32c2-40cc-abe4-1a13ff724481" /> |

### Custom Map Removed:
| Before | After |
|--------|-------|
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/d7822d70-8956-4215-91db-0eb2c2409729" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/5f15568e-7a1a-4ea5-a78f-dd53792ca0ef" /> |



