### PR TITLE
chore: manually set up effect for handling 'own-role-change' events

### DIFF
--- a/src/frontend/sharedComponents/ProjectRemovalListener.tsx
+++ b/src/frontend/sharedComponents/ProjectRemovalListener.tsx
@@ -3,6 +3,7 @@ import {CommonActions, useNavigationState} from '@react-navigation/native';
 import {
   useOwnRoleInProject,
   useProjectOwnRoleChangeListener,
+  useSingleProject,
 } from '@comapeo/core-react';
 import type {RoleChangeEvent} from '@comapeo/core/dist/mapeo-project';
 import {BLOCKED_ROLE_ID} from '../sharedTypes';
@@ -45,17 +46,23 @@ export const ProjectRemovalListener = () => {
     }
   }, [roleId, dispatchToRemovedProjectBottomSheet, currentRouteName]);
 
-  useProjectOwnRoleChangeListener({
-    projectId,
-    listener: React.useCallback(
-      (event: RoleChangeEvent) => {
-        if (event.role.roleId === BLOCKED_ROLE_ID) {
-          dispatchToRemovedProjectBottomSheet();
-        }
-      },
-      [dispatchToRemovedProjectBottomSheet],
-    ),
-  });
+  useProjectOwnRoleChangeListener({projectId});
+
+  const {data: projectApi} = useSingleProject({projectId});
+
+  React.useEffect(() => {
+    function handleRoleChange(event: RoleChangeEvent) {
+      if (event.role.roleId === BLOCKED_ROLE_ID) {
+        dispatchToRemovedProjectBottomSheet();
+      }
+    }
+
+    projectApi.addListener('own-role-change', handleRoleChange);
+
+    return () => {
+      projectApi.removeListener('own-role-change', handleRoleChange);
+    };
+  }, [projectApi, dispatchToRemovedProjectBottomSheet]);
 
   return null;
 };


### PR DESCRIPTION
`useProjectOwnRoleChangeListener()` core-react unnecessarily exposes a listener callback and there are plans to remove this in the next release (which will introduce a variety of breaking changes). Setting up the listener is more appropriate to do in the app code in this case.

This PR does some early work to prepare for a new release of core-react, and the changes here do not affect functionality related to handling the relevant events.

---

https://github.com/user-attachments/assets/f9637cdc-dc96-42fa-9491-6ff9ec045aa8

