### PR TITLE
fix: project character length limit

### DIFF
--- a/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/index.tsx
+++ b/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/index.tsx
@@ -173,7 +173,7 @@ export const CreateOrNameSoloProject = ({
                   testID="PROJECT.name-inp"
                   control={control}
                   name="projectName"
-                  rules={{maxLength: 100, required: true, minLength: 1}}
+                  rules={{maxLength: 60, required: true, minLength: 1}}
                   showCharacterCount
                 />
               </View>


### PR DESCRIPTION
closes #1677
Sets the maximum character length for project creation at 60.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/dc08bafc-9f93-4f39-9ea1-945a5d5c2ca7" />
