### PR TITLE
chore: add error boundary at top level

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -43,6 +43,7 @@ import {Suspense} from 'react';
 import {Loading} from './sharedComponents/Loading.tsx';
 import {createEarlyAccessStore} from './contexts/EarlyAccessContext.tsx';
 import {FatalError} from './screens/FatalError.tsx';
+import {FatalErrorUntranslated} from './screens/FatalErrorUntranslated.tsx';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
@@ -221,39 +222,41 @@ const App = () => {
   }, []);
 
   return (
-    <LocaleStoreProvider value={persistedLocaleStore}>
-      <IntlProvider>
-        {/* ServerLoading requires internationalization to be set up */}
-        <Sentry.ErrorBoundary fallback={<FatalError />}>
-          <ServerLoading serverStateStore={serverStateStore}>
-            <Suspense fallback={<Loading />}>
-              <AppProviders
-                queryClient={queryClient}
-                localDiscoveryController={localDiscoveryController}
-                mapeoApi={mapeoApi}
-                persistedDrafObservationStore={persistedDraftObservationStore}
-                trackStore={persistedTrackStore}
-                securityStore={persistedSecurityStore}
-                coordinateFormatStore={persistedCoordinateFormatStore}
-                manualEntryCoordinateFormatStore={
-                  persistedManualEntryCoordinateFormatStore
-                }
-                savedLocationStore={savedLocationStore}
-                activeProjectIdStore={persistedActiveProjectIdStore}
-                metricsDiagnosticsStore={persistedMetricsDiagnosticsStore}
-                appUsageStatsStore={appUsagePromptStore}
-                lowStorageBannerStore={lowStorageBannerStore}
-                earlyAccessStore={earlyAccessStore}>
-                <AppNavigator
-                  permissionAsked={permissionsAsked}
-                  navigationIntegration={navigationIntegration}
-                />
-              </AppProviders>
-            </Suspense>
-          </ServerLoading>
-        </Sentry.ErrorBoundary>
-      </IntlProvider>
-    </LocaleStoreProvider>
+    <Sentry.ErrorBoundary fallback={<FatalErrorUntranslated />}>
+      <LocaleStoreProvider value={persistedLocaleStore}>
+        <IntlProvider>
+          {/* This fatal error requires internationalization to be set up */}
+          <Sentry.ErrorBoundary fallback={<FatalError />}>
+            <ServerLoading serverStateStore={serverStateStore}>
+              <Suspense fallback={<Loading />}>
+                <AppProviders
+                  queryClient={queryClient}
+                  localDiscoveryController={localDiscoveryController}
+                  mapeoApi={mapeoApi}
+                  persistedDrafObservationStore={persistedDraftObservationStore}
+                  trackStore={persistedTrackStore}
+                  securityStore={persistedSecurityStore}
+                  coordinateFormatStore={persistedCoordinateFormatStore}
+                  manualEntryCoordinateFormatStore={
+                    persistedManualEntryCoordinateFormatStore
+                  }
+                  savedLocationStore={savedLocationStore}
+                  activeProjectIdStore={persistedActiveProjectIdStore}
+                  metricsDiagnosticsStore={persistedMetricsDiagnosticsStore}
+                  appUsageStatsStore={appUsagePromptStore}
+                  lowStorageBannerStore={lowStorageBannerStore}
+                  earlyAccessStore={earlyAccessStore}>
+                  <AppNavigator
+                    permissionAsked={permissionsAsked}
+                    navigationIntegration={navigationIntegration}
+                  />
+                </AppProviders>
+              </Suspense>
+            </ServerLoading>
+          </Sentry.ErrorBoundary>
+        </IntlProvider>
+      </LocaleStoreProvider>
+    </Sentry.ErrorBoundary>
   );
 };
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -42,6 +42,7 @@ import PostHog from 'posthog-react-native';
 import {Suspense} from 'react';
 import {Loading} from './sharedComponents/Loading.tsx';
 import {createEarlyAccessStore} from './contexts/EarlyAccessContext.tsx';
+import {FatalError} from './screens/FatalError.tsx';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
@@ -220,37 +221,39 @@ const App = () => {
   }, []);
 
   return (
-    <LocaleStoreProvider value={persistedLocaleStore}>
-      <IntlProvider>
-        {/* ServerLoading requires internationalization to be set up */}
-        <ServerLoading serverStateStore={serverStateStore}>
-          <Suspense fallback={<Loading />}>
-            <AppProviders
-              queryClient={queryClient}
-              localDiscoveryController={localDiscoveryController}
-              mapeoApi={mapeoApi}
-              persistedDrafObservationStore={persistedDraftObservationStore}
-              trackStore={persistedTrackStore}
-              securityStore={persistedSecurityStore}
-              coordinateFormatStore={persistedCoordinateFormatStore}
-              manualEntryCoordinateFormatStore={
-                persistedManualEntryCoordinateFormatStore
-              }
-              savedLocationStore={savedLocationStore}
-              activeProjectIdStore={persistedActiveProjectIdStore}
-              metricsDiagnosticsStore={persistedMetricsDiagnosticsStore}
-              appUsageStatsStore={appUsagePromptStore}
-              lowStorageBannerStore={lowStorageBannerStore}
-              earlyAccessStore={earlyAccessStore}>
-              <AppNavigator
-                permissionAsked={permissionsAsked}
-                navigationIntegration={navigationIntegration}
-              />
-            </AppProviders>
-          </Suspense>
-        </ServerLoading>
-      </IntlProvider>
-    </LocaleStoreProvider>
+    <Sentry.ErrorBoundary fallback={<FatalError />}>
+      <LocaleStoreProvider value={persistedLocaleStore}>
+        <IntlProvider>
+          {/* ServerLoading requires internationalization to be set up */}
+          <ServerLoading serverStateStore={serverStateStore}>
+            <Suspense fallback={<Loading />}>
+              <AppProviders
+                queryClient={queryClient}
+                localDiscoveryController={localDiscoveryController}
+                mapeoApi={mapeoApi}
+                persistedDrafObservationStore={persistedDraftObservationStore}
+                trackStore={persistedTrackStore}
+                securityStore={persistedSecurityStore}
+                coordinateFormatStore={persistedCoordinateFormatStore}
+                manualEntryCoordinateFormatStore={
+                  persistedManualEntryCoordinateFormatStore
+                }
+                savedLocationStore={savedLocationStore}
+                activeProjectIdStore={persistedActiveProjectIdStore}
+                metricsDiagnosticsStore={persistedMetricsDiagnosticsStore}
+                appUsageStatsStore={appUsagePromptStore}
+                lowStorageBannerStore={lowStorageBannerStore}
+                earlyAccessStore={earlyAccessStore}>
+                <AppNavigator
+                  permissionAsked={permissionsAsked}
+                  navigationIntegration={navigationIntegration}
+                />
+              </AppProviders>
+            </Suspense>
+          </ServerLoading>
+        </IntlProvider>
+      </LocaleStoreProvider>
+    </Sentry.ErrorBoundary>
   );
 };
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -221,10 +221,10 @@ const App = () => {
   }, []);
 
   return (
-    <Sentry.ErrorBoundary fallback={<FatalError />}>
-      <LocaleStoreProvider value={persistedLocaleStore}>
-        <IntlProvider>
-          {/* ServerLoading requires internationalization to be set up */}
+    <LocaleStoreProvider value={persistedLocaleStore}>
+      <IntlProvider>
+        {/* ServerLoading requires internationalization to be set up */}
+        <Sentry.ErrorBoundary fallback={<FatalError />}>
           <ServerLoading serverStateStore={serverStateStore}>
             <Suspense fallback={<Loading />}>
               <AppProviders
@@ -251,9 +251,9 @@ const App = () => {
               </AppProviders>
             </Suspense>
           </ServerLoading>
-        </IntlProvider>
-      </LocaleStoreProvider>
-    </Sentry.ErrorBoundary>
+        </Sentry.ErrorBoundary>
+      </IntlProvider>
+    </LocaleStoreProvider>
   );
 };
 

--- a/src/frontend/ServerLoading.tsx
+++ b/src/frontend/ServerLoading.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 
-import {FatalError} from './screens/FatalError';
 import type {ServerStateStore} from './lib/ServerStateStore.js';
 
 export const ServerLoading = ({
@@ -23,7 +22,7 @@ export const ServerLoading = ({
 
   if (serverState.value === 'ERROR') {
     SplashScreen.hide();
-    return <FatalError />;
+    throw new Error('Server not loading');
   }
 
   return <>{children}</>;

--- a/src/frontend/screens/FatalError.tsx
+++ b/src/frontend/screens/FatalError.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
 import RNRestart from 'react-native-restart';
-import {Text} from '../sharedComponents/Text';
-import {Button} from '../sharedComponents/Button';
 import {WHITE} from '../lib/styles';
 import {defineMessages, useIntl} from 'react-intl';
 import {MapPinErrorIcon} from '../sharedComponents/MapPinErrorIcon';
+import {PrimaryButton} from '../sharedComponents/Buttons';
+import {HeaderText} from '../sharedComponents/Text/HeaderText';
 
 const m = defineMessages({
   somethingWrong: {
@@ -25,28 +25,20 @@ export const FatalError = () => {
     <View style={styles.container}>
       <View style={{alignItems: 'center'}}>
         <MapPinErrorIcon />
-        <Text style={styles.text}>{formatMessage(m.somethingWrong)}</Text>
+        <HeaderText style={styles.text}>
+          {formatMessage(m.somethingWrong)}
+        </HeaderText>
       </View>
-      <Button
-        fullWidth
+      <PrimaryButton
+        fullSize
+        text={formatMessage(m.restart)}
+        renderIcon={({size, color}) => {
+          return <MaterialIcon size={size} name="refresh" color={color} />;
+        }}
         onPress={() => {
           RNRestart.restart();
-        }}>
-        <View
-          style={{
-            flexDirection: 'row',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}>
-          <MaterialIcon
-            style={{marginRight: 10}}
-            size={30}
-            name="refresh"
-            color={WHITE}
-          />
-          <Text style={{color: WHITE}}>{formatMessage(m.restart)}</Text>
-        </View>
-      </Button>
+        }}
+      />
     </View>
   );
 };
@@ -62,9 +54,6 @@ const styles = StyleSheet.create({
     backgroundColor: WHITE,
   },
   text: {
-    fontSize: 32,
-    fontWeight: 'bold',
-    textAlign: 'center',
     marginTop: 20,
   },
 });

--- a/src/frontend/screens/FatalErrorUntranslated.tsx
+++ b/src/frontend/screens/FatalErrorUntranslated.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {StyleSheet, View} from 'react-native';
+import MaterialIcon from '@react-native-vector-icons/material-icons';
+import RNRestart from 'react-native-restart';
+import {WHITE} from '../lib/styles';
+import {MapPinErrorIcon} from '../sharedComponents/MapPinErrorIcon';
+import {PrimaryButton} from '../sharedComponents/Buttons';
+import {HeaderText} from '../sharedComponents/Text/HeaderText';
+
+export const FatalErrorUntranslated = () => {
+  return (
+    <View style={styles.container}>
+      <View style={{alignItems: 'center'}}>
+        <MapPinErrorIcon />
+        <HeaderText style={styles.text}>Something Went Wrong</HeaderText>
+      </View>
+      <PrimaryButton
+        fullSize
+        text="Restart App"
+        renderIcon={({size, color}) => {
+          return <MaterialIcon size={size} name="refresh" color={color} />;
+        }}
+        onPress={() => {
+          RNRestart.restart();
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    height: '100%',
+    padding: 20,
+    paddingTop: 80,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: WHITE,
+  },
+  text: {
+    marginTop: 20,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
closes #930

To test, I threw an error in `<Serverloading/>` and in `<LocaleStoreProvider/>`.  Note: In development mode, React will rethrow errors caught within an error boundary to the global error handler. This means the error will look like an uncaught error, but if you dismiss that error, you will see the error boundary fallback.