### PR TITLE
fix: crowded preset view

### DIFF
--- a/src/frontend/sharedComponents/PresetView.tsx
+++ b/src/frontend/sharedComponents/PresetView.tsx
@@ -29,7 +29,7 @@ export const PresetView = ({
       disabled={presetDisabled}
       onPress={presetDisabled ? undefined : onPressPreset}
       style={styles.preset}>
-      <View style={{flexDirection: 'row', alignItems: 'center'}}>
+      <View style={{flexDirection: 'row', alignItems: 'center', flex: 1}}>
         {PresetIcon}
         <Text style={styles.categoryName}>{presetName}</Text>
       </View>
@@ -58,5 +58,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     marginLeft: 10,
     fontWeight: 'bold',
+    flexShrink: 1,
   },
 });


### PR DESCRIPTION
closes #1668 
Uses flex to make sure category name fits in box.
Compare to earlier photos in issue...
<img width="350" alt="image" src="https://github.com/user-attachments/assets/dcf6ec08-5180-45da-9378-901dde66ee59" /><img width="350" alt="image" src="https://github.com/user-attachments/assets/836db862-0d1a-411d-b41a-617162d1df78" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/879198a5-faf8-461b-b831-54f72b7f0698" /><img width="350" alt="image" src="https://github.com/user-attachments/assets/6f08d17f-ca79-4421-999e-bc385829ea92" />
