### PR TITLE
chore: address circular deps

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,17 +1,15 @@
+// @ts-check
 const {execSync} = require('child_process');
 const semverParse = require('semver/functions/parse');
 
 /** @import {ExpoConfig} from '@expo/config-types' */
-/** @typedef {typeof VALID_APP_VARIANTS[number]} AppVariant */
+/** @import {AppVariant} from './src/frontend/lib/appVariant' */
 
 const EAS_PROJECT_ID = '2d5b8137-12ec-45aa-9c23-56b6a1c522b7';
 const EAS_UPDATES_URL = 'https://u.expo.dev/' + EAS_PROJECT_ID;
-const VALID_APP_VARIANTS = /** @type (const) */ ([
-  'development',
-  'production',
-  'releaseCandidate',
-  'preRelease',
-]);
+const VALID_APP_VARIANTS = /** @satisfies {readonly AppVariant[]} */ (
+  /** @type {const} */ (['development', 'production', 'rc', 'preRelease'])
+);
 
 const APP_VARIANT = process.env.APP_VARIANT || 'development';
 validateAppVariant(APP_VARIANT);
@@ -28,7 +26,7 @@ const VARIANT_TO_APP_ID_SUFFIX =
   /** @satisfies {Record<AppVariant, string>} */ ({
     development: '.dev',
     production: '',
-    releaseCandidate: '.rc',
+    rc: '.rc',
     preRelease: '.pre',
   });
 const APP_NAME_BASE = 'CoMapeo';
@@ -36,14 +34,14 @@ const VARIANT_TO_APP_NAME_SUFFIX =
   /** @satisfies {Record<AppVariant, string>} */ ({
     development: ' Dev',
     production: '',
-    releaseCandidate: ' RC',
+    rc: ' RC',
     preRelease: ' Pre',
   });
 const VARIANT_TO_VERSION_PRE_RELEASE =
   /** @satisfies {Record<AppVariant, string>} */ ({
     development: '-dev',
     production: '',
-    releaseCandidate: '-rc',
+    rc: '-rc',
     preRelease: '-pre',
   });
 const APP_ID = /** @type {const} */ (
@@ -57,7 +55,7 @@ const VERSION_PRE_RELEASE_SUFFIX = /** @type {const} */ (
 );
 // --- END: App name, ID, and versioning ---
 
-/** @type {({config}: {config: ExpoConfig}): ExpoConfig} */
+/** @type {({config}: {config: ExpoConfig})=> ExpoConfig} */
 module.exports = ({config}) => {
   const versionName = APP_VERSION || generateVersionName();
 

--- a/app.config.js
+++ b/app.config.js
@@ -7,8 +7,14 @@ const semverParse = require('semver/functions/parse');
 
 const EAS_PROJECT_ID = '2d5b8137-12ec-45aa-9c23-56b6a1c522b7';
 const EAS_UPDATES_URL = 'https://u.expo.dev/' + EAS_PROJECT_ID;
+
 const VALID_APP_VARIANTS = /** @satisfies {readonly AppVariant[]} */ (
-  /** @type {const} */ (['development', 'production', 'rc', 'preRelease'])
+  /** @type {const} */ ([
+    'development',
+    'production',
+    'releaseCandidate',
+    'preRelease',
+  ])
 );
 
 const APP_VARIANT = process.env.APP_VARIANT || 'development';
@@ -26,7 +32,7 @@ const VARIANT_TO_APP_ID_SUFFIX =
   /** @satisfies {Record<AppVariant, string>} */ ({
     development: '.dev',
     production: '',
-    rc: '.rc',
+    releaseCandidate: '.rc',
     preRelease: '.pre',
   });
 const APP_NAME_BASE = 'CoMapeo';
@@ -34,14 +40,14 @@ const VARIANT_TO_APP_NAME_SUFFIX =
   /** @satisfies {Record<AppVariant, string>} */ ({
     development: ' Dev',
     production: '',
-    rc: ' RC',
+    releaseCandidate: ' RC',
     preRelease: ' Pre',
   });
 const VARIANT_TO_VERSION_PRE_RELEASE =
   /** @satisfies {Record<AppVariant, string>} */ ({
     development: '-dev',
     production: '',
-    rc: '-rc',
+    releaseCandidate: '-rc',
     preRelease: '-pre',
   });
 const APP_ID = /** @type {const} */ (

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -10,7 +10,6 @@ import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Sentry from '@sentry/react-native';
 import * as TaskManager from 'expo-task-manager';
-import {applicationId} from 'expo-application';
 import {LOCATION_TASK_NAME, LocationCallbackInfo} from './sharedTypes/location';
 import {storage} from './hooks/persistedState/createPersistedState';
 import {getSentryUserId} from './metrics/getSentryUserId';
@@ -41,20 +40,17 @@ import {createEarlyAccessStore} from './contexts/EarlyAccessContext.tsx';
 import {FatalError} from './screens/FatalError.tsx';
 import {FatalErrorUntranslated} from './screens/FatalErrorUntranslated.tsx';
 import {postHog} from './lib/posthog.ts';
+import {APP_VARIANT} from './lib/appVariant.ts';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
-const devMode = applicationId?.endsWith('.dev');
-const testMode = applicationId?.endsWith('.pre');
+const sentryEnvironment: SentryEnvironment =
+  APP_VARIANT === 'rc'
+    ? 'qa'
+    : APP_VARIANT === 'production'
+      ? 'production'
+      : 'development';
 
-let sentryEnvironment: SentryEnvironment = 'production';
-if (devMode || testMode) {
-  sentryEnvironment = 'development';
-} else if (applicationId?.endsWith('.rc')) {
-  sentryEnvironment = 'qa';
-}
-
-const sentryDebug = applicationId?.endsWith('.dev');
 const appMetricsOptIn = sentryEnvironment !== 'production';
 let navigationIntegration:
   | ReturnType<(typeof Sentry)['reactNavigationIntegration']>
@@ -66,7 +62,7 @@ Sentry.init({
   tracesSampleRate: appMetricsOptIn ? 1.0 : 0, // Only enable tracing once we have user consent
   enableUserInteractionTracing: appMetricsOptIn, // Only enable user interaction tracing once we have user consent
   environment: sentryEnvironment,
-  debug: false, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+  debug: false, // this added alot of unneccesary noise to the console.
   initialScope: {user: {id: sentryUserId}},
   enableMetrics: false,
 });
@@ -182,19 +178,6 @@ TaskManager.defineTask(
     }
   },
 );
-
-// export const postHog = new PostHog(
-//   'phc_cr3WAkAaM5rsbiTUF36fzlu8HTrfzL8nOy5elccBdpq',
-//   {
-//     host: 'https://us.i.posthog.com',
-//     //@ts-expect-error - this is the zustand typing, which is he same as posthog's customStorage typing. But zustand typing is less strict, but its quite a ts workaround to make it work, this is the simplest solution.
-//     customStorage: MMKVStoreInitializer,
-//     defaultOptIn: false,
-//     // disable for dev mode and e2e tests
-//     disabled:
-//       process.env.EXPO_PUBLIC_E2E_TEST === 'true' || devMode || testMode,
-//   },
-// );
 
 const appUsagePromptStore = createAppUsageStatsStore({
   persist: true,

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -12,10 +12,7 @@ import * as Sentry from '@sentry/react-native';
 import * as TaskManager from 'expo-task-manager';
 import {applicationId} from 'expo-application';
 import {LOCATION_TASK_NAME, LocationCallbackInfo} from './sharedTypes/location';
-import {
-  MMKVStoreInitializer,
-  storage,
-} from './hooks/persistedState/createPersistedState';
+import {storage} from './hooks/persistedState/createPersistedState';
 import {getSentryUserId} from './metrics/getSentryUserId';
 import {AppDiagnosticMetrics} from './metrics/AppDiagnosticMetrics';
 import {DeviceDiagnosticMetrics} from './metrics/DeviceDiagnosticMetrics';
@@ -38,12 +35,12 @@ import {createServerStateStore} from './lib/ServerStateStore.ts';
 import {createMapeoApi} from './lib/createMapeoApi.ts';
 import {createLowStorageBannerStore} from './contexts/LowStorageBannerContext.tsx';
 import {createAppUsageStatsStore} from './contexts/AppUsageStatsContext.tsx';
-import PostHog from 'posthog-react-native';
 import {Suspense} from 'react';
 import {Loading} from './sharedComponents/Loading.tsx';
 import {createEarlyAccessStore} from './contexts/EarlyAccessContext.tsx';
 import {FatalError} from './screens/FatalError.tsx';
 import {FatalErrorUntranslated} from './screens/FatalErrorUntranslated.tsx';
+import {postHog} from './lib/posthog.ts';
 
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
@@ -69,7 +66,7 @@ Sentry.init({
   tracesSampleRate: appMetricsOptIn ? 1.0 : 0, // Only enable tracing once we have user consent
   enableUserInteractionTracing: appMetricsOptIn, // Only enable user interaction tracing once we have user consent
   environment: sentryEnvironment,
-  debug: sentryDebug, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+  debug: false, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   initialScope: {user: {id: sentryUserId}},
   enableMetrics: false,
 });
@@ -186,18 +183,18 @@ TaskManager.defineTask(
   },
 );
 
-export const postHog = new PostHog(
-  'phc_cr3WAkAaM5rsbiTUF36fzlu8HTrfzL8nOy5elccBdpq',
-  {
-    host: 'https://us.i.posthog.com',
-    //@ts-expect-error - this is the zustand typing, which is he same as posthog's customStorage typing. But zustand typing is less strict, but its quite a ts workaround to make it work, this is the simplest solution.
-    customStorage: MMKVStoreInitializer,
-    defaultOptIn: false,
-    // disable for dev mode and e2e tests
-    disabled:
-      process.env.EXPO_PUBLIC_E2E_TEST === 'true' || devMode || testMode,
-  },
-);
+// export const postHog = new PostHog(
+//   'phc_cr3WAkAaM5rsbiTUF36fzlu8HTrfzL8nOy5elccBdpq',
+//   {
+//     host: 'https://us.i.posthog.com',
+//     //@ts-expect-error - this is the zustand typing, which is he same as posthog's customStorage typing. But zustand typing is less strict, but its quite a ts workaround to make it work, this is the simplest solution.
+//     customStorage: MMKVStoreInitializer,
+//     defaultOptIn: false,
+//     // disable for dev mode and e2e tests
+//     disabled:
+//       process.env.EXPO_PUBLIC_E2E_TEST === 'true' || devMode || testMode,
+//   },
+// );
 
 const appUsagePromptStore = createAppUsageStatsStore({
   persist: true,

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -45,7 +45,7 @@ import {APP_VARIANT} from './lib/appVariant.ts';
 type SentryEnvironment = 'development' | 'qa' | 'production';
 
 const sentryEnvironment: SentryEnvironment =
-  APP_VARIANT === 'rc'
+  APP_VARIANT === 'releaseCandidate'
     ? 'qa'
     : APP_VARIANT === 'production'
       ? 'production'

--- a/src/frontend/AppNavigator.tsx
+++ b/src/frontend/AppNavigator.tsx
@@ -10,7 +10,7 @@ import {useSetUpInvitesListeners} from '@comapeo/core-react';
 import {RootStackNavigator} from './Navigation/Stack';
 import type Sentry from '@sentry/react-native';
 import {PostHogProvider} from 'posthog-react-native';
-import {postHog} from './App';
+import {postHog} from './lib/posthog';
 
 export const AppNavigator = ({
   permissionAsked,

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {RootStack} from '.';
 import {MessageDescriptor} from 'react-intl';
 import {
   ObservationEdit,
@@ -141,6 +140,7 @@ import {WhatsIncludedBottomSheet} from '../../screens/RemoteArchive/WhatsInclude
 import {MapAddedBottomSheet} from '../../screens/BackgroundMaps/MapAddedBottomSheet.tsx';
 import {DeleteCustomMapBottomSheet} from '../../screens/BackgroundMaps/DeleteCustomMapBottomSheet.tsx';
 import {ConfirmDiscardTrackBottomSheet} from '../../screens/SaveTrack/ConfirmDiscardTrackBottomSheet.tsx';
+import {RootStack} from './RootStack.ts';
 
 export const TAB_BAR_HEIGHT = 70;
 

--- a/src/frontend/Navigation/Stack/OnboardingScreens.tsx
+++ b/src/frontend/Navigation/Stack/OnboardingScreens.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {RootStack} from '.';
 import {IntroToCoMapeo} from '../../screens/Onboarding/IntroToCoMapeo';
 import {DataPrivacy} from '../../screens/Onboarding/DataPrivacy';
 import {OnboardingPrivacyPolicy} from '../../screens/Onboarding/OnboardingPrivacyPolicy';
@@ -12,6 +11,7 @@ import {ErrorBottomSheet} from '../../sharedComponents/ErrorBottomSheet';
 import {InviteReceived} from '../../screens/Invites/InviteReceived';
 import {InviteSuccessfullyAccepted} from '../../screens/Invites/InviteSuccessfullyAccepted';
 import {InviteCanceled} from '../../screens/Invites/InviteCanceled';
+import {RootStack} from './RootStack';
 
 export const createOnboardingScreens = ({
   intl,

--- a/src/frontend/Navigation/Stack/RootStack.ts
+++ b/src/frontend/Navigation/Stack/RootStack.ts
@@ -1,0 +1,4 @@
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {AppStackParamsList} from '../../sharedTypes/navigation';
+
+export const RootStack = createNativeStackNavigator<AppStackParamsList>();

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {WHITE, MEDIUM_GREY} from '../../lib/styles';
@@ -15,8 +14,7 @@ import {useActiveProjectId} from '../../contexts/ActiveProjectIdStoreContext';
 import {AuthScreen} from '../../screens/AuthScreen';
 import {ActiveProjectProvider} from '../../contexts/ActiveProjectContext';
 import {useIntl} from 'react-intl';
-
-export const RootStack = createNativeStackNavigator<AppStackParamsList>();
+import {RootStack} from './RootStack';
 
 export type NavigatorLayout = NonNullable<
   React.ComponentProps<typeof RootStack.Navigator>['layout']

--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -1,5 +1,4 @@
 import {createContext, useContext} from 'react';
-import * as v from 'valibot';
 import {createStore, useStore, type StoreApi} from 'zustand';
 import {
   createJSONStorage,
@@ -7,31 +6,11 @@ import {
 } from 'zustand/middleware';
 
 import {MMKVStoreInitializer} from '../hooks/persistedState/createPersistedState';
-import {isSupportedLanguageTag, SupportedLanguageTag} from '../lib/intl';
+import {SupportedLanguageTag} from '../lib/intl';
+import {type LocaleState} from '../sharedTypes/locale';
 
 // Do not change!
 export const STORAGE_KEY = 'locale' as const;
-
-export const LocaleStateSchema = v.variant('languageTag', [
-  v.object({
-    languageTag: v.null(),
-    useSystemPreferences: v.literal(true),
-  }),
-  v.object({
-    languageTag: v.pipe(
-      v.string(),
-      v.transform((value): SupportedLanguageTag => {
-        if (!isSupportedLanguageTag(value)) {
-          throw new Error(`Value is not a supported language tag: ${value}`);
-        }
-        return value;
-      }),
-    ),
-    useSystemPreferences: v.literal(false),
-  }),
-]);
-
-export type LocaleState = v.InferOutput<typeof LocaleStateSchema>;
 
 function createInitialState(): LocaleState {
   return {

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -11,7 +11,7 @@ import {useMutation, useQuery} from '@tanstack/react-query';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {MEMBER_ROLE_ID} from '../../sharedTypes';
 import {saveDocuments} from '@react-native-documents/picker';
-import {Exports} from '../../screens/ExportObservations';
+import {Exports} from '../../sharedTypes/navigation';
 import * as FileSystem from 'expo-file-system/legacy';
 import {useAppLanguageTag} from '../useAppLanguageTag';
 import {useIntl} from 'react-intl';

--- a/src/frontend/lib/appVariant.ts
+++ b/src/frontend/lib/appVariant.ts
@@ -1,11 +1,15 @@
 import {applicationId} from 'expo-application';
 
-export type AppVariant = 'development' | 'rc' | 'production' | 'preRelease';
+export type AppVariant =
+  | 'development'
+  | 'releaseCandidate'
+  | 'production'
+  | 'preRelease';
 
 export const APP_VARIANT: AppVariant = applicationId?.endsWith('.dev')
   ? 'development'
   : applicationId?.endsWith('.rc')
-    ? 'rc'
+    ? 'releaseCandidate'
     : applicationId?.endsWith('.pre')
       ? 'preRelease'
       : 'production';

--- a/src/frontend/lib/appVariant.ts
+++ b/src/frontend/lib/appVariant.ts
@@ -2,18 +2,10 @@ import {applicationId} from 'expo-application';
 
 export type AppVariant = 'development' | 'rc' | 'production' | 'preRelease';
 
-export function getAppVariant(): AppVariant {
-  if (applicationId?.endsWith('.dev')) {
-    return 'development';
-  }
-
-  if (applicationId?.endsWith('.rc')) {
-    return 'rc';
-  }
-
-  if (applicationId?.endsWith('.pre')) {
-    return 'preRelease';
-  }
-
-  return 'production';
-}
+export const APP_VARIANT: AppVariant = applicationId?.endsWith('.dev')
+  ? 'development'
+  : applicationId?.endsWith('.rc')
+    ? 'rc'
+    : applicationId?.endsWith('.pre')
+      ? 'preRelease'
+      : 'production';

--- a/src/frontend/lib/appVariant.ts
+++ b/src/frontend/lib/appVariant.ts
@@ -1,0 +1,19 @@
+import {applicationId} from 'expo-application';
+
+export type AppVariant = 'development' | 'rc' | 'production' | 'preRelease';
+
+export function getAppVariant(): AppVariant {
+  if (applicationId?.endsWith('.dev')) {
+    return 'development';
+  }
+
+  if (applicationId?.endsWith('.rc')) {
+    return 'rc';
+  }
+
+  if (applicationId?.endsWith('.pre')) {
+    return 'preRelease';
+  }
+
+  return 'production';
+}

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -1,8 +1,8 @@
 // Mapping of language tags to corresponding translated messages used in app
 import MESSAGES from '../../../translations/messages.json';
-import {LocaleState} from '../contexts/LocaleStoreContext';
 // Mapping of language tag to corresponding native and english names
 import LANGUAGES from '../languages.json';
+import {type LocaleState} from '../sharedTypes/locale';
 
 // Language tag that has corresponding translations
 export type TranslatedLanguageTag = keyof typeof MESSAGES;

--- a/src/frontend/lib/posthog.ts
+++ b/src/frontend/lib/posthog.ts
@@ -1,8 +1,6 @@
 import PostHog from 'posthog-react-native';
 import {MMKVStoreInitializer} from '../hooks/persistedState/createPersistedState';
-import {getAppVariant} from './appVariant';
-
-const APP_VARIANT = getAppVariant();
+import {APP_VARIANT} from './appVariant';
 
 export const postHog = new PostHog(
   'phc_cr3WAkAaM5rsbiTUF36fzlu8HTrfzL8nOy5elccBdpq',

--- a/src/frontend/lib/posthog.ts
+++ b/src/frontend/lib/posthog.ts
@@ -1,0 +1,20 @@
+import PostHog from 'posthog-react-native';
+import {MMKVStoreInitializer} from '../hooks/persistedState/createPersistedState';
+import {getAppVariant} from './appVariant';
+
+const APP_VARIANT = getAppVariant();
+
+export const postHog = new PostHog(
+  'phc_cr3WAkAaM5rsbiTUF36fzlu8HTrfzL8nOy5elccBdpq',
+  {
+    host: 'https://us.i.posthog.com',
+    // @ts-expect-error - this is the zustand typing, which is he same as posthog's customStorage typing. But zustand typing is less strict, but its quite a ts workaround to make it work, this is the simplest solution.
+    customStorage: MMKVStoreInitializer,
+    defaultOptIn: false,
+    // disable for dev mode and e2e tests
+    disabled:
+      process.env.EXPO_PUBLIC_E2E_TEST === 'true' ||
+      APP_VARIANT === 'development' ||
+      APP_VARIANT === 'preRelease',
+  },
+);

--- a/src/frontend/screens/ExportObservations.tsx
+++ b/src/frontend/screens/ExportObservations.tsx
@@ -4,7 +4,7 @@ import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {defineMessages, useIntl} from 'react-intl';
 import {BodyText} from '../sharedComponents/Text/BodyText';
 import {PrimaryButton, SecondaryButton} from '../sharedComponents/Buttons';
-import {NativeRootNavigationProps} from '../sharedTypes/navigation';
+import {Exports, NativeRootNavigationProps} from '../sharedTypes/navigation';
 import {DARK_GREY, LIGHT_GREY, WARNING_RED} from '../lib/styles';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
 import {useState} from 'react';
@@ -54,8 +54,6 @@ const m = defineMessages({
     defaultMessage: 'Choose an option',
   },
 });
-
-export type Exports = 'Observation' | 'Tracks' | 'ObservationsWithMedia';
 
 export const ExportObservations = ({
   navigation,

--- a/src/frontend/screens/ExportSuccess.tsx
+++ b/src/frontend/screens/ExportSuccess.tsx
@@ -5,9 +5,11 @@ import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {BodyText} from '../sharedComponents/Text/BodyText';
 import {SecondaryButton} from '../sharedComponents/Buttons';
 import SuccessIcon from '../images/Success.svg';
-import {type NativeRootNavigationProps} from '../sharedTypes/navigation';
+import {
+  type Exports,
+  type NativeRootNavigationProps,
+} from '../sharedTypes/navigation';
 import {BLACK, NEW_DARK_GREY} from '../lib/styles';
-import {type Exports} from './ExportObservations';
 
 const m = defineMessages({
   title: {id: 'ExportSuccess.title', defaultMessage: 'Success!'},

--- a/src/frontend/screens/ManualGpsScreen/DmsForm/DmsInputGroup.tsx
+++ b/src/frontend/screens/ManualGpsScreen/DmsForm/DmsInputGroup.tsx
@@ -12,7 +12,7 @@ import {Text} from '../../../sharedComponents/Text';
 import {Select} from '../../../sharedComponents/Select';
 import {BLACK, LIGHT_GREY} from '../../../lib/styles';
 import {INTEGER_REGEX, parseNumber} from '../shared';
-import {DmsData, DmsUnit} from './index';
+import {DmsData, DmsUnit} from './types';
 
 const m = defineMessages({
   degrees: {

--- a/src/frontend/screens/ManualGpsScreen/DmsForm/index.tsx
+++ b/src/frontend/screens/ManualGpsScreen/DmsForm/index.tsx
@@ -10,20 +10,15 @@ import {
   parseNumber,
 } from '../shared';
 import {DmsInputGroup} from './DmsInputGroup';
+import {type DmsData, type DmsUnit} from './types';
+
+export type {DmsData, DmsUnit} from './types';
 
 const INITIAL_UNIT_VALUES = {
   degrees: '',
   minutes: '',
   seconds: '',
 };
-
-export type DmsData = {
-  degrees: string;
-  minutes: string;
-  seconds: string;
-};
-
-export type DmsUnit = keyof DmsData;
 
 const m = defineMessages({
   invalidCoordinates: {

--- a/src/frontend/screens/ManualGpsScreen/DmsForm/types.ts
+++ b/src/frontend/screens/ManualGpsScreen/DmsForm/types.ts
@@ -1,0 +1,7 @@
+export type DmsData = {
+  degrees: string;
+  minutes: string;
+  seconds: string;
+};
+
+export type DmsUnit = keyof DmsData;

--- a/src/frontend/sharedTypes/locale.ts
+++ b/src/frontend/sharedTypes/locale.ts
@@ -1,0 +1,25 @@
+import * as v from 'valibot';
+
+import {isSupportedLanguageTag, SupportedLanguageTag} from '../lib/intl';
+
+// Do not change! Bump version in LocaleStoreContext when modifying this schema.
+export const LocaleStateSchema = v.variant('languageTag', [
+  v.object({
+    languageTag: v.null(),
+    useSystemPreferences: v.literal(true),
+  }),
+  v.object({
+    languageTag: v.pipe(
+      v.string(),
+      v.transform((value): SupportedLanguageTag => {
+        if (!isSupportedLanguageTag(value)) {
+          throw new Error(`Value is not a supported language tag: ${value}`);
+        }
+        return value;
+      }),
+    ),
+    useSystemPreferences: v.literal(false),
+  }),
+]);
+
+export type LocaleState = v.InferOutput<typeof LocaleStateSchema>;

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -7,8 +7,9 @@ import {MessageDescriptor} from 'react-intl';
 import {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
 import {Attachment, DeviceRoleForNewInvite, DeviceType, PhotoEXIF} from '.';
 import {PermissionResponse} from 'expo-audio';
-import {Exports} from '../screens/ExportObservations';
 import {PhotoMetadata} from '../contexts/PersistedStores/DraftObservationStore';
+
+export type Exports = 'Observation' | 'Tracks' | 'ObservationsWithMedia';
 
 export interface TabBarIconProps {
   size: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "*": ["./node_modules/@digidem/types/vendor/*/index.d.ts"]
     }
   },
-  "include": ["src/frontend/**/*"],
+  "include": ["src/frontend/**/*", "app.config.js"],
   "exclude": [
     "node_modules",
     "metro.config.js",


### PR DESCRIPTION
closes #345 

# Circular deps addressed:
Locale Types: The `LocaleStoreContext` was defining the `type LocaleState`, which was being imported by `intl.ts`. Several function from `intl.ts` are being imported by`LocaleStoreContext`. I separated the definition of `type LocaleState` into its own file.
Files: 
- LocaleStoreContext.tsx
- intl.ts
- sharedTypes/locale.ts

DMS types: Previously `DMSForm` was exporting `DmsData` and `DmsUnit`, which was being imported by DMSInputGroup. I separated `DmsData` and `DmsUnit` into its own type folder
Files:
- src/frontend/screens/ManualGpsScreen/DmsForm/types.ts
- src/frontend/screens/ManualGpsScreen/DmsForm/index.tsx
- src/frontend/screens/ManualGpsScreen-/DmsForm/DmsInputGroup.tsx

ExportType: Previously the type `Export` was being exported by the `ExportObservation` screen. I seperated the exportType into the shared navigation types
Files:
- src/frontend/hooks/server/projects.ts
- src/frontend/screens/ExportObservations.tsx
- src/frontend/screens/ExportSuccess.tsx
- src/frontend/sharedTypes/navigation.ts

RootStack. The RootStack was being exported by Stack/index. I separated the RootStack into its own file
Files:
- src/frontend/Navigation/Stack/AppScreens.tsx
- src/frontend/Navigation/Stack/index.tsx
- src/frontend/Navigation/Stack/OnboardingScreens.tsx
- src/frontend/Navigation/Stack/RootStack.ts

PostHog: The Posthog instance was being created in App.tsx. App.tsx was importing AppNavigator. AppNavigator was importing the PostHog Instance. I seperated the PostHog instance into it own file. I also consolidated the AppVariant (which was being used by PostHog). The App Variant was being used in several places, but were checking for it on each instance instead of just having one instance of it. I also updated the tsconfig to properly include app.config.js in typescript checking.
Files:
- src/frontend/App.tsx
- src/frontend/AppNavigator.tsx
- app.config.js
- tsconfig.json

