### PR TITLE
fix: no passcode required export or track permissions

### DIFF
--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -93,6 +93,9 @@ export function useFindRemoteArchive({url}: {url?: string}) {
   });
 }
 
+// 'background' key prefix prevents passcode prompt during permission dialog (see AuthContext.tsx)
+const EXPORT_MUTATION_KEY = ['background', 'export', 'observations'] as const;
+
 export function useExportObservations({projectId}: {projectId: string}) {
   const exportNoMedia = useExportGeoJSON({projectId});
   const exportWithMedia = useExportZipFile({projectId});
@@ -100,6 +103,7 @@ export function useExportObservations({projectId}: {projectId: string}) {
   const {formatDate} = useIntl();
 
   return useMutation({
+    mutationKey: EXPORT_MUTATION_KEY,
     retry: false,
     networkMode: 'always',
     mutationFn: async ({exportType}: {exportType: Exports}) => {

--- a/src/frontend/hooks/useLocationPermissionTracker.ts
+++ b/src/frontend/hooks/useLocationPermissionTracker.ts
@@ -1,0 +1,19 @@
+import {useMutation} from '@tanstack/react-query';
+
+// 'background' key prefix prevents passcode prompt during permission dialog (see AuthContext.tsx)
+const LOCATION_PERMISSION_MODAL_KEY = [
+  'background',
+  'location',
+  'permission',
+  'modal',
+] as const;
+
+// 'background' key prefix prevents passcode prompt during permission dialog (see AuthContext.tsx)
+
+export function useLocationPermissionModalMutation<T>(fn: () => Promise<T>) {
+  return useMutation({
+    mutationKey: LOCATION_PERMISSION_MODAL_KEY,
+    mutationFn: fn,
+    networkMode: 'always',
+  });
+}

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
@@ -8,6 +8,7 @@ import {StartStopTrack} from './StartStopTrack';
 import Animated, {SlideInDown, SlideOutDown} from 'react-native-reanimated';
 import {WHITE} from '../../../lib/styles';
 import {useFocusEffect} from '@react-navigation/native';
+import {useLocationPermissionModalMutation} from '../../../hooks/useLocationPermissionTracker';
 
 const handleOpenSettings = () => {
   Linking.sendIntent('android.settings.LOCATION_SOURCE_SETTINGS');
@@ -18,6 +19,13 @@ export const TrackBottomSheet = React.memo(() => {
     React.useState<Location.LocationPermissionResponse | null>(null);
   const [backgroundPermission, setBackgroundPermission] =
     React.useState<Location.LocationPermissionResponse | null>(null);
+
+  const requestForegroundPermission = useLocationPermissionModalMutation(
+    Location.requestForegroundPermissionsAsync,
+  );
+  const requestBackgroundPermission = useLocationPermissionModalMutation(
+    Location.requestBackgroundPermissionsAsync,
+  );
 
   const checkPermissions = React.useCallback(async () => {
     const [foreground, background] = await Promise.all([
@@ -70,7 +78,7 @@ export const TrackBottomSheet = React.memo(() => {
           askForegroundLocationPermission={async () => {
             if (foregroundPermission.canAskAgain) {
               const permission =
-                await Location.requestForegroundPermissionsAsync();
+                await requestForegroundPermission.mutateAsync();
               setForegroundPermission(permission);
             } else {
               handleOpenSettings();
@@ -85,7 +93,7 @@ export const TrackBottomSheet = React.memo(() => {
           askBackgroundLocationPermission={async () => {
             if (backgroundPermission.canAskAgain) {
               const permission =
-                await Location.requestBackgroundPermissionsAsync();
+                await requestBackgroundPermission.mutateAsync();
               setBackgroundPermission(permission);
             } else {
               handleOpenSettings();


### PR DESCRIPTION
closes #1715 
closes #1713 
Prevent passcode prompt during export and location permission dialog for tracks.
I fixed this by adding a special 'background' key during the hook that adds to/ uses a check established in the PR below.
The tracks permission was fixed with the same pattern used for Audio done in this PR: https://github.com/digidem/comapeo-mobile/pull/1682
The Export mutation was fixed in a similar way to select file (see same PR above)

