### PR TITLE
fix: add timezone to metadata

### DIFF
--- a/src/frontend/screens/ObservationMetadata.tsx
+++ b/src/frontend/screens/ObservationMetadata.tsx
@@ -271,7 +271,7 @@ export const ObservationMetadata: NativeNavigationComponent<
 
     const date = `${formatMessage(m.date)}: ${formatDate(createdAt, {dateStyle: 'full'})}`;
 
-    const time = formatTime(createdAt, {timeStyle: 'medium'});
+    const time = formatTime(createdAt, {timeZoneName: 'short'});
 
     const baseLocation =
       lat === undefined || lon === undefined
@@ -308,7 +308,7 @@ export const ObservationMetadata: NativeNavigationComponent<
                 <FormattedDate value={createdAt} dateStyle="full" />
               </BodyText>
               <BodyText style={{color: NEW_DARK_GREY}} variant="smallMeta">
-                <FormattedTime value={createdAt} timeStyle="short" />
+                <FormattedTime value={createdAt} timeZoneName="short" />
               </BodyText>
             </View>
           </View>

--- a/src/frontend/screens/PhotoPreviewModal/InfoItem.tsx
+++ b/src/frontend/screens/PhotoPreviewModal/InfoItem.tsx
@@ -45,7 +45,7 @@ export function CreatedAtInfoItem({createdAt}: {createdAt: number}) {
 
       <BodyText selectable style={sharedStyles.secondaryInfoText}>
         {formatTime(createdAt, {
-          timeStyle: 'short',
+          timeZoneName: 'short',
         })}
       </BodyText>
     </InfoItem>


### PR DESCRIPTION
closes #1679 
Uses intl time formatting to extract and display short timezone on photo and observation metadata.
It displays the currently set timezone that the device is set to at the moment of displaying/ sharing that metadata.

I was not sure which format type to choose, but chose short. Here are all of the options. Would a different option be better?

-  // short: 12/16/2021, PST
-  // long: 12/16/2021, Pacific Standard Time
- // shortOffset: 12/16/2021, GMT-8
- // longOffset: 12/16/2021, GMT-08:00
- // shortGeneric: 12/16/2021, PT
- // longGeneric: 12/16/2021, Pacific Time
- From here: https://developer.mozilla.org/en-

US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat

Used for the photo metadata:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/a38dffe0-c101-484d-952c-6650108946a9" />

Observation metadata:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/fc7ca5fe-23a8-44ff-871e-7b2a0adace75" />

And sharing the Observation metadata:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/86fc4f6e-806f-45ec-b0ec-9dc06c8e9ea9" />

This one is one where the phone is set to Hawaii Time. What's App share...
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b228121b-bfda-4291-ac29-ead23b1b44e2" />
