### PR TITLE
chore: update `@comape/core` and related deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "@babel/preset-env": "7.28.5",
         "@babel/runtime": "7.28.4",
         "@comapeo/cloud": "0.3.0",
-        "@comapeo/core": "5.2.1",
+        "@comapeo/core": "5.5.0",
         "@comapeo/schema": "2.2.0",
         "@digidem/types": "2.3.0",
         "@eslint-react/eslint-plugin": "1.52.2",
@@ -2556,9 +2556,9 @@
       "license": "MIT"
     },
     "node_modules/@comapeo/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-W+THNXlKjutzlmtNxQR203YVUd9roHlna4Z3n8E64qxleBaaMSFKPpRPMHPhlYgALCP6J61B9J3rqnJEFnZLtg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-B4L5uz116BsUiXQDx8Y/4BmhNDWT+2CjEKhUdDvPjkNWLlTaj7e6DMb0HCd9ANwBvSFLCN5HngNOzaS7l+UkjQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2584,7 +2584,7 @@
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "dot-prop-extra": "^10.2.0",
-        "drizzle-orm": "^1.0.0-beta.1-ac4ce44",
+        "drizzle-orm": "1.0.0-beta.1-fd8bfcc",
         "ensure-error": "^4.0.0",
         "fastify": "^4.0.0",
         "fastify-plugin": "^4.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.10.0-pre",
       "hasInstallScript": true,
       "dependencies": {
-        "@comapeo/core-react": "7.2.0",
+        "@comapeo/core-react": "8.0.0",
         "@comapeo/ipc": "6.0.2",
         "@comapeo/nodejs-mobile-react-native": "18.20.4-2",
         "@expo-google-fonts/rubik": "0.4.2",
@@ -2625,13 +2625,13 @@
       }
     },
     "node_modules/@comapeo/core-react": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-7.2.0.tgz",
-      "integrity": "sha512-XewUU9BuxUK06QA7v2A0jUE5EAwV2L/UYBFgYjV6IZrhce3og6VPEYGzfa5fb23EGpvs4Xzv8NBperU/8uxsTg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-8.0.0.tgz",
+      "integrity": "sha512-RcJQeTObVoSBkCw4bE5vlgiu1WzIKlryGAt6yYLKRVvnPFWs5jvQmPWjfjAcyGWCy/oeWdbZ082TLN9XCFbDjg==",
       "license": "MIT",
       "peerDependencies": {
-        "@comapeo/core": "^5.1.1",
-        "@comapeo/ipc": "^6.0.0",
+        "@comapeo/core": "^5.2.1",
+        "@comapeo/ipc": "^6.0.2",
         "@comapeo/schema": "*",
         "@tanstack/react-query": "^5",
         "react": "^18 || ^19"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@babel/preset-env": "7.28.5",
     "@babel/runtime": "7.28.4",
     "@comapeo/cloud": "0.3.0",
-    "@comapeo/core": "5.2.1",
+    "@comapeo/core": "5.5.0",
     "@comapeo/schema": "2.2.0",
     "@digidem/types": "2.3.0",
     "@eslint-react/eslint-plugin": "1.52.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:e2e:build": "npm run build:android:e2e && npm run test:e2e:nobuild"
   },
   "dependencies": {
-    "@comapeo/core-react": "7.2.0",
+    "@comapeo/core-react": "8.0.0",
     "@comapeo/ipc": "6.0.2",
     "@comapeo/nodejs-mobile-react-native": "18.20.4-2",
     "@expo-google-fonts/rubik": "0.4.2",

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@comapeo/core": "5.2.1",
+        "@comapeo/core": "5.5.0",
         "@comapeo/default-categories": "1.0.0",
         "@comapeo/ipc": "6.0.2",
         "@sentry/node": "9.28.0",
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@comapeo/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-W+THNXlKjutzlmtNxQR203YVUd9roHlna4Z3n8E64qxleBaaMSFKPpRPMHPhlYgALCP6J61B9J3rqnJEFnZLtg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-B4L5uz116BsUiXQDx8Y/4BmhNDWT+2CjEKhUdDvPjkNWLlTaj7e6DMb0HCd9ANwBvSFLCN5HngNOzaS7l+UkjQ==",
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
@@ -330,7 +330,7 @@
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "dot-prop-extra": "^10.2.0",
-        "drizzle-orm": "^1.0.0-beta.1-ac4ce44",
+        "drizzle-orm": "1.0.0-beta.1-fd8bfcc",
         "ensure-error": "^4.0.0",
         "fastify": "^4.0.0",
         "fastify-plugin": "^4.5.1",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -13,7 +13,7 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "dependencies": {
-    "@comapeo/core": "5.2.1",
+    "@comapeo/core": "5.5.0",
     "@comapeo/default-categories": "1.0.0",
     "@comapeo/ipc": "6.0.2",
     "@sentry/node": "9.28.0",

--- a/src/frontend/AppNavigator.tsx
+++ b/src/frontend/AppNavigator.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
 import {type AppStackParamsList} from './sharedTypes/navigation';
 
-import {useSetUpInvitesListeners} from '@comapeo/core-react';
 import {RootStackNavigator} from './Navigation/Stack';
 import type Sentry from '@sentry/react-native';
 import {PostHogProvider} from 'posthog-react-native';
@@ -23,7 +22,6 @@ export const AppNavigator = ({
 }) => {
   const containerRef =
     React.useRef<NavigationContainerRef<AppStackParamsList>>(null);
-  useSetUpInvitesListeners();
 
   if (permissionAsked) {
     SplashScreen.hide();


### PR DESCRIPTION
closes: https://github.com/digidem/comapeo-mobile/issues/1719

Updates `@comape/core` and related deps:  and `@comape/core-react`. `@comape/ipc` is typically a related dep that is usually updated with @comape/core, but it is at the @latest version already!

#Updated Deps:
- updated @comape/core from 5.2.1 to 5.5.0
- updated @comape/core-react from 5.2.1 to 5.5.0

