### PR TITLE
chore: create plugin to remove permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -81,6 +81,7 @@
       ["./expo-config-plugins/increaseJavaMemory.js"],
       ["./expo-config-plugins/flagSecure/index.js"],
       ["./expo-config-plugins/customPermissionText.js"],
+      ["./expo-config-plugins/removeMediaPlaybackPermission.js"],
       [
         "react-native-share",
         {

--- a/expo-config-plugins/removeMediaPlaybackPermission.js
+++ b/expo-config-plugins/removeMediaPlaybackPermission.js
@@ -1,0 +1,19 @@
+const {withAndroidManifest} = require('@expo/config-plugins');
+
+/**
+ * Removes the FOREGROUND_SERVICE_MEDIA_PLAYBACK permission injected by
+ * expo-audio's AndroidManifest.xml. The app does not play audio in the
+ * background, so this permission is not needed.
+ */
+module.exports = function removeMediaPlaybackPermission(config) {
+  return withAndroidManifest(config, config => {
+    const manifest = config.modResults.manifest;
+    const permissions = manifest['uses-permission'] ?? [];
+    manifest['uses-permission'] = permissions.filter(
+      p =>
+        p.$['android:name'] !==
+        'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+    );
+    return config;
+  });
+};


### PR DESCRIPTION
closes #1770.

This plugin removes FOREGROUND_SERVICE_MEDIA_PLAYBACK from the android manifest.

This should be cherry picked into the [hotfix v10.1](https://github.com/digidem/comapeo-mobile/pull/1769) after it is merged with develop.