### PR TITLE
chore: use `replace` instead of `navigate`

### DIFF
--- a/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
@@ -71,7 +71,7 @@ export function ReceivingBackgroundMap({
         onError: (err: unknown) => {
           const error = toError(err, 'Failed to cancel map download');
           Sentry.captureException(error);
-          navigation.navigate('ErrorBottomSheet', {error});
+          navigation.replace('ErrorBottomSheet', {error});
         },
       },
     );


### PR DESCRIPTION
towards #1757 

This does not fully fix ([see why](https://github.com/digidem/comapeo-mobile/issues/1757#issuecomment-4113934468)) the error, but it prevent the user from getting stuck. Previously if the user tried to press `cancel` in the `ReplaceBackgroundMap` screen and there was an error, the user could get stuck on this page. This fix takes this page out of the stack when the user is navigated to the error bottom sheet, so that when the user closes the error bottom sheet they will the not be stuck.

the base branch of this is NOT `develop` it is #1704 
