### PR TITLE
chore: use official exported types from @comapeo/core

### DIFF
--- a/src/frontend/hooks/server/media.ts
+++ b/src/frontend/hooks/server/media.ts
@@ -1,5 +1,5 @@
 import {useAttachmentUrl, useCreateBlob} from '@comapeo/core-react';
-import type {BlobId, BlobVariant} from '@comapeo/core/dist/types';
+import type {BlobApi} from '@comapeo/core';
 import {useMutation} from '@tanstack/react-query';
 import type {LocationObject} from 'expo-location';
 import {URL} from 'react-native-url-polyfill';
@@ -96,7 +96,7 @@ export function useCreateAudioAttachment({projectId}: {projectId: string}) {
 function buildBlobId(
   attachment: Attachment,
   requestedVariant: 'original' | 'thumbnail' | 'preview',
-): BlobId {
+): BlobApi.BlobId {
   if (
     attachment.type !== 'photo' &&
     attachment.type !== 'audio' &&
@@ -126,7 +126,7 @@ function buildBlobId(
 
 export function useAttachmentUrlQuery(
   attachment: Attachment,
-  variant: BlobVariant<'photo' | 'audio' | 'video'>,
+  variant: BlobApi.BlobVariant<'photo' | 'audio' | 'video'>,
 ) {
   const {projectId} = useActiveProject();
   if (

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -1,4 +1,4 @@
-import {type MemberInfo} from '@comapeo/core/dist/member-api';
+import type {MemberApi} from '@comapeo/core';
 import {
   useProjectSettings as useComapeoProjectSettings,
   useExportGeoJSON,
@@ -37,14 +37,16 @@ export function useGetOwnRole() {
 }
 
 // TODO: Ideally this is handled in @comapeo/core (https://github.com/digidem/comapeo-core/issues/1031)
-export type ArchiveServerMemberInfo = MemberInfo & {
+export type ArchiveServerMemberInfo = MemberApi.MemberInfo & {
   deviceType: 'selfHostedServer';
-  selfHostedServerDetails: NonNullable<MemberInfo['selfHostedServerDetails']>;
+  selfHostedServerDetails: NonNullable<
+    MemberApi.MemberInfo['selfHostedServerDetails']
+  >;
 };
 
 // TODO: Ideally this is handled in @comapeo/core (https://github.com/digidem/comapeo-core/issues/1031)
 export function isActiveArchiveServerMember(
-  member: MemberInfo,
+  member: MemberApi.MemberInfo,
 ): member is ArchiveServerMemberInfo {
   if (member.deviceType !== 'selfHostedServer') return false;
   if (!member.selfHostedServerDetails) return false;

--- a/src/frontend/hooks/useIsLastCoordinator.test.tsx
+++ b/src/frontend/hooks/useIsLastCoordinator.test.tsx
@@ -1,5 +1,6 @@
 import {renderHook} from '@testing-library/react-native';
 import {type ReactNode} from 'react';
+import type {MemberApi} from '@comapeo/core';
 import {useManyMembers} from '@comapeo/core-react';
 
 import {ActiveProjectProvider} from '../contexts/ActiveProjectContext';
@@ -9,7 +10,6 @@ import {
   CREATOR_ROLE_ID,
   MEMBER_ROLE_ID,
 } from '../sharedTypes';
-import {type MemberInfo} from '@comapeo/core/dist/member-api';
 
 jest.mock('@comapeo/core-react', () => ({
   useManyMembers: jest.fn(),
@@ -36,16 +36,17 @@ function createWrapper() {
 
 function mockMember(
   deviceId: string,
-  roleId: string,
+  roleId: MemberApi.RoleId,
   deviceType: 'mobile' | 'desktop' = 'mobile',
-): MemberInfo {
+): MemberApi.MemberInfo {
   return {
     deviceId,
     name: `Device ${deviceId}`,
+    // @ts-expect-error Unsound but enough for testing purposes
     role: {roleId},
     deviceType,
     joinedAt: new Date().toISOString(),
-  } as MemberInfo;
+  };
 }
 
 afterEach(() => {

--- a/src/frontend/hooks/useIsLastMember.test.tsx
+++ b/src/frontend/hooks/useIsLastMember.test.tsx
@@ -1,5 +1,6 @@
 import {renderHook} from '@testing-library/react-native';
 import {type ReactNode} from 'react';
+import type {MemberApi} from '@comapeo/core';
 import {useManyMembers} from '@comapeo/core-react';
 
 import {ActiveProjectProvider} from '../contexts/ActiveProjectContext';
@@ -11,7 +12,6 @@ import {
   BLOCKED_ROLE_ID,
   LEFT_ROLE_ID,
 } from '../sharedTypes';
-import {type MemberInfo} from '@comapeo/core/dist/member-api';
 
 jest.mock('@comapeo/core-react', () => ({
   useManyMembers: jest.fn(),
@@ -38,16 +38,17 @@ function createWrapper() {
 
 function mockMember(
   deviceId: string,
-  roleId: string,
+  roleId: MemberApi.RoleId,
   deviceType: 'mobile' | 'desktop' = 'mobile',
-): MemberInfo {
+): MemberApi.MemberInfo {
   return {
     deviceId,
     name: `Device ${deviceId}`,
+    // @ts-expect-error Unsound but enough for testing purposes
     role: {roleId},
     deviceType,
     joinedAt: new Date().toISOString(),
-  } as MemberInfo;
+  };
 }
 
 afterEach(() => {

--- a/src/frontend/hooks/useListenToInviteCancel.ts
+++ b/src/frontend/hooks/useListenToInviteCancel.ts
@@ -1,13 +1,14 @@
-import {Invite} from '@comapeo/core/dist/invite/invite-api';
 import {useEffect} from 'react';
-import {useNavigationFromRoot} from './useNavigationWithTypes';
+import type {InviteApi} from '@comapeo/core';
 import {useClientApi} from '@comapeo/core-react';
+
+import {useNavigationFromRoot} from './useNavigationWithTypes';
 
 export function useListenToInviteCancel(inviteId: string) {
   const navigation = useNavigationFromRoot();
   const {invite: mapeoApiInvite} = useClientApi();
   useEffect(() => {
-    function navigateOnCancel(invite: Invite) {
+    function navigateOnCancel(invite: InviteApi.Invite) {
       if (invite.inviteId !== inviteId) return;
 
       if (invite.state === 'canceled') {

--- a/src/frontend/sharedComponents/ProjectRemovalListener.tsx
+++ b/src/frontend/sharedComponents/ProjectRemovalListener.tsx
@@ -4,6 +4,7 @@ import {
   useOwnRoleInProject,
   useProjectOwnRoleChangeListener,
 } from '@comapeo/core-react';
+// TODO: Use type officially exported from @comapeo/core when available
 import type {RoleChangeEvent} from '@comapeo/core/dist/mapeo-project';
 import {BLOCKED_ROLE_ID} from '../sharedTypes';
 import {useNavigationFromHomeTabs} from '../hooks/useNavigationWithTypes';

--- a/src/frontend/sharedComponents/SelectDevice.test.ts
+++ b/src/frontend/sharedComponents/SelectDevice.test.ts
@@ -1,5 +1,5 @@
 import {getSelectableDevices} from './SelectDevice';
-import {type MemberInfo} from '@comapeo/core/dist/member-api';
+import type {MemberApi} from '@comapeo/core';
 import {type MapeoClientApi} from '@comapeo/ipc';
 import {
   BLOCKED_ROLE_ID,
@@ -28,16 +28,17 @@ function mockPeer(
 
 function mockMember(
   deviceId: string,
-  roleId: string,
+  roleId: MemberApi.RoleId,
   deviceType: 'mobile' | 'desktop' = 'mobile',
-): MemberInfo {
+): MemberApi.MemberInfo {
   return {
     deviceId,
     name: `Device ${deviceId}`,
+    // @ts-expect-error Unsound but enough for testing purposes
     role: {roleId},
     deviceType,
     joinedAt: new Date().toISOString(),
-  } as MemberInfo;
+  };
 }
 
 describe('getSelectableDevices', () => {
@@ -48,7 +49,7 @@ describe('getSelectableDevices', () => {
         mockPeer('peer-2', 'Peer 2'),
         mockPeer('peer-3', 'Peer 3'),
       ];
-      const projectMembers: MemberInfo[] = [];
+      const projectMembers: MemberApi.MemberInfo[] = [];
 
       const result = getSelectableDevices({
         peers,
@@ -203,7 +204,7 @@ describe('getSelectableDevices', () => {
         mockPeer('peer-1', 'Peer 1'),
         mockPeer('peer-2', 'Peer 2'),
       ];
-      const projectMembers: MemberInfo[] = [];
+      const projectMembers: MemberApi.MemberInfo[] = [];
 
       const result = getSelectableDevices({
         peers,
@@ -278,9 +279,9 @@ describe('getSelectableDevices', () => {
         mockPeer('peer-3', 'Peer 3'),
       ];
       const projectMembers = [
-        mockMember('peer-1', 'COORDINATOR_ROLE_ID'),
+        mockMember('peer-1', COORDINATOR_ROLE_ID),
         mockMember('peer-2', BLOCKED_ROLE_ID),
-        mockMember('peer-3', 'MEMBER_ROLE_ID'),
+        mockMember('peer-3', MEMBER_ROLE_ID),
       ];
 
       const result = getSelectableDevices({
@@ -300,9 +301,9 @@ describe('getSelectableDevices', () => {
         mockPeer('peer-3', 'Peer 3'),
       ];
       const projectMembers = [
-        mockMember('peer-1', 'COORDINATOR_ROLE_ID'),
+        mockMember('peer-1', COORDINATOR_ROLE_ID),
         mockMember('peer-2', LEFT_ROLE_ID),
-        mockMember('peer-3', 'MEMBER_ROLE_ID'),
+        mockMember('peer-3', MEMBER_ROLE_ID),
       ];
 
       const result = getSelectableDevices({
@@ -323,10 +324,10 @@ describe('getSelectableDevices', () => {
         mockPeer('peer-4', 'Peer 4'),
       ];
       const projectMembers = [
-        mockMember('peer-1', 'COORDINATOR_ROLE_ID'),
+        mockMember('peer-1', COORDINATOR_ROLE_ID),
         mockMember('peer-2', BLOCKED_ROLE_ID),
         mockMember('peer-3', LEFT_ROLE_ID),
-        mockMember('peer-4', 'MEMBER_ROLE_ID'),
+        mockMember('peer-4', MEMBER_ROLE_ID),
       ];
 
       const result = getSelectableDevices({
@@ -343,7 +344,7 @@ describe('getSelectableDevices', () => {
   describe('edge cases', () => {
     it('should handle empty peers and members arrays', () => {
       const peers: PublicPeerInfo[] = [];
-      const projectMembers: MemberInfo[] = [];
+      const projectMembers: MemberApi.MemberInfo[] = [];
 
       const invitesResult = getSelectableDevices({
         peers,

--- a/src/frontend/sharedComponents/SelectDevice.tsx
+++ b/src/frontend/sharedComponents/SelectDevice.tsx
@@ -3,7 +3,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {ScrollView, StyleSheet, View, TouchableOpacity} from 'react-native';
 
 import {useManyMembers} from '@comapeo/core-react';
-import {type MemberInfo} from '@comapeo/core/dist/member-api';
+import type {MemberApi} from '@comapeo/core';
 import {type MapeoClientApi} from '@comapeo/ipc';
 import {useLocalDiscoveryState} from '../hooks/useLocalDiscoveryState';
 import {useLocalPeers} from '../hooks/useLocalPeers';
@@ -145,7 +145,7 @@ SelectDevice.navTitleMapShare = m.titleMapShare;
 
 type GetSelectableDevicesParams = {
   peers: PublicPeerInfo[];
-  projectMembers: MemberInfo[];
+  projectMembers: MemberApi.MemberInfo[];
   selectionMode: SelectionMode;
 };
 

--- a/src/frontend/sharedTypes/index.ts
+++ b/src/frontend/sharedTypes/index.ts
@@ -1,16 +1,14 @@
 import {ImageStyle, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {Observation, ObservationValue} from '@comapeo/schema';
-import type {RoleId, RoleIdForNewInvite} from '@comapeo/core/dist/roles';
-import {MemberInfo} from '@comapeo/core/dist/member-api';
-import {type BlobId} from '@comapeo/core/dist/types';
+import type {BlobApi, MemberApi} from '@comapeo/core';
 
 export type DeviceConnectionStatus = 'connected' | 'disconnected';
 
-export type DeviceType = MemberInfo['deviceType'];
+export type DeviceType = MemberApi.MemberInfo['deviceType'];
 
-export type DeviceRole = RoleId;
+export type DeviceRole = MemberApi.RoleId;
 
-export type DeviceRoleForNewInvite = RoleIdForNewInvite;
+export type DeviceRoleForNewInvite = MemberApi.RoleIdForNewInvite;
 
 export type ViewStyleProp = StyleProp<ViewStyle>;
 export type TextStyleProp = StyleProp<TextStyle>;
@@ -30,7 +28,7 @@ export type ClientGeneratedObservation = Omit<ObservationValue, 'schemaName'>;
 
 export type Attachment = Observation['attachments'][number];
 
-export type PhotoVariant = (BlobId & {type: 'photo'})['variant'];
+export type PhotoVariant = (BlobApi.BlobId & {type: 'photo'})['variant'];
 
 export type MediaSyncSetting = 'previews' | 'everything';
 


### PR DESCRIPTION
Puts mobile in a better position to upgrade to `@comapeo/core@6`, which removes the ability to import from paths that aren't specified in the module's conditional exports.

The only place that hasn't been updated is `sharedComponents/ProjectRemovalListener.tsx`, which needs a type that isn't yet exported from core.

The only runtime changes are a couple of improvements in the affected tests. Otherwise there shouldn't be any change in functionality in the app.