### PR TITLE
chore: fix package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2381,7 +2381,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }


### PR DESCRIPTION
Fixes package-lock using node 24.10.0 and npm 11.6.2