### PR TITLE
chore: pass errors to error bottom sheet

### DIFF
--- a/src/frontend/hooks/useTracking.ts
+++ b/src/frontend/hooks/useTracking.ts
@@ -8,6 +8,7 @@ import {LOCATION_TASK_NAME} from '../sharedTypes/location.ts';
 import {useNavigation} from '@react-navigation/native';
 import * as Sentry from '@sentry/react-native';
 import {useLocationContext} from '../contexts/LocationContext';
+import {toError} from '../utils/errors';
 
 export function useTracking() {
   const {setTracking, addNewLocations, clearCurrentTrack} = useTrackActions();
@@ -30,7 +31,9 @@ export function useTracking() {
       Sentry.captureException(err);
       setTracking(false);
       // @ts-expect-error - this is a typing issue, we are using the non-strongly typed hook as this can technically be used in any screen. But regardless of the screen, we want to show the error bottom sheet.
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(err, 'Tracking failed'),
+      });
     });
   }, [isTracking, setTracking, navigation]);
 

--- a/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
+++ b/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
@@ -11,6 +11,7 @@ import * as Sentry from '@sentry/react-native';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {PrimaryButton, SecondaryButton} from '../../sharedComponents/Buttons';
+import {toError} from '../../utils/errors';
 
 const m = defineMessages({
   title: {
@@ -55,7 +56,9 @@ export const ConfirmPasscodeBottomSheet = ({
       navigation.popTo('Security');
     } catch (e) {
       Sentry.captureException(e);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(e, 'Error setting passcode'),
+      });
     } finally {
       setLoading(false);
     }

--- a/src/frontend/screens/AppPasscode/TurnOffPasscodeBottomSheet.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscodeBottomSheet.tsx
@@ -8,6 +8,7 @@ import ErrorIcon from '../../images/Error.svg';
 import {useSecurityActions} from '../../contexts/SecurityStoreContext';
 import {BottomSheetWrapper} from '../../sharedComponents/BottomSheetWrapper';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {toError} from '../../utils/errors';
 import {
   DestructiveButton,
   SecondaryButton,
@@ -43,9 +44,11 @@ export const TurnOffPasscodeBottomSheet = ({
         setIsLoading(false);
         navigation.pop(4);
       })
-      .catch(() => {
+      .catch(err => {
         setIsLoading(false);
-        navigation.navigate('ErrorBottomSheet');
+        navigation.navigate('ErrorBottomSheet', {
+          error: toError(err, 'Failed to turn off passcode'),
+        });
       });
   }
 

--- a/src/frontend/screens/Audio/AudioAttachmentPlaybackScreen.tsx
+++ b/src/frontend/screens/Audio/AudioAttachmentPlaybackScreen.tsx
@@ -23,6 +23,7 @@ import {audioStyles, SIDE_ICON_BUTTON_WIDTH} from '../../screens/Audio/shared';
 import * as Sentry from '@sentry/react-native';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
+import {toError} from '../../utils/errors';
 import {FormattedObservationDate} from '../../sharedComponents/FormattedData';
 import {useAttachmentUrl} from '@comapeo/core-react';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
@@ -77,7 +78,9 @@ export const AudioAttachmentPlaybackScreen = ({
       }
     } catch (error) {
       Sentry.captureException(error);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(error, 'Audio playback failed'),
+      });
     }
   };
 
@@ -104,7 +107,9 @@ export const AudioAttachmentPlaybackScreen = ({
       await Share.open({url: fileUri, failOnCancel: false});
     } catch (err) {
       Sentry.captureException(err);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(err, 'Error sharing audio'),
+      });
     } finally {
       setShareLoading(false);
     }

--- a/src/frontend/screens/Audio/AudioDraftPlaybackScreen.tsx
+++ b/src/frontend/screens/Audio/AudioDraftPlaybackScreen.tsx
@@ -20,6 +20,7 @@ import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {audioStyles} from './shared';
 import {useDraftObservationActions} from '../../contexts/DraftObservationContext';
 import * as Sentry from '@sentry/react-native';
+import {toError} from '../../utils/errors';
 
 const m = defineMessages({
   recordingSaved: {
@@ -62,7 +63,9 @@ export const AudioDraftPlaybackScreen = ({
       }
     } catch (error) {
       Sentry.captureException(error);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(error, 'Audio playback failed'),
+      });
     }
   };
 

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -17,6 +17,7 @@ import {millisecondsToMMSS} from '../../../lib/millisecondsToFormattedTime';
 import {BodyText} from '../../../sharedComponents/Text/BodyText';
 import {useDraftObservationActions} from '../../../contexts/DraftObservationContext';
 import * as Sentry from '@sentry/react-native';
+import {toError} from '../../../utils/errors';
 
 const m = defineMessages({
   lessThan5: {
@@ -57,7 +58,9 @@ export function AudioRecording({
       start();
     } catch (error) {
       Sentry.captureException(error);
-      navigation.replace('ErrorBottomSheet');
+      navigation.replace('ErrorBottomSheet', {
+        error: toError(error, 'Error starting recording'),
+      });
     }
   }, [startRecording, navigation]);
 
@@ -79,7 +82,9 @@ export function AudioRecording({
       });
     } catch (error) {
       Sentry.captureException(error);
-      navigation.replace('ErrorBottomSheet');
+      navigation.replace('ErrorBottomSheet', {
+        error: toError(error, 'Error finishing recording'),
+      });
     } finally {
       setIsLoading(false);
     }

--- a/src/frontend/screens/BackgroundMaps/BackgroundMaps.tsx
+++ b/src/frontend/screens/BackgroundMaps/BackgroundMaps.tsx
@@ -210,7 +210,7 @@ export function BackgroundMapsScreen() {
               removeCustomMapMutation.mutate(undefined, {
                 onError: err => {
                   Sentry.captureException(err);
-                  navigate('ErrorBottomSheet');
+                  navigate('ErrorBottomSheet', {error: err});
                 },
               });
             }}

--- a/src/frontend/screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx
+++ b/src/frontend/screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx
@@ -81,7 +81,7 @@ export const DeleteCustomMapBottomSheet = () => {
                   },
                   onError: err => {
                     Sentry.captureException(err);
-                    navigation.navigate('ErrorBottomSheet');
+                    navigation.navigate('ErrorBottomSheet', {error: err});
                   },
                 });
               }}

--- a/src/frontend/screens/ConfirmDeletePhoto.tsx
+++ b/src/frontend/screens/ConfirmDeletePhoto.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import {View} from 'react-native';
 import MaterialIcons from '@react-native-vector-icons/material-icons';
-import Error from '../images/Error.svg';
+import ErrorIcon from '../images/Error.svg';
 import {BottomSheetWrapper} from '../sharedComponents/BottomSheetWrapper';
 import {DestructiveButton, SecondaryButton} from '../sharedComponents/Buttons';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
@@ -40,7 +40,7 @@ export function ConfirmDeletePhoto({
     <BottomSheetWrapper>
       <View style={{alignItems: 'center', gap: 40}}>
         <View style={{alignItems: 'center', gap: 20}}>
-          <Error />
+          <ErrorIcon />
           <HeaderText
             selectable
             variant="header2"

--- a/src/frontend/screens/ConfirmDeletePhoto.tsx
+++ b/src/frontend/screens/ConfirmDeletePhoto.tsx
@@ -9,6 +9,7 @@ import {DestructiveButton, SecondaryButton} from '../sharedComponents/Buttons';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {type NativeRootNavigationProps} from '../sharedTypes/navigation';
 import {useDraftObservationActions} from '../contexts/DraftObservationContext';
+import {toError} from '../utils/errors';
 
 const m = defineMessages({
   title: {
@@ -61,7 +62,9 @@ export function ConfirmDeletePhoto({
                 deleteUnsavedAttachment(photoId);
               } catch (reason) {
                 Sentry.captureException(reason);
-                navigation.navigate('ErrorBottomSheet');
+                navigation.navigate('ErrorBottomSheet', {
+                  error: toError(reason, 'Error deleting photo'),
+                });
                 return;
               }
 

--- a/src/frontend/screens/DeviceName/EditScreen.tsx
+++ b/src/frontend/screens/DeviceName/EditScreen.tsx
@@ -124,7 +124,7 @@ export const EditScreen = ({
           },
           onError: err => {
             Sentry.captureException(err);
-            navigation.navigate('ErrorBottomSheet');
+            navigation.navigate('ErrorBottomSheet', {error: err});
           },
         },
       );

--- a/src/frontend/screens/Exchange/ExchangeSettingsBottomSheet.tsx
+++ b/src/frontend/screens/Exchange/ExchangeSettingsBottomSheet.tsx
@@ -60,7 +60,7 @@ export const ExchangeSettingsBottomSheet = () => {
         },
         onError: error => {
           Sentry.captureException(error);
-          navigate('ErrorBottomSheet');
+          navigate('ErrorBottomSheet', {error});
         },
       },
     );

--- a/src/frontend/screens/ExportObservations.tsx
+++ b/src/frontend/screens/ExportObservations.tsx
@@ -14,6 +14,7 @@ import {useObservations} from '../hooks/server/observations';
 import {useTracks} from '../hooks/server/track';
 import * as Sentry from '@sentry/react-native';
 import {isUserCancelled, useExportObservations} from '../hooks/server/projects';
+import {toError} from '../utils/errors';
 
 const m = defineMessages({
   close: {
@@ -83,7 +84,9 @@ export const ExportObservations = ({
             return;
           }
           Sentry.captureException(err);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {
+            error: toError(err, 'Error on export'),
+          });
         },
       },
     );

--- a/src/frontend/screens/Invites/InviteReceived.tsx
+++ b/src/frontend/screens/Invites/InviteReceived.tsx
@@ -103,7 +103,7 @@ export const InviteReceived = ({
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.replace('ErrorBottomSheet');
+          navigation.replace('ErrorBottomSheet', {error: err});
         },
       },
     );
@@ -118,7 +118,7 @@ export const InviteReceived = ({
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.replace('ErrorBottomSheet');
+          navigation.replace('ErrorBottomSheet', {error: err});
         },
       },
     );

--- a/src/frontend/screens/ObservationCreate/ObservationCreateSaveButton.tsx
+++ b/src/frontend/screens/ObservationCreate/ObservationCreateSaveButton.tsx
@@ -25,6 +25,7 @@ import {
   useDraftObservationActions,
   useDraftObservationState,
 } from '../../contexts/DraftObservationContext';
+import {toError} from '../../utils/errors';
 import {
   isUnsavedAudioAttachment,
   isUnsavedPhotoAttachment,
@@ -209,7 +210,9 @@ export const ObservationCreateSaveButton = () => {
       finalizeSave();
     } catch (err) {
       Sentry.captureException(err);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(err, 'Error creating an observation'),
+      });
     }
   }
 

--- a/src/frontend/screens/ObservationEdit/ObservationEditSaveButton.tsx
+++ b/src/frontend/screens/ObservationEdit/ObservationEditSaveButton.tsx
@@ -22,6 +22,7 @@ import {
   isUnsavedAudioAttachment,
   isUnsavedPhotoAttachment,
 } from '../../lib/attachmentTypeChecks';
+import {toError} from '../../utils/errors';
 
 export const ObservationEditSaveButton = () => {
   const value = useDraftObservationState(store => store.value);
@@ -114,7 +115,9 @@ export const ObservationEditSaveButton = () => {
       });
     } catch (err) {
       Sentry.captureException(err);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(err, 'Error saving edited observation'),
+      });
       return;
     }
   }

--- a/src/frontend/screens/Onboarding/MapOnYourOwnIntro.tsx
+++ b/src/frontend/screens/Onboarding/MapOnYourOwnIntro.tsx
@@ -63,8 +63,8 @@ export const MapOnYourOwnIntro = ({
 
   function handleGoToMap() {
     createProject(undefined, {
-      onError: () => {
-        navigation.navigate('ErrorBottomSheet');
+      onError: err => {
+        navigation.navigate('ErrorBottomSheet', {error: err});
       },
       onSuccess: projectId => {
         setActiveProjectId(projectId);

--- a/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/index.tsx
+++ b/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/index.tsx
@@ -19,6 +19,7 @@ import {HeaderText} from '../../../sharedComponents/Text/HeaderText';
 import {useActiveProjectIdActions} from '../../../contexts/ActiveProjectIdStoreContext';
 import * as Sentry from '@sentry/react-native';
 import {useActiveProject} from '../../../contexts/ActiveProjectContext';
+import {toError} from '../../../utils/errors';
 import UniqueProjectIcon from '../../../images/IndexPointingUp.svg';
 import NameMismatchIcon from '../../../images/WarningYellow.svg';
 import SpeechBubbleIcon from '../../../images/SpeechBubble.svg';
@@ -119,7 +120,9 @@ export const CreateOrNameSoloProject = ({
 
     const onError = (err: unknown) => {
       Sentry.captureException(err);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(err, 'Error creating or naming project'),
+      });
     };
 
     if (isSolo) {

--- a/src/frontend/screens/ProjectCreation/ShareProjectStats.tsx
+++ b/src/frontend/screens/ProjectCreation/ShareProjectStats.tsx
@@ -15,6 +15,7 @@ import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useUpdateProjectSettings} from '@comapeo/core-react';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {usePreventAndroidBackButton} from '../../hooks/usePreventAndroidBackButton';
+import {toError} from '../../utils/errors';
 
 const m = defineMessages({
   shareProjectStats: {
@@ -78,13 +79,15 @@ export const ShareProjectStats = ({
           onSuccess: () => goToSuccess(true),
           onError: err => {
             Sentry.captureException(err);
-            navigation.navigate('ErrorBottomSheet');
+            navigation.navigate('ErrorBottomSheet', {error: err});
           },
         },
       );
     } catch (err) {
       Sentry.captureException(err);
-      navigation.navigate('ErrorBottomSheet');
+      navigation.navigate('ErrorBottomSheet', {
+        error: toError(err, 'Error updating sharing settings'),
+      });
     }
   }
   const isSubmitting = updateSettings.status === 'pending';

--- a/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
+++ b/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
@@ -81,7 +81,7 @@ export const EditProjectDetails: NativeNavigationComponent<
                 },
                 onError: err => {
                   Sentry.captureException(err);
-                  navigation.navigate('ErrorBottomSheet');
+                  navigation.navigate('ErrorBottomSheet', {error: err});
                 },
               },
             );

--- a/src/frontend/screens/ProjectStatistics/index.tsx
+++ b/src/frontend/screens/ProjectStatistics/index.tsx
@@ -63,7 +63,7 @@ export const ProjectStatistics = ({
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {error: err});
         },
       },
     );

--- a/src/frontend/screens/RemoteArchive/AddRemoteArchive.tsx
+++ b/src/frontend/screens/RemoteArchive/AddRemoteArchive.tsx
@@ -194,7 +194,7 @@ const AddFoundArchive = ({name, url}: AddFoundArchiveProps) => {
         },
         onError: err => {
           Sentry.captureException(err);
-          navigate('ErrorBottomSheet');
+          navigate('ErrorBottomSheet', {error: err});
         },
       },
     );

--- a/src/frontend/screens/RemoteArchive/RemoveRemoteArchive.tsx
+++ b/src/frontend/screens/RemoteArchive/RemoveRemoteArchive.tsx
@@ -78,7 +78,7 @@ export function RemoveRemoteArchive({
                     {
                       onError: err => {
                         Sentry.captureException(err);
-                        navigation.navigate('ErrorBottomSheet');
+                        navigation.navigate('ErrorBottomSheet', {error: err});
                       },
                       onSuccess: () => {
                         navigation.goBack();

--- a/src/frontend/screens/RemovedFromProjectBottomSheet.tsx
+++ b/src/frontend/screens/RemovedFromProjectBottomSheet.tsx
@@ -16,6 +16,7 @@ import {useActiveProjectIdActions} from '../contexts/ActiveProjectIdStoreContext
 import {UIActivityIndicator} from 'react-native-indicators';
 import {ColorCard} from '../sharedComponents/ColorCard';
 import {DEFAULT_PROJECT_COLOR} from '../constants';
+import {toError} from '../utils/errors';
 
 const m = defineMessages({
   close: {
@@ -85,7 +86,7 @@ export const RemovedFromProjectBottomSheet = ({
                       if (!defaultProject) {
                         // The user should ALWAYS have a default (solo) project. This was not implemented until after v6. So this creates one if it does not exist
                         createProject.mutate(undefined, {
-                          onError: () => {
+                          onError: err => {
                             const firstProject = projects[0];
                             //if there is a project just open that project
                             if (firstProject) {
@@ -93,7 +94,12 @@ export const RemovedFromProjectBottomSheet = ({
                               navigation.popToTop();
                               return;
                             }
-                            navigation.navigate('ErrorBottomSheet');
+                            navigation.navigate('ErrorBottomSheet', {
+                              error: toError(
+                                err,
+                                'Error creating default project',
+                              ),
+                            });
                           },
                           onSuccess: newDefaultProjectId => {
                             setActiveProjectId(newDefaultProjectId);

--- a/src/frontend/screens/Settings/Config.tsx
+++ b/src/frontend/screens/Settings/Config.tsx
@@ -101,7 +101,7 @@ export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
               },
               onError: err => {
                 Sentry.captureException(err);
-                navigation.navigate('ErrorBottomSheet');
+                navigation.navigate('ErrorBottomSheet', {error: err});
               },
               onSuccess: () => {
                 Alert.alert(
@@ -115,7 +115,7 @@ export const Config: NativeNavigationComponent<'Config'> = ({navigation}) => {
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {error: err});
         },
       },
     );

--- a/src/frontend/screens/Track/index.tsx
+++ b/src/frontend/screens/Track/index.tsx
@@ -69,7 +69,7 @@ export const TrackScreen = ({
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {error: err});
         },
       },
     );

--- a/src/frontend/screens/YourTeam/LeaveProject.tsx
+++ b/src/frontend/screens/YourTeam/LeaveProject.tsx
@@ -16,6 +16,7 @@ import {useProjectSettings} from '../../hooks/server/projects';
 import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreContext';
 import * as Sentry from '@sentry/react-native';
 import {UIActivityIndicator} from 'react-native-indicators';
+import {toError} from '../../utils/errors';
 
 const m = defineMessages({
   leaveProjectTitle: {
@@ -70,12 +71,14 @@ export const LeaveProject = ({
             }
           } catch (err) {
             Sentry.captureException(err);
-            navigation.replace('ErrorBottomSheet');
+            navigation.replace('ErrorBottomSheet', {
+              error: toError(err, 'Error updating active project'),
+            });
           }
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.replace('ErrorBottomSheet');
+          navigation.replace('ErrorBottomSheet', {error: err});
         },
       },
     );

--- a/src/frontend/screens/YourTeam/RemoveDevice.tsx
+++ b/src/frontend/screens/YourTeam/RemoveDevice.tsx
@@ -66,7 +66,7 @@ export const RemoveDevice: NativeNavigationComponent<'RemoveDevice'> = ({
         },
         onError: error => {
           Sentry.captureException(error);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {error});
         },
       },
     );

--- a/src/frontend/screens/YourTeam/ReviewAndInvite/index.tsx
+++ b/src/frontend/screens/YourTeam/ReviewAndInvite/index.tsx
@@ -7,6 +7,7 @@ import {useSendInvite, useRequestCancelInvite} from '@comapeo/core-react';
 import {useActiveProject} from '../../../contexts/ActiveProjectContext';
 import * as Sentry from '@sentry/react-native';
 import {resetToYourTeam} from '../../../lib/resetToYourTeam';
+import {toError} from '../../../utils/errors';
 
 const m = defineMessages({
   title: {
@@ -53,7 +54,7 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
         },
         onError(error) {
           Sentry.captureException(error);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {error});
         },
       },
     );
@@ -68,7 +69,9 @@ export const ReviewAndInvite: NativeNavigationComponent<'ReviewAndInvite'> = ({
         },
         onError: err => {
           Sentry.captureException(err);
-          navigation.navigate('ErrorBottomSheet');
+          navigation.navigate('ErrorBottomSheet', {
+            error: toError(err, 'Error canceling invitation'),
+          });
         },
       },
     );

--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -14,6 +14,7 @@ import {useLocationState} from '../contexts/LocationContext';
 import {PhotoMetadata} from '../contexts/PersistedStores/DraftObservationStore';
 import * as Sentry from '@sentry/react-native';
 import {useNavigationFromRoot} from '../hooks/useNavigationWithTypes';
+import {toError} from '../utils/errors';
 
 const m = defineMessages({
   noCameraAccess: {
@@ -100,7 +101,9 @@ export const CameraView = ({onAddPress}: Props) => {
       })
       .catch(err => {
         Sentry.captureException(err);
-        navigation.navigate('ErrorBottomSheet');
+        navigation.navigate('ErrorBottomSheet', {
+          error: toError(err, 'Error taking picture'),
+        });
       })
       .finally(() => {
         setCapturing(false);

--- a/src/frontend/sharedComponents/ErrorBottomSheet.tsx
+++ b/src/frontend/sharedComponents/ErrorBottomSheet.tsx
@@ -20,8 +20,10 @@ const m = defineMessages({
 
 export const ErrorBottomSheet = ({
   navigation,
+  route, // eslint-disable-line @typescript-eslint/no-unused-vars
 }: NativeRootNavigationProps<'ErrorBottomSheet'>) => {
   const {formatMessage} = useIntl();
+  // For future use, an error is now available via route.params.error
   return (
     <BottomSheetWrapper>
       <View style={styles.container}>

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -144,7 +144,7 @@ export type RootStackParamsList = {
   InviteCanceled: {projectName: string};
   RemovedFromProjectBottomSheet: {projectId: string};
   ObservationMetadata: {observationId: string};
-  ErrorBottomSheet: undefined;
+  ErrorBottomSheet: {error: Error};
   BackgroundMapErrorBottomSheet: {title: string; description: string};
   AllProjects: undefined;
   InviteCollaborators: undefined;
@@ -200,7 +200,7 @@ export type OnboardingParamsList = {
   Success: undefined;
   JoinProjectIntro: undefined;
   MapOnYourOwnIntro: undefined;
-  ErrorBottomSheet: undefined;
+  ErrorBottomSheet: {error: Error};
 };
 
 export type AppStackParamsList = RootStackParamsList & OnboardingParamsList;

--- a/src/frontend/utils/errors.ts
+++ b/src/frontend/utils/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Converts an unknown error value to an Error instance.
+ * Useful for catch blocks and error handlers where the error type is unknown.
+ *
+ * @param err - The caught error value (can be anything)
+ * @param fallbackMessage - Message to use if err is not an Error instance
+ * @returns An Error instance
+ */
+export function toError(err: unknown, fallbackMessage: string): Error {
+  if (err instanceof Error) {
+    return err;
+  }
+  return new Error(fallbackMessage);
+}


### PR DESCRIPTION
closes #1690 
**Summary**

- Adds error navigation parameter to ErrorBottomSheet (not used yet but ready for future!)
- Creates a utility to convert errors where the type of error we are getting is unknown to Error instances
- Updates all uses of the ErrorBottomSheet

**Questions:**
- I wasn't really sure what to do/ say for the error messages, since I am not sure at all how the error is going to be handled in the error bottom sheet and how translations will work there, so I didn't make the error messages translatable at this point. I feel like they are just placeholders? But if you know more about this feature and think we will in fact use these messages, then I am happy to make them translatable.
- I made the error required in the Error Bottom Sheet. We had not discussed this, so could you let me know if you have another thought about that? 

**Note**
I touched the files that are not optimized for React Compiler here, but since I am touching so many files and this is such a big PR, I didn't think this was the time to optimize those components. But please let me know if you think it would in fact be a good idea to optimize them in here.