### PR TITLE
chore: refactor use passcode lockout

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -418,9 +418,6 @@
   "constants.red": {
     "message": "Red"
   },
-  "hooks.usePasscodeLockout.lockoutMessage": {
-    "message": "Try again in {minutes, plural, one {# minute} other {# minutes}}"
-  },
   "projectInfoCard.coordinator": {
     "message": "You are a coordinator on this project."
   },
@@ -872,6 +869,9 @@
   },
   "screens.EnterPassword.enterPass": {
     "message": "Enter your passcode"
+  },
+  "screens.EnterPassword.lockoutMessage": {
+    "message": "Try again in {minutes, plural, one {# minute} other {# minutes}}"
   },
   "screens.EnterPassword.wrongPass": {
     "message": "Incorrect Passcode"

--- a/src/frontend/hooks/usePasscodeLockout.ts
+++ b/src/frontend/hooks/usePasscodeLockout.ts
@@ -1,42 +1,40 @@
-import {useEffect, useState} from 'react';
-import {
-  useSecurityActions,
-  useSecurityState,
-} from '../contexts/SecurityStoreContext';
-import {getRemainingLockoutMinutes} from '../lib/security';
-import {defineMessages, useIntl} from 'react-intl';
+import {useEffect, useRef, useState} from 'react';
 
-const m = defineMessages({
-  lockoutMessage: {
-    id: 'hooks.usePasscodeLockout.lockoutMessage',
-    defaultMessage:
-      'Try again in {minutes, plural, one {# minute} other {# minutes}}',
-  },
-});
+function calcMinutes(lockUntil: number): number {
+  const remaining = Math.ceil((lockUntil - Date.now()) / 60_000);
+  return remaining > 0 ? remaining : 0;
+}
 
-export function usePasscodeLockout() {
-  const {lockUntil} = useSecurityState();
-  const {setLockUntil} = useSecurityActions();
-  const [minutes, setMinutes] = useState(0);
-  const {formatMessage} = useIntl();
+export function usePasscodeLockout({
+  lockUntil,
+  clearError,
+}: {
+  lockUntil: number;
+  clearError: () => void;
+}): number {
+  const [minutes, setMinutes] = useState(() => calcMinutes(lockUntil));
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    let timeout: NodeJS.Timeout | null = null;
-    if (lockUntil) {
-      const calcMinutes = getRemainingLockoutMinutes(lockUntil);
-      setMinutes(calcMinutes);
-      timeout = setTimeout(() => {
-        setLockUntil(0);
-      }, calcMinutes * 60_000);
-    }
-
-    return () => {
-      if (timeout) clearTimeout(timeout);
+    const update = () => {
+      const mins = calcMinutes(lockUntil);
+      setMinutes(mins);
+      if (!mins && intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+        clearError();
+      }
     };
-  }, [lockUntil, setLockUntil]);
 
-  return {
-    isLockedOut: !!lockUntil,
-    message: formatMessage(m.lockoutMessage, {minutes}),
-  };
+    update();
+
+    if (!calcMinutes(lockUntil)) return;
+
+    intervalRef.current = setInterval(update, 15_000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [lockUntil, clearError]);
+
+  return minutes;
 }

--- a/src/frontend/hooks/usePasscodeLockout.ts
+++ b/src/frontend/hooks/usePasscodeLockout.ts
@@ -1,9 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
-
-function calcMinutes(lockUntil: number): number {
-  const remaining = Math.ceil((lockUntil - Date.now()) / 60_000);
-  return remaining > 0 ? remaining : 0;
-}
+import {getRemainingLockoutMinutes} from '../lib/security';
 
 export function usePasscodeLockout({
   lockUntil,
@@ -12,12 +8,14 @@ export function usePasscodeLockout({
   lockUntil: number;
   clearError: () => void;
 }): number {
-  const [minutes, setMinutes] = useState(() => calcMinutes(lockUntil));
+  const [minutes, setMinutes] = useState(() =>
+    getRemainingLockoutMinutes(lockUntil),
+  );
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const update = () => {
-      const mins = calcMinutes(lockUntil);
+      const mins = getRemainingLockoutMinutes(lockUntil);
       setMinutes(mins);
       if (!mins && intervalRef.current) {
         clearInterval(intervalRef.current);
@@ -28,7 +26,7 @@ export function usePasscodeLockout({
 
     update();
 
-    if (!calcMinutes(lockUntil)) return;
+    if (!getRemainingLockoutMinutes(lockUntil)) return;
 
     intervalRef.current = setInterval(update, 15_000);
     return () => {

--- a/src/frontend/lib/security.ts
+++ b/src/frontend/lib/security.ts
@@ -18,9 +18,8 @@ export const StoredPasscodeSchema = pipe(
 );
 
 export function getRemainingLockoutMinutes(lockUntil: number): number {
-  if (!lockUntil) return 0;
-  const msRemaining = lockUntil - Date.now();
-  return msRemaining > 0 ? Math.ceil(msRemaining / 60000) : 0;
+  const remaining = Math.ceil((lockUntil - Date.now()) / 60_000);
+  return remaining > 0 ? remaining : 0;
 }
 
 export function getLockoutThreshold(attempts: number): number | null {

--- a/src/frontend/screens/AuthScreen.tsx
+++ b/src/frontend/screens/AuthScreen.tsx
@@ -13,6 +13,7 @@ import {BodyText} from '../sharedComponents/Text/BodyText';
 import {PasscodeInput} from '../sharedComponents/PasscodeInput';
 import {ScreenContentWithDock} from '../sharedComponents/ScreenContentWithDock';
 import {usePasscodeLockout} from '../hooks/usePasscodeLockout';
+import {useSecurityState} from '../contexts/SecurityStoreContext';
 
 const m = defineMessages({
   enterPass: {
@@ -23,6 +24,11 @@ const m = defineMessages({
     id: 'screens.EnterPassword.wrongPass',
     defaultMessage: 'Incorrect Passcode ',
   },
+  lockoutMessage: {
+    id: 'screens.EnterPassword.lockoutMessage',
+    defaultMessage:
+      'Try again in {minutes, plural, one {# minute} other {# minutes}}',
+  },
 });
 
 export const AuthScreen = () => {
@@ -30,9 +36,13 @@ export const AuthScreen = () => {
   const [error, setError] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const {authenticate} = useAuthContext();
+  const lockUntil = useSecurityState(store => store.lockUntil);
   const [inputtedPass, setInputtedPass] = React.useState('');
   const scrollViewRef = React.useRef<ScrollView>(null);
-  const {isLockedOut, message: lockoutMessage} = usePasscodeLockout();
+  const lockedOutMinutes = usePasscodeLockout({
+    lockUntil,
+    clearError: () => setError(false),
+  });
 
   if (error) {
     if (inputtedPass.length === 5) setInputtedPass('');
@@ -74,10 +84,12 @@ export const AuthScreen = () => {
       {process.env.EXPO_PUBLIC_E2E_TEST !== 'true' && (
         <CoMapeoLogoSvg style={{height: window.height / 3, aspectRatio: 1}} />
       )}
-      {isLockedOut ? (
+      {lockedOutMinutes > 0 ? (
         <View style={styles.lockoutContainer}>
           <ClockIcon width={20} height={20} />
-          <BodyText style={styles.lockoutText}>{lockoutMessage}</BodyText>
+          <BodyText style={styles.lockoutText}>
+            {t(m.lockoutMessage, {minutes: lockedOutMinutes})}
+          </BodyText>
         </View>
       ) : (
         <BodyText>{t(m.enterPass)}</BodyText>
@@ -92,7 +104,7 @@ export const AuthScreen = () => {
           error={error}
           inputValue={inputtedPass}
           onChangeTextWithValidation={setInputWithValidation}
-          editable={!isLockedOut}
+          editable={lockedOutMinutes <= 0}
         />
       )}
     </ScreenContentWithDock>


### PR DESCRIPTION
Simplifies the usePasscodeLockout hook. The refactor in #1665 exposed how complicated the code was. This simplifies the hooks (and respects the new eslint rules).

One thing to note. Previously when the timer ran out we would set `lockUntil` to 0. I took out that logic because lockUntil is a date. So we are checking the date relative to `date.Now()`. So a stale date doesn't matter since it is relative. 
