### PR TITLE
chore: e2e for discarding edited observation

### DIFF
--- a/tests/e2e/specs/observations/edit-observation.test.ts
+++ b/tests/e2e/specs/observations/edit-observation.test.ts
@@ -50,4 +50,27 @@ describe('Observations - Edit Observation Flow', () => {
     await expect($(byTextMatches('New detail'))).toBeDisplayed();
     await $(byResourceId('MAIN.header-back-btn')).click();
   });
+
+  it('should discard changes when user chooses not to save', async () => {
+    const caveItem = await $(byTextMatches('Cave'));
+    await caveItem.click();
+    const editBtn = await $(byResourceId('editButton'));
+    await editBtn.click();
+
+    const descriptionInput = await $(byResourceId('OBS.description-inp'));
+    await descriptionInput.click();
+    await descriptionInput.setValue('This will be discarded');
+    await driver.hideKeyboard();
+
+    const closeIcon = await $(byResourceId('close-icon'));
+    await closeIcon.click();
+    const discardBtn = await $(byResourceId('OBS.discard-obs-btn'));
+    await discardBtn.click();
+
+    await expect($(byTextMatches('Updated description'))).toBeDisplayed();
+    await expect(
+      $(byTextMatches('This will be discarded')),
+    ).not.toBeDisplayed();
+    await $(byResourceId('MAIN.header-back-btn')).click();
+  });
 });

--- a/tests/e2e/specs/observations/restart-navigation.test.ts
+++ b/tests/e2e/specs/observations/restart-navigation.test.ts
@@ -83,7 +83,7 @@ describe('MAIN - Observation Navigation Flow', () => {
     await expect($(byTextMatches('Updated description'))).toBeDisplayed();
   });
 
-  it('should navigate back to map screen after discarding observarion', async () => {
+  it('should navigate back to map screen after discarding observation', async () => {
     const closeBtn = await $(byResourceId('OBS.header-left-close'));
     await closeBtn.click();
 


### PR DESCRIPTION
closes #1695 
Adds test to check to make sure discarded edits on an observation are discarded.