### PR TITLE
fix: screen saver blocked on audio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "expo-font": "14.0.10",
         "expo-image": "3.0.11",
         "expo-image-manipulator": "14.0.8",
+        "expo-keep-awake": "15.0.8",
         "expo-localization": "17.0.8",
         "expo-location": "19.0.8",
         "expo-secure-store": "15.0.8",
@@ -16977,6 +16978,16 @@
       "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
       "license": "MIT"
     },
+    "node_modules/expo-keep-awake": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
+      "integrity": "sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-localization": {
       "version": "17.0.8",
       "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-17.0.8.tgz",
@@ -17493,16 +17504,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/expo/node_modules/expo-keep-awake": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
-      "integrity": "sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
       }
     },
     "node_modules/expo/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "expo-font": "14.0.10",
     "expo-image": "3.0.11",
     "expo-image-manipulator": "14.0.8",
+    "expo-keep-awake": "15.0.8",
     "expo-localization": "17.0.8",
     "expo-location": "19.0.8",
     "expo-secure-store": "15.0.8",

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {StyleSheet, TouchableOpacity, View, AppState, Text} from 'react-native';
+import {useKeepAwake} from 'expo-keep-awake';
 import {BLUE_GREY, DARK_GREY, WHITE} from '../../../lib/styles';
 import {ScreenContentWithDock} from '../../../sharedComponents/ScreenContentWithDock';
 import {AnimatedBackground} from './AnimatedBackground';
@@ -38,6 +39,7 @@ export function AudioRecording({
   navigation,
 }: NativeRootNavigationProps<'AudioRecording'>) {
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';
+  useKeepAwake();
   const {startRecording, stopRecording, status} = useAudioRecording();
   const timeElapsed = status.durationMillis;
   const [isLoading, setIsLoading] = React.useState(true);
@@ -85,7 +87,6 @@ export function AudioRecording({
       navigation.replace('ErrorBottomSheet', {
         error: toError(error, 'Error finishing recording'),
       });
-    } finally {
       setIsLoading(false);
     }
   }, [stopRecording, navigation, addAudio]);


### PR DESCRIPTION
closes #1691 
Adds keep awake module from expo to prevent screen saver from coming up during audio recording. 


Optimizes audio recorder for react compiler.
-  removed the finally block 
- The React Compiler can't optimize try/finally blocks.
- [Here is a reference to the issue in react native](https://github.com/facebook/react/issues/34131)
- [And another issue referencing the same thing](https://github.com/facebook/react/issues/35644)

The screen saver does not come on during development (dev mode). If you want to see the screen saver pop up, you need to build a test or rc. But with this code, even when the screensaver does come on in all other situations, it will not come on during the recording of audio, thus preventing the audio from being stopped prematurely.

**Just FYI, there is now a way to record in the background using expo-audio in case we want to go that route.**