### PR TITLE
chore: update core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "@babel/preset-env": "7.28.5",
         "@babel/runtime": "7.28.4",
         "@comapeo/cloud": "0.3.0",
-        "@comapeo/core": "5.2.1",
+        "@comapeo/core": "5.5.0",
         "@comapeo/schema": "2.2.0",
         "@digidem/types": "2.3.0",
         "@eslint-react/eslint-plugin": "1.52.2",
@@ -2556,9 +2556,9 @@
       "license": "MIT"
     },
     "node_modules/@comapeo/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-W+THNXlKjutzlmtNxQR203YVUd9roHlna4Z3n8E64qxleBaaMSFKPpRPMHPhlYgALCP6J61B9J3rqnJEFnZLtg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-B4L5uz116BsUiXQDx8Y/4BmhNDWT+2CjEKhUdDvPjkNWLlTaj7e6DMb0HCd9ANwBvSFLCN5HngNOzaS7l+UkjQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2584,7 +2584,7 @@
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "dot-prop-extra": "^10.2.0",
-        "drizzle-orm": "^1.0.0-beta.1-ac4ce44",
+        "drizzle-orm": "1.0.0-beta.1-fd8bfcc",
         "ensure-error": "^4.0.0",
         "fastify": "^4.0.0",
         "fastify-plugin": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@babel/preset-env": "7.28.5",
     "@babel/runtime": "7.28.4",
     "@comapeo/cloud": "0.3.0",
-    "@comapeo/core": "5.2.1",
+    "@comapeo/core": "5.5.0",
     "@comapeo/schema": "2.2.0",
     "@digidem/types": "2.3.0",
     "@eslint-react/eslint-plugin": "1.52.2",

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@comapeo/core": "5.2.1",
+        "@comapeo/core": "5.5.0",
         "@comapeo/default-categories": "1.0.0",
         "@comapeo/ipc": "6.0.2",
         "@sentry/node": "9.28.0",
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@comapeo/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-W+THNXlKjutzlmtNxQR203YVUd9roHlna4Z3n8E64qxleBaaMSFKPpRPMHPhlYgALCP6J61B9J3rqnJEFnZLtg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-B4L5uz116BsUiXQDx8Y/4BmhNDWT+2CjEKhUdDvPjkNWLlTaj7e6DMb0HCd9ANwBvSFLCN5HngNOzaS7l+UkjQ==",
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
@@ -330,7 +330,7 @@
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "dot-prop-extra": "^10.2.0",
-        "drizzle-orm": "^1.0.0-beta.1-ac4ce44",
+        "drizzle-orm": "1.0.0-beta.1-fd8bfcc",
         "ensure-error": "^4.0.0",
         "fastify": "^4.0.0",
         "fastify-plugin": "^4.5.1",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -13,7 +13,7 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "dependencies": {
-    "@comapeo/core": "5.2.1",
+    "@comapeo/core": "5.5.0",
     "@comapeo/default-categories": "1.0.0",
     "@comapeo/ipc": "6.0.2",
     "@sentry/node": "9.28.0",


### PR DESCRIPTION
Updates mapeo core to @latest.

closes https://github.com/digidem/comapeo-mobile/issues/1723 which closes: https://github.com/digidem/comapeo-mobile/issues/1719

in [v9](https://github.com/digidem/comapeo-mobile/pull/1622), core was upgraded (but it was not upgraded in develop). This upgrades it, so that the next release v10 does not revert core from v9

It does not update the related deps, `ipc` and `core-react`. These updates are breaking, and are being addressed by the map server worker by @cimigree. the latest version of core is compatible with the older version of ipc and core-react

Should be merged before v10 is put into QA.