### PR TITLE
fix: text now visible on project edit

### DIFF
--- a/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
+++ b/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
@@ -5,7 +5,7 @@ import {HookFormTextInput} from '../../sharedComponents/HookFormTextInput';
 import {useForm} from 'react-hook-form';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
-import {BLACK, COMAPEO_BLUE} from '../../lib/styles';
+import {COMAPEO_BLUE} from '../../lib/styles';
 import {useProjectRoleAndDetails} from '../../hooks/useProjectRoleAndDetails';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {HorizontalScrollView} from '../../sharedComponents/HorizontalScrollView';
@@ -99,7 +99,7 @@ export const EditProjectDetails: NativeNavigationComponent<
         </HeaderText>
         <HookFormTextInput
           rules={{maxLength: 60, required: true}}
-          style={{textAlignVertical: 'top', fontSize: 20, color: BLACK}}
+          style={{textAlignVertical: 'top', fontSize: 20}}
           control={control}
           showCharacterCount={true}
           name="projectName"
@@ -114,7 +114,7 @@ export const EditProjectDetails: NativeNavigationComponent<
           control={control}
           rules={{maxLength: 60, required: false}}
           multiline={true}
-          style={{textAlignVertical: 'top', fontSize: 20, color: BLACK}}
+          style={{textAlignVertical: 'top', fontSize: 20}}
           showCharacterCount={true}
           name="projectDescription"
           testID="edit-project-description"

--- a/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
+++ b/src/frontend/screens/ProjectSettings/EditProjectDetails.tsx
@@ -5,7 +5,7 @@ import {HookFormTextInput} from '../../sharedComponents/HookFormTextInput';
 import {useForm} from 'react-hook-form';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
-import {COMAPEO_BLUE} from '../../lib/styles';
+import {BLACK, COMAPEO_BLUE} from '../../lib/styles';
 import {useProjectRoleAndDetails} from '../../hooks/useProjectRoleAndDetails';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {HorizontalScrollView} from '../../sharedComponents/HorizontalScrollView';
@@ -99,7 +99,7 @@ export const EditProjectDetails: NativeNavigationComponent<
         </HeaderText>
         <HookFormTextInput
           rules={{maxLength: 60, required: true}}
-          style={{textAlignVertical: 'top', fontSize: 20}}
+          style={{textAlignVertical: 'top', fontSize: 20, color: BLACK}}
           control={control}
           showCharacterCount={true}
           name="projectName"
@@ -114,7 +114,7 @@ export const EditProjectDetails: NativeNavigationComponent<
           control={control}
           rules={{maxLength: 60, required: false}}
           multiline={true}
-          style={{textAlignVertical: 'top', fontSize: 20}}
+          style={{textAlignVertical: 'top', fontSize: 20, color: BLACK}}
           showCharacterCount={true}
           name="projectDescription"
           testID="edit-project-description"

--- a/src/frontend/sharedComponents/HookFormTextInput.tsx
+++ b/src/frontend/sharedComponents/HookFormTextInput.tsx
@@ -10,7 +10,7 @@ import {
   UseControllerProps,
 } from 'react-hook-form';
 import {TextInput as RNTextInput, StyleSheet, View} from 'react-native';
-import {BLACK, LIGHT_GREY, NEW_DARK_GREY, RED} from '../lib/styles';
+import {BLACK, NEW_DARK_GREY, RED, LIGHT_GREY} from '../lib/styles';
 import {ErrorIcon} from './icons';
 import {ViewStyleProp} from '../sharedTypes';
 import {Text} from './Text';
@@ -69,6 +69,7 @@ export const HookFormTextInput = <InputFields extends FieldValues>({
           render={({field: {value, onChange, onBlur}}) => (
             <RNTextInput
               testID={testID}
+              placeholderTextColor={NEW_DARK_GREY}
               style={{
                 flex: 1,
                 color: BLACK,

--- a/src/frontend/sharedComponents/HookFormTextInput.tsx
+++ b/src/frontend/sharedComponents/HookFormTextInput.tsx
@@ -70,16 +70,19 @@ export const HookFormTextInput = <InputFields extends FieldValues>({
             <RNTextInput
               testID={testID}
               placeholderTextColor={NEW_DARK_GREY}
-              style={{
-                flex: 1,
-                color: BLACK,
-                fontFamily: 'Rubik_500Medium',
-                fontSize: 16,
-              }}
               value={value}
               onBlur={onBlur}
               onChangeText={onChange}
               {...RNInputProp}
+              style={[
+                {
+                  flex: 1,
+                  color: BLACK,
+                  fontFamily: 'Rubik_500Medium',
+                  fontSize: 16,
+                },
+                RNInputProp.style,
+              ]}
             />
           )}
         />


### PR DESCRIPTION
closes #1709 
The style prop on the Hook Form Text Input was in the wrong place and was getting overridden by {...RNInputProp} so we would lose the color (and font weight) we set there.
Now React Native's style array properly merges the styles.

Base styles are applied first then RNInputProp.style can come in from the parent to override if necessary.
So now, color: BLACK is preserved unless parent explicitly overrides it.

I also added the placeholder color.
I think that there are now defaults on Pixels of white text and/ or placeholders that there did not used to be and aren't on Samsungs. So it didn't used to matter that our style wasn't applied. But now it does!

<img width="250" alt="image" src="https://github.com/user-attachments/assets/38350b30-1768-435e-9982-6cc4204ce31f" />

To test you need to build an RC and install it. And it will work now!
