### PR TITLE
feat: map share fixes

### DIFF
--- a/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
@@ -3,6 +3,7 @@ import {StyleSheet, View, Pressable} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
 import * as Sentry from '@sentry/react-native';
+import {useKeepAwake} from 'expo-keep-awake';
 
 import {
   useAbortReceivedMapShareDownload,
@@ -48,6 +49,7 @@ export function ReceivingBackgroundMap({
   const mapShare = useSingleReceivedMapShare({shareId});
 
   usePreventAndroidBackButton();
+  useKeepAwake();
 
   React.useEffect(() => {
     if (mapShare.status === 'canceled') {
@@ -71,7 +73,7 @@ export function ReceivingBackgroundMap({
         onError: (err: unknown) => {
           const error = toError(err, 'Failed to cancel map download');
           Sentry.captureException(error);
-          navigation.navigate('ErrorBottomSheet', {error});
+          navigation.replace('ErrorBottomSheet', {error});
         },
       },
     );

--- a/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
@@ -52,7 +52,7 @@ export function ReceivingBackgroundMap({
   useKeepAwake();
 
   React.useEffect(() => {
-    if (mapShare.status === 'canceled' || mapShare.status === 'aborted') {
+    if (mapShare.status === 'canceled') {
       navigation.replace('MapShareCanceledBottomSheet');
       return;
     }

--- a/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
@@ -52,7 +52,7 @@ export function ReceivingBackgroundMap({
   useKeepAwake();
 
   React.useEffect(() => {
-    if (mapShare.status === 'canceled') {
+    if (mapShare.status === 'canceled' || mapShare.status === 'aborted') {
       navigation.replace('MapShareCanceledBottomSheet');
       return;
     }
@@ -71,6 +71,16 @@ export function ReceivingBackgroundMap({
           navigation.popTo('BackgroundMaps');
         },
         onError: (err: unknown) => {
+          const errString = String(err);
+
+          if (
+            errString.includes('Invalid status transition') &&
+            (errString.includes('canceled') || errString.includes('aborted'))
+          ) {
+            navigation.replace('MapShareCanceledBottomSheet');
+            return;
+          }
+
           const error = toError(err, 'Failed to cancel map download');
           Sentry.captureException(error);
           navigation.replace('ErrorBottomSheet', {error});

--- a/src/frontend/screens/BackgroundMaps/ReplaceBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReplaceBackgroundMap.tsx
@@ -14,6 +14,7 @@ import {VERY_LIGHT_GREY, RED, NEW_DARK_GREY} from '../../lib/styles';
 import {
   useDeclineReceivedMapShare,
   useDownloadReceivedMapShare,
+  useSingleReceivedMapShare,
 } from '@comapeo/core-react';
 import * as Sentry from '@sentry/react-native';
 import {toError} from '../../utils/errors';
@@ -44,8 +45,16 @@ export function ReplaceBackgroundMap({
 }: NativeRootNavigationProps<'ReplaceBackgroundMap'>) {
   const {formatMessage: t} = useIntl();
   const {shareId} = route.params;
+  const mapShare = useSingleReceivedMapShare({shareId});
   const {mutate: declineMapShare} = useDeclineReceivedMapShare();
   const {mutate: downloadMapShare} = useDownloadReceivedMapShare();
+
+  React.useEffect(() => {
+    if (mapShare.status === 'canceled' || mapShare.status === 'aborted') {
+      navigation.replace('MapShareCanceledBottomSheet');
+      return;
+    }
+  }, [mapShare, navigation]);
 
   const handleReplace = () => {
     downloadMapShare(
@@ -55,9 +64,15 @@ export function ReplaceBackgroundMap({
           navigation.replace('ReceivingBackgroundMap', {shareId});
         },
         onError: (err: unknown) => {
+          const errString = String(err);
+          if (errString.includes('409')) {
+            navigation.replace('MapShareCanceledBottomSheet');
+            return;
+          }
+
           const error = toError(err, 'Failed to start map download');
           Sentry.captureException(error);
-          navigation.navigate('ErrorBottomSheet', {error});
+          navigation.replace('ErrorBottomSheet', {error});
         },
       },
     );
@@ -71,9 +86,15 @@ export function ReplaceBackgroundMap({
           navigation.popTo('BackgroundMaps');
         },
         onError: (err: unknown) => {
+          const errString = String(err);
+          if (errString.includes('409')) {
+            navigation.replace('MapShareCanceledBottomSheet');
+            return;
+          }
+
           const error = toError(err, 'Failed to decline map share');
           Sentry.captureException(error);
-          navigation.navigate('ErrorBottomSheet', {error});
+          navigation.replace('ErrorBottomSheet', {error});
         },
       },
     );

--- a/src/frontend/screens/BackgroundMaps/SendingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/SendingBackgroundMap.tsx
@@ -95,6 +95,23 @@ export function SendingBackgroundMap({
           navigation.goBack();
         },
         onError: (err: Error) => {
+          const errString = String(err);
+
+          if (errString.includes('409')) {
+            navigation.replace('MapShareCanceledBottomSheet');
+            return;
+          }
+
+          if (
+            errString.includes('Invalid status transition') &&
+            (errString.includes('canceled') ||
+              errString.includes('aborted') ||
+              errString.includes('declined'))
+          ) {
+            navigation.replace('MapShareCanceledBottomSheet');
+            return;
+          }
+
           Sentry.captureException(err);
           navigation.replace('ErrorBottomSheet', {error: err});
         },

--- a/src/frontend/screens/BackgroundMaps/SendingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/SendingBackgroundMap.tsx
@@ -3,6 +3,7 @@ import {AppState, StyleSheet, View, Pressable} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import * as Sentry from '@sentry/react-native';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
+import {useKeepAwake} from 'expo-keep-awake';
 
 import {
   useCancelSentMapShare,
@@ -80,6 +81,7 @@ export function SendingBackgroundMap({
   const currentTime = useCurrentTime(1000);
 
   usePreventAndroidBackButton();
+  useKeepAwake();
 
   const elapsedSeconds = mapShare
     ? Math.floor((currentTime.getTime() - mapShare.mapShareCreatedAt) / 1000)


### PR DESCRIPTION
closes #1759 
closes #1757 
closes #1756 

I also included your fix just for simplicity.
This PR uses the keep awake so the Sending and Receiving background map screens don't black out even when map sharing takes a long time, which will cause the map sharing to cancel.
In order to prevent the other errors and failures where map cancelling throws errors, I had to look for, catch, and handle specific errors. Also looking for cancel or abort on the replace map page, although for me, the useEffect wasn't where that was caught... it was in the error catchers. But maybe it will be caught on a production version.
Doing all this error catching fixes the issues for the user even though I know it is not pretty.

I have an APK if it is helpful.
Here is a link to one: https://drive.google.com/file/d/1NbP5wwAywB0RasDDs3eHvBwc6rBWkfUv/view?usp=sharing