### PR TITLE
 feat: updated download observations screen

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -939,6 +939,9 @@
   "screens.ExportObservations.download": {
     "message": "Download"
   },
+  "screens.ExportObservations.downloadObservations": {
+    "message": "Download Observations"
+  },
   "screens.ExportObservations.errorMessage": {
     "message": "Choose an option"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -1409,9 +1409,6 @@
   "screens.ObservationList.TrackListItem.Track": {
     "message": "Track"
   },
-  "screens.ObservationList.downloadObservation": {
-    "message": "Download Observations"
-  },
   "screens.ObservationList.observationListTitle": {
     "description": "Title of screen with list of observations",
     "message": "Observations"

--- a/src/frontend/Navigation/Stack/AppScreens.tsx
+++ b/src/frontend/Navigation/Stack/AppScreens.tsx
@@ -538,6 +538,11 @@ export const createAppScreens = ({
         component={CollaboratorInfo}
         options={createCollaboratorInfoNavOptions({intl})}
       />
+      <RootStack.Screen
+        name="ExportObservations"
+        component={ExportObservations}
+        options={{headerTitle: intl(ExportObservations.navTitle)}}
+      />
     </RootStack.Group>
     <RootStack.Group
       screenOptions={{
@@ -573,10 +578,7 @@ export const createAppScreens = ({
         name="TrackRecordingActive"
         component={TrackRecordingActive}
       />
-      <RootStack.Screen
-        name="ExportObservations"
-        component={ExportObservations}
-      />
+
       <RootStack.Screen
         name="DidNotMoveBottomSheet"
         component={DidNotMoveBottomSheet}

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import {TouchableOpacity} from 'react-native';
-import {
-  createBottomTabNavigator,
-  BottomTabHeaderProps,
-} from '@react-navigation/bottom-tabs';
-import {useNavigation} from '@react-navigation/native';
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {CameraScreen} from '../../screens/CameraScreen';
 import {MapScreen} from '../../screens/MapScreen';
 import {ObservationsList} from '../../screens/ObservationsList';
 import {HomeHeader} from '../../sharedComponents/HomeHeader';
-import {HomeTabsParamsList} from '../../sharedTypes/navigation';
+import {
+  HomeTabsParamsList,
+  NativeRootNavigationProps,
+} from '../../sharedTypes/navigation';
 import {TabBar} from './TabBar';
 import {Loading} from '../../sharedComponents/Loading';
 import {NEW_DARK_GREY, WHITE} from '../../lib/styles';
@@ -24,56 +23,7 @@ import {useAuthContext} from '../../contexts/AuthContext';
 
 const Tab = createBottomTabNavigator<HomeTabsParamsList>();
 
-function useShowDownloadIcon() {
-  const {data: observations} = useObservations();
-  const {data: tracks} = useTracks();
-  const {authState} = useAuthContext();
-
-  return (
-    (observations.length > 0 || tracks.length > 0) && authState !== 'obscured'
-  );
-}
-
-function DownloadObservationsButton() {
-  const navigation = useNavigation();
-  const shouldShow = useShowDownloadIcon();
-
-  if (!shouldShow) {
-    return null;
-  }
-
-  return (
-    <TouchableOpacity
-      style={{
-        marginRight: 20,
-      }}
-      accessibilityLabel="Download Observations"
-      onPress={() => {
-        // @ts-expect-error - navigation type mismatch between tab and stack
-        navigation.navigate('ExportObservations');
-      }}>
-      <DownloadIcon size={30} color={NEW_DARK_GREY} />
-    </TouchableOpacity>
-  );
-}
-
-function ObservationsListHeaderComponent(
-  props: BottomTabHeaderProps & {onPress: () => void},
-) {
-  const shouldShowDownloadIcon = useShowDownloadIcon();
-
-  return (
-    <HomeHeader
-      {...props}
-      backgroundColor={WHITE}
-      showBottomBorder={true}
-      onPress={props.onPress}
-      shrinkTitle={shouldShowDownloadIcon}
-    />
-  );
-}
-
-export const HomeTabs = () => {
+export const HomeTabs = ({navigation}: NativeRootNavigationProps<'Home'>) => {
   const [drawerOpen, setDrawerOpen] = useOpenDrawer();
 
   return (
@@ -122,11 +72,17 @@ export const HomeTabs = () => {
             component={ObservationsList}
             options={{
               headerTransparent: false,
-              headerRight: () => <DownloadObservationsButton />,
+              headerRight: () => (
+                <DownloadObservationsButton
+                  onPress={() => navigation.navigate('ExportObservations')}
+                />
+              ),
               header: props => (
                 <React.Suspense fallback={null}>
-                  <ObservationsListHeaderComponent
+                  <HomeHeader
                     {...props}
+                    backgroundColor={WHITE}
+                    showBottomBorder={true}
                     onPress={() => setDrawerOpen(val => !val)}
                   />
                 </React.Suspense>
@@ -140,3 +96,32 @@ export const HomeTabs = () => {
     </>
   );
 };
+
+function useShowDownloadIcon() {
+  const {data: observations} = useObservations();
+  const {data: tracks} = useTracks();
+  const {authState} = useAuthContext();
+
+  return (
+    (observations.length > 0 || tracks.length > 0) && authState !== 'obscured'
+  );
+}
+
+function DownloadObservationsButton({onPress}: {onPress: () => void}) {
+  const shouldShow = useShowDownloadIcon();
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <TouchableOpacity
+      style={{
+        marginRight: 20,
+      }}
+      accessibilityLabel="Download Observations"
+      onPress={onPress}>
+      <DownloadIcon size={30} color={NEW_DARK_GREY} />
+    </TouchableOpacity>
+  );
+}

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {TouchableOpacity} from 'react-native';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {CameraScreen} from '../../screens/CameraScreen';
 import {MapScreen} from '../../screens/MapScreen';
@@ -7,13 +8,59 @@ import {HomeHeader} from '../../sharedComponents/HomeHeader';
 import {HomeTabsParamsList} from '../../sharedTypes/navigation';
 import {TabBar} from './TabBar';
 import {Loading} from '../../sharedComponents/Loading';
-import {WHITE} from '../../lib/styles';
+import {NEW_DARK_GREY, WHITE} from '../../lib/styles';
 import {Drawer} from 'react-native-drawer-layout';
 import {DrawerMenu} from '../../sharedComponents/DrawerMenu';
 import {useOpenDrawer} from '../../hooks/useOpenDrawer';
 import {ProjectRemovalListener} from '../../sharedComponents/ProjectRemovalListener';
+import {DownloadIcon} from '../../sharedComponents/icons';
+import {useObservations} from '../../hooks/server/observations';
+import {useTracks} from '../../hooks/server/track';
+import {useAuthContext} from '../../contexts/AuthContext';
+import {useNavigation} from '@react-navigation/native';
+import {BottomTabHeaderProps} from '@react-navigation/bottom-tabs';
 
 const Tab = createBottomTabNavigator<HomeTabsParamsList>();
+
+function ObservationsListHeader(
+  props: BottomTabHeaderProps & {
+    onPress: () => void;
+  },
+) {
+  const navigation = useNavigation();
+  const {data: observations} = useObservations();
+  const {data: tracks} = useTracks();
+  const {authState} = useAuthContext();
+
+  const shouldShowDownloadIcon =
+    (observations.length > 0 || tracks.length > 0) && authState !== 'obscured';
+
+  return (
+    <HomeHeader
+      {...props}
+      backgroundColor={WHITE}
+      showBottomBorder
+      onPress={props.onPress}
+      shrinkHeader={shouldShowDownloadIcon}
+      downloadIcon={
+        shouldShowDownloadIcon ? (
+          <TouchableOpacity
+            style={{
+              justifyContent: 'center',
+              alignItems: 'center',
+              marginRight: 20,
+            }}
+            onPress={() => {
+              // @ts-expect-error - navigation type mismatch between tab and stack
+              navigation.navigate('ExportObservations');
+            }}>
+            <DownloadIcon size={30} color={NEW_DARK_GREY} />
+          </TouchableOpacity>
+        ) : undefined
+      }
+    />
+  );
+}
 
 export const HomeTabs = () => {
   const [drawerOpen, setDrawerOpen] = useOpenDrawer();
@@ -66,10 +113,8 @@ export const HomeTabs = () => {
               headerTransparent: false,
               header: props => (
                 <React.Suspense fallback={null}>
-                  <HomeHeader
+                  <ObservationsListHeader
                     {...props}
-                    backgroundColor={WHITE}
-                    showBottomBorder
                     onPress={() => setDrawerOpen(val => !val)}
                   />
                 </React.Suspense>

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -50,6 +50,7 @@ function ObservationsListHeader(
               alignItems: 'center',
               marginRight: 20,
             }}
+            accessibilityLabel="Download Observations"
             onPress={() => {
               // @ts-expect-error - navigation type mismatch between tab and stack
               navigation.navigate('ExportObservations');

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import {TouchableOpacity} from 'react-native';
-import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import {
+  createBottomTabNavigator,
+  BottomTabHeaderProps,
+} from '@react-navigation/bottom-tabs';
+import {useNavigation} from '@react-navigation/native';
 import {CameraScreen} from '../../screens/CameraScreen';
 import {MapScreen} from '../../screens/MapScreen';
 import {ObservationsList} from '../../screens/ObservationsList';
@@ -17,48 +21,54 @@ import {DownloadIcon} from '../../sharedComponents/icons';
 import {useObservations} from '../../hooks/server/observations';
 import {useTracks} from '../../hooks/server/track';
 import {useAuthContext} from '../../contexts/AuthContext';
-import {useNavigation} from '@react-navigation/native';
-import {BottomTabHeaderProps} from '@react-navigation/bottom-tabs';
 
 const Tab = createBottomTabNavigator<HomeTabsParamsList>();
 
-function ObservationsListHeader(
-  props: BottomTabHeaderProps & {
-    onPress: () => void;
-  },
-) {
-  const navigation = useNavigation();
+function useShowDownloadIcon() {
   const {data: observations} = useObservations();
   const {data: tracks} = useTracks();
   const {authState} = useAuthContext();
 
-  const shouldShowDownloadIcon =
-    (observations.length > 0 || tracks.length > 0) && authState !== 'obscured';
+  return (
+    (observations.length > 0 || tracks.length > 0) && authState !== 'obscured'
+  );
+}
+
+function DownloadObservationsButton() {
+  const navigation = useNavigation();
+  const shouldShow = useShowDownloadIcon();
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <TouchableOpacity
+      style={{
+        marginRight: 20,
+      }}
+      accessibilityLabel="Download Observations"
+      onPress={() => {
+        // @ts-expect-error - navigation type mismatch between tab and stack
+        navigation.navigate('ExportObservations');
+      }}>
+      <DownloadIcon size={30} color={NEW_DARK_GREY} />
+    </TouchableOpacity>
+  );
+}
+
+function ObservationsListHeaderComponent(
+  props: BottomTabHeaderProps & {onPress: () => void},
+) {
+  const shouldShowDownloadIcon = useShowDownloadIcon();
 
   return (
     <HomeHeader
       {...props}
       backgroundColor={WHITE}
-      showBottomBorder
+      showBottomBorder={true}
       onPress={props.onPress}
-      shrinkHeader={shouldShowDownloadIcon}
-      downloadIcon={
-        shouldShowDownloadIcon ? (
-          <TouchableOpacity
-            style={{
-              justifyContent: 'center',
-              alignItems: 'center',
-              marginRight: 20,
-            }}
-            accessibilityLabel="Download Observations"
-            onPress={() => {
-              // @ts-expect-error - navigation type mismatch between tab and stack
-              navigation.navigate('ExportObservations');
-            }}>
-            <DownloadIcon size={30} color={NEW_DARK_GREY} />
-          </TouchableOpacity>
-        ) : undefined
-      }
+      shrinkTitle={shouldShowDownloadIcon}
     />
   );
 }
@@ -112,9 +122,10 @@ export const HomeTabs = () => {
             component={ObservationsList}
             options={{
               headerTransparent: false,
+              headerRight: () => <DownloadObservationsButton />,
               header: props => (
                 <React.Suspense fallback={null}>
-                  <ObservationsListHeader
+                  <ObservationsListHeaderComponent
                     {...props}
                     onPress={() => setDrawerOpen(val => !val)}
                   />

--- a/src/frontend/screens/ExportObservations.tsx
+++ b/src/frontend/screens/ExportObservations.tsx
@@ -1,12 +1,12 @@
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
-import {BottomSheetWrapper} from '../sharedComponents/BottomSheetWrapper';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {defineMessages, useIntl} from 'react-intl';
 import {BodyText} from '../sharedComponents/Text/BodyText';
-import {PrimaryButton, SecondaryButton} from '../sharedComponents/Buttons';
+import {PrimaryButton} from '../sharedComponents/Buttons';
 import {Exports, NativeRootNavigationProps} from '../sharedTypes/navigation';
 import {DARK_GREY, LIGHT_GREY, WARNING_RED} from '../lib/styles';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
+import {DownloadIcon} from '../sharedComponents/icons';
 import {useState} from 'react';
 import {useActiveProject} from '../contexts/ActiveProjectContext';
 import {UIActivityIndicator} from 'react-native-indicators';
@@ -24,6 +24,10 @@ const m = defineMessages({
   download: {
     id: 'screens.ExportObservations.download',
     defaultMessage: 'Download',
+  },
+  downloadObservations: {
+    id: 'screens.ExportObservations.downloadObservations',
+    defaultMessage: 'Download Observations',
   },
   allObservations: {
     id: 'screens.ExportObservations.allObservations',
@@ -91,81 +95,81 @@ export const ExportObservations = ({
   }
 
   return (
-    <BottomSheetWrapper>
-      <View style={{alignItems: 'center', gap: 10}}>
-        {observations.length > 0 && (
-          <>
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <View style={styles.optionsContainer}>
+          {observations.length > 0 && (
+            <>
+              <ExportOptionCard
+                title={formatMessage(m.allObservations)}
+                description={formatMessage(m.allObservationsDescription)}
+                isSelected={typeToExport === 'Observation'}
+                showError={showError && !typeToExport}
+                onPress={() => {
+                  setTypeToExport('Observation');
+                  if (showError) {
+                    setShowError(false);
+                  }
+                }}
+              />
+              <ExportOptionCard
+                title={formatMessage(m.allObservationsAndMedia)}
+                description={formatMessage(
+                  m.allObservationsAndMediaDescription,
+                )}
+                isSelected={typeToExport === 'ObservationsWithMedia'}
+                showError={showError && !typeToExport}
+                onPress={() => {
+                  setTypeToExport('ObservationsWithMedia');
+                  if (showError) {
+                    setShowError(false);
+                  }
+                }}
+              />
+            </>
+          )}
+          {tracks.length > 0 && (
             <ExportOptionCard
-              title={formatMessage(m.allObservations)}
-              description={formatMessage(m.allObservationsDescription)}
-              isSelected={typeToExport === 'Observation'}
+              title={formatMessage(m.tracks)}
+              description={formatMessage(m.tracksDescription)}
+              isSelected={typeToExport === 'Tracks'}
               showError={showError && !typeToExport}
               onPress={() => {
-                setTypeToExport('Observation');
+                setTypeToExport('Tracks');
                 if (showError) {
                   setShowError(false);
                 }
               }}
             />
-            <ExportOptionCard
-              title={formatMessage(m.allObservationsAndMedia)}
-              description={formatMessage(m.allObservationsAndMediaDescription)}
-              isSelected={typeToExport === 'ObservationsWithMedia'}
-              showError={showError && !typeToExport}
-              onPress={() => {
-                setTypeToExport('ObservationsWithMedia');
-                if (showError) {
-                  setShowError(false);
-                }
-              }}
-            />
-          </>
-        )}
-        {tracks.length > 0 && (
-          <ExportOptionCard
-            title={formatMessage(m.tracks)}
-            description={formatMessage(m.tracksDescription)}
-            isSelected={typeToExport === 'Tracks'}
-            showError={showError && !typeToExport}
-            onPress={() => {
-              setTypeToExport('Tracks');
-              if (showError) {
-                setShowError(false);
-              }
-            }}
-          />
+          )}
+        </View>
+        {showError && (
+          <HeaderText
+            variant="header5"
+            style={{
+              color: WARNING_RED,
+              marginTop: 20,
+              textAlign: 'center',
+            }}>
+            {formatMessage(m.errorMessage)}
+          </HeaderText>
         )}
       </View>
-      {showError && (
-        <HeaderText
-          variant="header5"
-          style={{
-            color: WARNING_RED,
-            marginTop: 20,
-            textAlign: 'center',
-          }}>
-          {formatMessage(m.errorMessage)}
-        </HeaderText>
-      )}
-      {!exportAndShare.isPending ? (
-        <>
+      <View style={styles.buttonContainer}>
+        {!exportAndShare.isPending ? (
           <PrimaryButton
             fullSize={true}
             onPress={handlePressDownload}
-            style={{marginTop: 20, alignSelf: 'center'}}
             text={formatMessage(m.download)}
+            renderIcon={({color, size}) => (
+              <DownloadIcon color={color} size={size} />
+            )}
           />
-          <SecondaryButton
-            fullSize={true}
-            onPress={() => navigation.goBack()}
-            style={{marginTop: 20, alignSelf: 'center'}}
-            text={formatMessage(m.close)}
-          />
-        </>
-      ) : (
-        <UIActivityIndicator style={{paddingTop: 60, paddingBottom: 40}} />
-      )}
-    </BottomSheetWrapper>
+        ) : (
+          <UIActivityIndicator />
+        )}
+      </View>
+    </View>
   );
 };
 
@@ -200,7 +204,25 @@ export const ExportOptionCard = ({
   );
 };
 
+ExportObservations.navTitle = m.downloadObservations;
+
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+    gap: 20,
+  },
+  optionsContainer: {
+    gap: 15,
+  },
+  buttonContainer: {
+    padding: 20,
+    alignItems: 'center',
+  },
   cardButton: {
     alignItems: 'center',
     padding: 20,
@@ -209,5 +231,11 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     borderWidth: 1,
     borderColor: LIGHT_GREY,
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 1},
+    shadowOpacity: 0.3,
+    shadowRadius: 2,
+    elevation: 3,
   },
 });

--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import {View, FlatList, Dimensions, StyleSheet} from 'react-native';
 import {Observation, Track} from '@comapeo/schema';
-import {MessageDescriptor, defineMessages, useIntl} from 'react-intl';
+import {MessageDescriptor, defineMessages} from 'react-intl';
 import {ObservationListItem} from './ObservationListItem';
 import {ObservationEmptyView} from './ObservationsEmptyView';
 import {NativeHomeTabsNavigationProps} from '../../sharedTypes/navigation';
-import {LIGHT_GREY, WHITE} from '../../lib/styles';
+import {WHITE} from '../../lib/styles';
 import {TrackListItem} from './TrackListItem';
 import {useObservations} from '../../hooks/server/observations';
 import {useTracks} from '../../hooks/server/track';
 import {useAuthContext} from '../../contexts/AuthContext';
-import {SecondaryButton} from '../../sharedComponents/Buttons';
 
 const m = defineMessages({
   loading: {
@@ -30,10 +29,6 @@ const m = defineMessages({
     id: 'screens.ObservationList.observationListTitle',
     defaultMessage: 'Observations',
     description: 'Title of screen with list of observations',
-  },
-  downloadObservation: {
-    id: 'screens.ObservationList.downloadObservation',
-    defaultMessage: 'Download Observations',
   },
 });
 
@@ -57,7 +52,6 @@ export const ObservationsList: React.FC<
   const {data: observations} = useObservations();
   const {data: tracks} = useTracks();
   const {authState} = useAuthContext();
-  const {formatMessage} = useIntl();
 
   const rowsPerWindow = Math.ceil(
     (Dimensions.get('window').height - 65) / OBSERVATION_CELL_HEIGHT,
@@ -75,17 +69,6 @@ export const ObservationsList: React.FC<
     <View style={styles.container} testID="OBS.list-scrn">
       {/* re: https://github.com/digidem/comapeo-mobile/issues/586  */}
       <FlatList
-        ListHeaderComponent={
-          <View style={styles.populatedListHeader}>
-            <SecondaryButton
-              onPress={() => {
-                navigation.navigate('ExportObservations');
-              }}
-              text={formatMessage(m.downloadObservation)}
-              fullSize
-            />
-          </View>
-        }
         initialNumToRender={rowsPerWindow}
         getItemLayout={getItemLayout}
         keyExtractor={keyExtractor}
@@ -139,11 +122,5 @@ const styles = StyleSheet.create({
   },
   listItem: {
     height: OBSERVATION_CELL_HEIGHT,
-  },
-  populatedListHeader: {
-    alignItems: 'center',
-    padding: 20,
-    borderBottomWidth: 1,
-    borderBottomColor: LIGHT_GREY,
   },
 });

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -16,16 +16,15 @@ type HomeHeaderProps = BottomTabHeaderProps & {
   backgroundColor: string;
   showBottomBorder: boolean;
   onPress: () => void;
-  downloadIcon?: React.ReactNode;
-  shrinkHeader?: boolean;
+  shrinkTitle?: boolean;
 };
 
 export function HomeHeader({
   backgroundColor,
   showBottomBorder,
   onPress,
-  downloadIcon,
-  shrinkHeader,
+  options,
+  shrinkTitle,
 }: HomeHeaderProps) {
   const {projectId} = useActiveProject();
   const projectDetails = useProjectRoleAndDetails(projectId);
@@ -49,7 +48,7 @@ export function HomeHeader({
           style={[
             styles.titleBox,
             {backgroundColor: projectDetails.projectColor},
-            shrinkHeader && {maxWidth: '80%'},
+            shrinkTitle && {maxWidth: '80%'},
           ]}
           onPress={onPress}
           accessibilityLabel="Open Menu"
@@ -71,7 +70,10 @@ export function HomeHeader({
             </View>
           )}
         </TouchableOpacity>
-        {downloadIcon}
+        {options.headerRight?.(
+          // @ts-expect-error - our custom headerRight doesn't use these params
+          {},
+        )}
       </View>
     </View>
   );

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -16,7 +16,6 @@ type HomeHeaderProps = BottomTabHeaderProps & {
   backgroundColor: string;
   showBottomBorder: boolean;
   onPress: () => void;
-  shrinkTitle?: boolean;
 };
 
 export function HomeHeader({
@@ -24,7 +23,6 @@ export function HomeHeader({
   showBottomBorder,
   onPress,
   options,
-  shrinkTitle,
 }: HomeHeaderProps) {
   const {projectId} = useActiveProject();
   const projectDetails = useProjectRoleAndDetails(projectId);
@@ -48,7 +46,6 @@ export function HomeHeader({
           style={[
             styles.titleBox,
             {backgroundColor: projectDetails.projectColor},
-            shrinkTitle && {maxWidth: '80%'},
           ]}
           onPress={onPress}
           accessibilityLabel="Open Menu"

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -16,12 +16,16 @@ type HomeHeaderProps = BottomTabHeaderProps & {
   backgroundColor: string;
   showBottomBorder: boolean;
   onPress: () => void;
+  downloadIcon?: React.ReactNode;
+  shrinkHeader?: boolean;
 };
 
 export function HomeHeader({
   backgroundColor,
   showBottomBorder,
   onPress,
+  downloadIcon,
+  shrinkHeader,
 }: HomeHeaderProps) {
   const {projectId} = useActiveProject();
   const projectDetails = useProjectRoleAndDetails(projectId);
@@ -45,6 +49,7 @@ export function HomeHeader({
           style={[
             styles.titleBox,
             {backgroundColor: projectDetails.projectColor},
+            shrinkHeader && {maxWidth: '80%'},
           ]}
           onPress={onPress}
           accessibilityLabel="Open Menu"
@@ -66,6 +71,7 @@ export function HomeHeader({
             </View>
           )}
         </TouchableOpacity>
+        {downloadIcon}
       </View>
     </View>
   );

--- a/src/frontend/sharedComponents/HomeHeader.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.tsx
@@ -70,10 +70,9 @@ export function HomeHeader({
             </View>
           )}
         </TouchableOpacity>
-        {options.headerRight?.(
-          // @ts-expect-error - our custom headerRight doesn't use these params
-          {},
-        )}
+        <View style={{paddingLeft: 10}}>
+          {options.headerRight?.({canGoBack: false})}
+        </View>
       </View>
     </View>
   );
@@ -84,7 +83,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
   headerRow: {
-    width: '100%',
     minHeight: 58,
     flexDirection: 'row',
     alignItems: 'center',
@@ -92,13 +90,13 @@ const styles = StyleSheet.create({
   },
   titleBox: {
     height: 40,
-    maxWidth: '100%',
     borderRadius: 6,
     borderWidth: 0.5,
     borderColor: BLUE_GREY,
     flexDirection: 'row',
     alignItems: 'center',
     paddingRight: 10,
+    flexShrink: 1,
   },
   menuIconContainer: {
     width: 40,

--- a/tests/e2e/specs/observations/export-observations.test.ts
+++ b/tests/e2e/specs/observations/export-observations.test.ts
@@ -53,16 +53,17 @@ describe('Observations - should show download options', () => {
     await handleGPSAlert();
   });
 
-  it('should open Observations list and download button', async () => {
+  it('should open Observations list with download icon in header', async () => {
     const obsListTab = await $('~Go to observations list.');
     await obsListTab.click();
     await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
-    await expect($(byText('Download Observations'))).toBeDisplayed();
+    await expect($('~Download Observations')).toBeDisplayed();
   });
 
-  it('should open Export Observations bottom screen', async () => {
-    const downloadObsBtn = await $(byText('Download Observations'));
-    await downloadObsBtn.click();
+  it('should open Export Observations screen from header icon', async () => {
+    const downloadIcon = await $('~Download Observations');
+    await downloadIcon.click();
+    await expect($(byText('Download Observations'))).toBeDisplayed();
     await expect($(byText('All Observations'))).toBeDisplayed();
     await expect($(byText('All Observations with Media'))).toBeDisplayed();
   });
@@ -86,11 +87,9 @@ describe('Observations - should show download options', () => {
     await driver.back();
   });
 
-  it('should close bottom sheet on pressing close', async () => {
-    const closeBtn = await $(byText('Close'));
-    await closeBtn.click();
-    await expect($(byText('All Observations'))).not.toBeDisplayed();
-    await expect($(byText('All Observations with Media'))).not.toBeDisplayed();
+  it('should go back to observations list', async () => {
+    await driver.back();
+    await expect($(byResourceId('OBS.list-scrn'))).toBeDisplayed();
     // reset state back to map
     const mapBtn = await $('~Go to map.');
     await mapBtn.click();


### PR DESCRIPTION
closes #1725 
Switches download observations to full screen.
I left the text the way it was in the file. Not sure if the text in the screen shots and figma makes sense? 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/3de4a872-74e4-474a-a73c-a630aebe9a3b" />