### PR TITLE
chore: use new bottom sheet observation edit

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3,17 +3,6 @@
     "description": "Button on dialog to keep editing (cancelling close action)",
     "message": "Continue editing"
   },
-  "AppContainer.EditHeader.discardChangesButton": {
-    "description": "Title of dialog that shows when cancelling observation edits",
-    "message": "Discard changes"
-  },
-  "AppContainer.EditHeader.discardChangesDescription": {
-    "message": "Your changes will not be saved. This cannot be undone."
-  },
-  "AppContainer.EditHeader.discardChangesTitle": {
-    "description": "Title of dialog that shows when cancelling observation edits",
-    "message": "Discard changes?"
-  },
   "AppContainer.EditHeader.discardObservationButton": {
     "description": "Title of dialog that shows when cancelling observation edits",
     "message": "Discard Observation"
@@ -108,7 +97,7 @@
     "message": "Continue editing"
   },
   "ObservationEdit.HeaderLeft.discardObservationButton": {
-    "description": "Title of dialog that shows when cancelling observation edits",
+    "description": "Button to confirm discarding the observation edits",
     "message": "Discard changes"
   },
   "ObservationEdit.HeaderLeft.discardObservationDescription": {

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -135,6 +135,7 @@ import {LeaveProjectWarning} from '../../screens/YourTeam/LeaveProjectWarning.ts
 import {LeftProjectConfirmation} from '../../screens/YourTeam/LeftProjectConfirmation.tsx';
 import {ConfirmDiscardBottomSheet} from '../../screens/TrackEdit/ConfirmDiscardBottomSheet.tsx';
 import {ConfirmDiscardObservationBottomSheet} from '../../screens/ObservationCreate/ConfirmDiscardObservationBottomSheet.tsx';
+import {ConfirmDiscardObservationEditBottomSheet} from '../../screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx';
 import {WhatsIncludedBottomSheet} from '../../screens/RemoteArchive/WhatsIncludedBottomSheet.tsx';
 import {MapAddedBottomSheet} from '../../screens/BackgroundMaps/MapAddedBottomSheet.tsx';
 import {DeleteCustomMapBottomSheet} from '../../screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx';
@@ -626,6 +627,10 @@ export const createAppScreens = ({
       <RootStack.Screen
         name="ConfirmDiscardObservationBottomSheet"
         component={ConfirmDiscardObservationBottomSheet}
+      />
+      <RootStack.Screen
+        name="ConfirmDiscardObservationEditBottomSheet"
+        component={ConfirmDiscardObservationEditBottomSheet}
       />
       <RootStack.Screen
         name="ConfirmDiscardTrackBottomSheet"

--- a/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
+++ b/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import {StyleSheet, View} from 'react-native';
+import {defineMessages, useIntl} from 'react-intl';
+
+import ErrorIcon from '../../images/Error.svg';
+import DiscardIcon from '../../images/delete.svg';
+import {BottomSheetWrapper} from '../../sharedComponents/BottomSheetWrapper';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
+import {
+  DestructiveButton,
+  SecondaryButton,
+} from '../../sharedComponents/Buttons';
+import {useDraftObservation} from '../../hooks/useDraftObservation';
+import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
+
+const m = defineMessages({
+  discardTitle: {
+    id: 'ObservationEdit.HeaderLeft.discardTitle',
+    defaultMessage: 'Discard changes?',
+    description: 'Title of dialog that shows when cancelling observation edits',
+  },
+  discardObservationDescription: {
+    id: 'ObservationEdit.HeaderLeft.discardObservationDescription',
+    defaultMessage: 'Your changes will not be saved. This cannot be undone.',
+  },
+  discardCancel: {
+    id: 'ObservationEdit.HeaderLeft.discardCancel',
+    defaultMessage: 'Continue editing',
+    description: 'Button on dialog to keep editing (cancelling close action)',
+  },
+  discardObservationButton: {
+    id: 'ObservationEdit.HeaderLeft.discardObservationButton',
+    defaultMessage: 'Discard changes',
+    description: 'Button to confirm discarding the observation edits',
+  },
+});
+
+export const ConfirmDiscardObservationEditBottomSheet = ({
+  navigation,
+  route,
+}: NativeRootNavigationProps<'ConfirmDiscardObservationEditBottomSheet'>) => {
+  const {formatMessage: t} = useIntl();
+  const {clearDraft} = useDraftObservation();
+
+  function handleDiscard() {
+    clearDraft();
+    navigation.popTo('Observation', {
+      observationId: route.params.observationId,
+    });
+  }
+
+  return (
+    <BottomSheetWrapper>
+      <View style={styles.container}>
+        <View style={styles.icon}>
+          <ErrorIcon width={80} height={80} />
+        </View>
+
+        <HeaderText variant="header2" style={styles.title}>
+          {t(m.discardTitle)}
+        </HeaderText>
+
+        <BodyText variant="large" style={styles.description}>
+          {t(m.discardObservationDescription)}
+        </BodyText>
+
+        <View style={styles.buttonsContainer}>
+          <DestructiveButton
+            fullSize
+            text={t(m.discardObservationButton)}
+            renderIcon={() => <DiscardIcon />}
+            onPress={handleDiscard}
+          />
+          <SecondaryButton
+            fullSize
+            text={t(m.discardCancel)}
+            onPress={() => navigation.goBack()}
+          />
+        </View>
+      </View>
+    </BottomSheetWrapper>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+  },
+  icon: {
+    alignItems: 'center',
+  },
+  title: {
+    textAlign: 'center',
+  },
+  description: {
+    textAlign: 'center',
+  },
+  buttonsContainer: {
+    gap: 16,
+    alignItems: 'center',
+  },
+});

--- a/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
+++ b/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
@@ -1,55 +1,32 @@
 import * as React from 'react';
 import {HeaderLeftClose} from '../../sharedComponents/HeaderLeftClose';
 import {HeaderBackButtonProps} from '@react-navigation/elements';
-import {
-  BottomSheetModal,
-  useBottomSheetModal,
-} from '../../sharedComponents/BottomSheetModal';
-import {ConfirmDiscardBottomSheetContent} from '../../sharedComponents/ConfirmDiscardBottomSheetContent';
-import {defineMessages, useIntl} from 'react-intl';
-import {useDraftObservation} from '../../hooks/useDraftObservation';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useFocusEffect} from '@react-navigation/native';
 import {BackHandler} from 'react-native';
-
-const m = defineMessages({
-  discardTitle: {
-    id: 'ObservationEdit.HeaderLeft.discardTitle',
-    defaultMessage: 'Discard changes?',
-    description: 'Title of dialog that shows when cancelling observation edits',
-  },
-  discardObservationDescription: {
-    id: 'ObservationEdit.HeaderLeft.discardObservationDescription',
-    defaultMessage: 'Your changes will not be saved. This cannot be undone. ',
-  },
-  discardCancel: {
-    id: 'ObservationEdit.HeaderLeft.discardCancel',
-    defaultMessage: 'Continue editing',
-    description: 'Button on dialog to keep editing (cancelling close action)',
-  },
-  discardObservationButton: {
-    id: 'ObservationEdit.HeaderLeft.discardObservationButton',
-    defaultMessage: 'Discard changes',
-    description: 'Title of dialog that shows when cancelling observation edits',
-  },
-});
+import {usePersistedDraftObservation} from '../../hooks/persistedState/usePersistedDraftObservation';
 
 type HeaderLeftProps = {
   headerBackButtonProps: HeaderBackButtonProps;
 };
 
 export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
-  const {closeSheet, openSheet, isOpen, sheetRef} = useBottomSheetModal({
-    openOnMount: false,
-  });
-  const {formatMessage} = useIntl();
-  const {clearDraft} = useDraftObservation();
   const navigation = useNavigationFromRoot();
+  const observationId = usePersistedDraftObservation(
+    store => store.observationId,
+  );
+
+  const handlePress = React.useCallback(() => {
+    if (!observationId) return;
+    navigation.navigate('ConfirmDiscardObservationEditBottomSheet', {
+      observationId,
+    });
+  }, [navigation, observationId]);
 
   useFocusEffect(
     React.useCallback(() => {
       const onBackPress = () => {
-        openSheet();
+        handlePress();
         return true;
       };
 
@@ -59,31 +36,13 @@ export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
       );
 
       return () => subscription.remove();
-    }, [openSheet]),
+    }, [handlePress]),
   );
 
-  function handleDiscard() {
-    clearDraft();
-    closeSheet();
-    navigation.goBack();
-  }
-
   return (
-    <>
-      <HeaderLeftClose
-        onPress={openSheet}
-        headerBackButtonProps={headerBackButtonProps}
-      />
-      <BottomSheetModal isOpen={isOpen} ref={sheetRef}>
-        <ConfirmDiscardBottomSheetContent
-          closeSheet={closeSheet}
-          handleDiscard={handleDiscard}
-          header={formatMessage(m.discardTitle)}
-          subHeader={formatMessage(m.discardObservationDescription)}
-          discardButtonText={formatMessage(m.discardObservationButton)}
-          discardButtonCancel={formatMessage(m.discardCancel)}
-        />
-      </BottomSheetModal>
-    </>
+    <HeaderLeftClose
+      onPress={handlePress}
+      headerBackButtonProps={headerBackButtonProps}
+    />
   );
 };

--- a/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
+++ b/src/frontend/screens/PresetChooser/ObservationCategoryChooser.tsx
@@ -63,10 +63,13 @@ export const ObservationCategoryChooser: NativeNavigationComponent<
             headerBackButtonProps={props}
           />
         ) : (
-          <CustomHeaderLeftClose headerBackButtonProps={props} />
+          <CustomHeaderLeftClose
+            headerBackButtonProps={props}
+            observationId={observationId}
+          />
         ),
     });
-  }, [navigation, currentPreset, handleGoBack]);
+  }, [navigation, currentPreset, handleGoBack, observationId]);
 
   return (
     <View style={styles.container} testID="MAIN.categories-scrn">

--- a/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
@@ -7,47 +7,11 @@ import isEqual from 'lodash.isequal';
 import {CloseIcon} from './icons';
 import {BLACK} from '../lib/styles';
 import {useNavigationFromRoot} from '../hooks/useNavigationWithTypes';
-import {useDraftObservation} from '../hooks/useDraftObservation';
-import {defineMessages, useIntl} from 'react-intl';
 import {useObservationWithPreset} from '../hooks/useObservationWithPreset';
 import {ClientGeneratedObservation} from '../sharedTypes';
 import {Observation} from '@comapeo/schema';
 import {usePersistedDraftObservation} from '../hooks/persistedState/usePersistedDraftObservation';
-import {
-  CommonActions,
-  useFocusEffect,
-  useNavigation,
-} from '@react-navigation/native';
-import {
-  BottomSheetModalContent,
-  BottomSheetModal,
-  useBottomSheetModal,
-} from './BottomSheetModal';
-
-import ErrorIcon from '../images/Error.svg';
-import DiscardIcon from '../images/delete.svg';
-
-const m = defineMessages({
-  discardChangesTitle: {
-    id: 'AppContainer.EditHeader.discardChangesTitle',
-    defaultMessage: 'Discard changes?',
-    description: 'Title of dialog that shows when cancelling observation edits',
-  },
-  discardChangesDescription: {
-    id: 'AppContainer.EditHeader.discardChangesDescription',
-    defaultMessage: 'Your changes will not be saved. This cannot be undone. ',
-  },
-  discardCancel: {
-    id: 'AppContainer.EditHeader.discardCancel',
-    defaultMessage: 'Continue editing',
-    description: 'Button on dialog to keep editing (cancelling close action)',
-  },
-  discardChangesButton: {
-    id: 'AppContainer.EditHeader.discardChangesButton',
-    defaultMessage: 'Discard changes',
-    description: 'Title of dialog that shows when cancelling observation edits',
-  },
-});
+import {useFocusEffect, useNavigation} from '@react-navigation/native';
 
 // We use a slightly larger back icon, to improve accessibility
 // TODO iOS: This should probably be a chevron not an arrow
@@ -70,60 +34,31 @@ export const CustomHeaderLeftClose = ({
   headerBackButtonProps,
   observationId,
 }: CustomHeaderLeftCloseProps) => {
-  const {isOpen, sheetRef, closeSheet, openSheet} = useBottomSheetModal({
-    openOnMount: false,
-  });
-  const {formatMessage} = useIntl();
-  const {clearDraft} = useDraftObservation();
   const navigation = useNavigationFromRoot();
 
-  const handleDiscard = React.useCallback(() => {
-    clearDraft();
-    navigation.dispatch(
-      CommonActions.reset({index: 0, routes: [{name: 'Home'}]}),
-    );
-  }, [clearDraft, navigation]);
+  const openBottomSheet = React.useCallback(() => {
+    if (observationId) {
+      navigation.navigate('ConfirmDiscardObservationEditBottomSheet', {
+        observationId,
+      });
+    } else {
+      navigation.navigate('ConfirmDiscardObservationBottomSheet');
+    }
+  }, [navigation, observationId]);
 
-  return (
-    <>
-      {observationId ? (
-        <HeaderBackEditObservation
-          tintColor={tintColor}
-          headerBackButtonProps={headerBackButtonProps}
-          observationId={observationId}
-          openBottomSheet={openSheet}
-        />
-      ) : (
-        <HeaderBackNewObservation
-          tintColor={tintColor}
-          headerBackButtonProps={headerBackButtonProps}
-          openBottomSheet={() =>
-            navigation.navigate('ConfirmDiscardObservationBottomSheet')
-          }
-        />
-      )}
-      <BottomSheetModal isOpen={isOpen} ref={sheetRef}>
-        <BottomSheetModalContent
-          title={formatMessage(m.discardChangesTitle)}
-          description={formatMessage(m.discardChangesDescription)}
-          buttonConfigs={[
-            {
-              variation: 'filled',
-              dangerous: true,
-              onPress: handleDiscard,
-              text: formatMessage(m.discardChangesButton),
-              icon: <DiscardIcon />,
-            },
-            {
-              onPress: closeSheet,
-              text: formatMessage(m.discardCancel),
-              variation: 'outlined',
-            },
-          ]}
-          icon={<ErrorIcon width={60} height={60} />}
-        />
-      </BottomSheetModal>
-    </>
+  return observationId ? (
+    <HeaderBackEditObservation
+      tintColor={tintColor}
+      headerBackButtonProps={headerBackButtonProps}
+      observationId={observationId}
+      openBottomSheet={openBottomSheet}
+    />
+  ) : (
+    <HeaderBackNewObservation
+      tintColor={tintColor}
+      headerBackButtonProps={headerBackButtonProps}
+      openBottomSheet={openBottomSheet}
+    />
   );
 };
 

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -188,6 +188,7 @@ export type RootStackParamsList = {
   DeleteCustomMapBottomSheet: undefined;
   WhatsIncludedBottomSheet: undefined;
   ConfirmDiscardObservationBottomSheet: undefined;
+  ConfirmDiscardObservationEditBottomSheet: {observationId: string};
   ConfirmDiscardTrackBottomSheet: undefined;
 };
 


### PR DESCRIPTION
close #1643 
Uses our bottom sheet for handling the attempted discard of an observation being edited.

### Confirm Discard of an Observation while Editing it:
| Before | After |
|--------|-------|
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/074ffef8-5c72-4e6b-8e89-434aecb3edea" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/368db26f-78b2-411c-acde-079a76cbeafd" /> |