### PR TITLE
fix: observation edit attachments not persisting

### DIFF
--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -235,6 +235,7 @@ function useCheckDraftObservationAndNavigate({
 }) {
   const {navigate} = useNavigationFromHomeTabs();
   const existingObservation = useDraftObservationState(store => store.value);
+  const id = useDraftObservationState(store => store.id);
 
   useFocusEffect(
     React.useCallback(() => {
@@ -247,12 +248,12 @@ function useCheckDraftObservationAndNavigate({
         navigate('ObservationCategoryChooser');
 
         // if existing observation, preset match, and docId exists, navigate to Observation Edit Screen
-      } else if ('docId' in existingObservation) {
+      } else if (id?.docId) {
         navigate('ObservationEdit');
       } else {
         navigate('ObservationCreate');
       }
-    }, [existingObservation, navigate, authState]),
+    }, [existingObservation, navigate, authState, id]),
   );
 }
 

--- a/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
+++ b/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
@@ -38,16 +38,13 @@ const m = defineMessages({
 
 export const ConfirmDiscardObservationEditBottomSheet = ({
   navigation,
-  route,
 }: NativeRootNavigationProps<'ConfirmDiscardObservationEditBottomSheet'>) => {
   const {formatMessage: t} = useIntl();
   const {clearDraft} = useDraftObservationActions();
 
   function handleDiscard() {
     clearDraft();
-    navigation.popTo('Observation', {
-      observationId: route.params.observationId,
-    });
+    navigation.pop(2);
   }
 
   return (

--- a/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
+++ b/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
@@ -65,6 +65,7 @@ export const ConfirmDiscardObservationEditBottomSheet = ({
         <View style={styles.buttonsContainer}>
           <DestructiveButton
             fullSize
+            testID="OBS.discard-obs-btn"
             text={t(m.discardObservationButton)}
             renderIcon={() => <DiscardIcon />}
             onPress={handleDiscard}

--- a/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
+++ b/src/frontend/screens/ObservationEdit/ConfirmDiscardObservationEditBottomSheet.tsx
@@ -44,6 +44,7 @@ export const ConfirmDiscardObservationEditBottomSheet = ({
 
   function handleDiscard() {
     clearDraft();
+    // We are trying to just goBack(), but we need to close 2 screens, the bottom sheet and ObservationEdit.
     navigation.pop(2);
   }
 

--- a/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
+++ b/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
@@ -4,7 +4,6 @@ import {HeaderBackButtonProps} from '@react-navigation/elements';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useFocusEffect} from '@react-navigation/native';
 import {BackHandler} from 'react-native';
-import {useDraftObservationState} from '../../contexts/DraftObservationContext';
 
 type HeaderLeftProps = {
   headerBackButtonProps: HeaderBackButtonProps;
@@ -12,14 +11,10 @@ type HeaderLeftProps = {
 
 export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
   const navigation = useNavigationFromRoot();
-  const observationId = useDraftObservationState(val => val.id);
 
   const handlePress = React.useCallback(() => {
-    if (!observationId) return;
-    navigation.navigate('ConfirmDiscardObservationEditBottomSheet', {
-      observationId: observationId.docId,
-    });
-  }, [navigation, observationId]);
+    navigation.navigate('ConfirmDiscardObservationEditBottomSheet');
+  }, [navigation]);
 
   useFocusEffect(
     React.useCallback(() => {

--- a/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
@@ -38,9 +38,7 @@ export const CustomHeaderLeftClose = ({
 
   const openBottomSheet = React.useCallback(() => {
     if (observationId) {
-      navigation.navigate('ConfirmDiscardObservationEditBottomSheet', {
-        observationId,
-      });
+      navigation.navigate('ConfirmDiscardObservationEditBottomSheet');
     } else {
       navigation.navigate('ConfirmDiscardObservationBottomSheet');
     }

--- a/src/frontend/sharedComponents/HeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/HeaderLeftClose.tsx
@@ -18,6 +18,7 @@ export const HeaderLeftClose = ({
   return (
     <HeaderBackButton
       {...headerBackButtonProps}
+      testID="OBS.header-left-close"
       style={{marginLeft: 0, marginRight: 15}}
       onPress={onPress}
       backImage={() => <HeaderCloseIcon tintColor={tintColor || BLACK} />}

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -187,7 +187,7 @@ export type RootStackParamsList = {
   DeleteCustomMapBottomSheet: undefined;
   WhatsIncludedBottomSheet: undefined;
   ConfirmDiscardObservationBottomSheet: undefined;
-  ConfirmDiscardObservationEditBottomSheet: {observationId: string};
+  ConfirmDiscardObservationEditBottomSheet: undefined;
   ConfirmDiscardTrackBottomSheet: undefined;
   TurnOffPasscodeBottomSheet: undefined;
 };

--- a/tests/e2e/specs/observations/restart-navigation.test.ts
+++ b/tests/e2e/specs/observations/restart-navigation.test.ts
@@ -71,10 +71,16 @@ describe('MAIN - Observation Navigation Flow', () => {
     await expect($(byTextMatches('Change'))).toBeDisplayed();
     await expect($(byResourceId('OBS.description-inp'))).toBeDisplayed();
 
+    const descriptionInput = await $(byResourceId('OBS.description-inp'));
+    await descriptionInput.click();
+    await descriptionInput.setValue('Updated description');
+
     await driver.terminateApp('com.comapeo.rc');
     await driver.activateApp('com.comapeo.rc');
 
     await expect($(byTextMatches('Edit Observation'))).toBeDisplayed();
+    //updated description should still be present
+    await expect($(byTextMatches('Updated description'))).toBeDisplayed();
   });
 
   it('should navigate back to map screen after discarding observarion', async () => {
@@ -86,11 +92,8 @@ describe('MAIN - Observation Navigation Flow', () => {
     const discardBtn = await $(byResourceId('OBS.discard-obs-btn'));
     await discardBtn.click();
 
-    await expect($(byTextMatches('Observation'))).toBeDisplayed();
-
-    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
-    await backBtn.click();
-
+    // should not go back to the observation screen since the app was restarted
+    await expect($(byTextMatches('Observation'))).not.toBeDisplayed();
     const mapsScreen = await $(byResourceId('MAIN.mapbox-map-view'));
     await expect(mapsScreen).toBeDisplayed();
   });

--- a/tests/e2e/specs/observations/restart-navigation.test.ts
+++ b/tests/e2e/specs/observations/restart-navigation.test.ts
@@ -1,6 +1,7 @@
 import {expect} from '@wdio/globals';
 import {describe, it} from 'mocha';
 import {byResourceId, byTextMatches, byText} from '../../utils/selectors';
+import {handleGPSAlert} from '../../utils/alerts';
 
 describe('MAIN - Observation Navigation Flow', () => {
   it('should start on the Map screen if no observation exists', async () => {
@@ -46,5 +47,33 @@ describe('MAIN - Observation Navigation Flow', () => {
     await discardObs.click();
 
     await expect($(byResourceId('MAIN.mapbox-map-view'))).toBeDisplayed();
+  });
+
+  it('should create an observation, then edit, the reopen to edit screen when restarting app', async () => {
+    const addObsBtn = await $('~Add Observation');
+    await addObsBtn.click();
+    const animalCategory = await $(byTextMatches('Animal'));
+    await animalCategory.click();
+    const saveBtn = await $(byResourceId('OBS.edit-save-btn'));
+    await saveBtn.click();
+    await driver.pause(1000);
+    await handleGPSAlert();
+    const obervationsList = await $('~Go to observations list.');
+    await obervationsList.click();
+
+    const animalObs = await $(byTextMatches('Animal'));
+    await animalObs.click();
+
+    const editBtn = await $(byResourceId('editButton'));
+    await editBtn.click();
+
+    await expect($(byTextMatches('Edit Observation'))).toBeDisplayed();
+    await expect($(byTextMatches('Change'))).toBeDisplayed();
+    await expect($(byResourceId('OBS.description-inp'))).toBeDisplayed();
+
+    await driver.terminateApp('com.comapeo.rc');
+    await driver.activateApp('com.comapeo.rc');
+
+    await expect($(byTextMatches('Edit Observation'))).toBeDisplayed();
   });
 });

--- a/tests/e2e/specs/observations/restart-navigation.test.ts
+++ b/tests/e2e/specs/observations/restart-navigation.test.ts
@@ -76,4 +76,22 @@ describe('MAIN - Observation Navigation Flow', () => {
 
     await expect($(byTextMatches('Edit Observation'))).toBeDisplayed();
   });
+
+  it('should navigate back to map screen after discarding observarion', async () => {
+    const closeBtn = await $(byResourceId('OBS.header-left-close'));
+    await closeBtn.click();
+
+    await expect($(byTextMatches('Discard changes?'))).toBeDisplayed();
+
+    const discardBtn = await $(byResourceId('OBS.discard-obs-btn'));
+    await discardBtn.click();
+
+    await expect($(byTextMatches('Observation'))).toBeDisplayed();
+
+    const backBtn = await $(byResourceId('MAIN.header-back-btn'));
+    await backBtn.click();
+
+    const mapsScreen = await $(byResourceId('MAIN.mapbox-map-view'));
+    await expect(mapsScreen).toBeDisplayed();
+  });
 });


### PR DESCRIPTION
closes #1678 

The issue was that we were navigating to the wrong screen when re-opening the app. Instead of navigating to observationEdit, we were accidentally navigating to ObservationCreate. In order to determine which screen to navigate to, we look for the `docId`. If there is a `docId`, it is a saved observation, if there is no `docId`, it is a new, unsaved observation. With the new observation store we are saving the `docId`in a new place. So i updated to check to properly look for the `docId`.

I also updated the navigation from the `ConfirmDiscardObservationEditBottomSheet`. Previously it was 'popTo' to the `observation` screen. But when closing and re-opening the app, we navigate from the map screen to the observationEdit screen. This means that `popTo(Observation)` adds `Observation` to the stack because it is not there originally. So when the user clicks back from the observation screen, it does back to the observationEdit screen, which is not the desired behaviour.