### PR TITLE
fix: navigation from privacy policy

### DIFF
--- a/src/frontend/screens/DataAndPrivacy/DataAndPrivacy.tsx
+++ b/src/frontend/screens/DataAndPrivacy/DataAndPrivacy.tsx
@@ -94,7 +94,7 @@ export const DataAndPrivacy = ({
             {formatMessage(m.respectsPrivacy)}
           </HeaderText>
           <TouchableOpacity
-            onPress={() => navigation.popTo('SettingsPrivacyPolicy')}>
+            onPress={() => navigation.navigate('SettingsPrivacyPolicy')}>
             <HeaderText variant="header5" style={styles.learnMore}>
               {formatMessage(m.learnMore)}
             </HeaderText>


### PR DESCRIPTION
closes #1714 
Fixes navigation in settings data and privacy from privacy policy. 
I accidentally used pop to to navigate to the info from learn more (back when we upgraded react navigation). 
That was removing data and privacy from the stack! 
Now, instead, we "navigate" there so that we can navigate back.