### PR TITLE
fix: app crashing on switching project in observation

### DIFF
--- a/src/frontend/constants.ts
+++ b/src/frontend/constants.ts
@@ -48,6 +48,8 @@ export const EDITING_SCREEN_NAMES: (
   'Success',
   'AuthScreen',
   'ErrorBottomSheet',
+  'ConfirmDiscardObservationBottomSheet',
+  'ConfirmDiscardObservationEditBottomSheet',
 ];
 
 export const INVITE_SCREEN_NAME: (keyof AppStackParamsList)[] = [

--- a/src/frontend/screens/Invites/InviteReceived.tsx
+++ b/src/frontend/screens/Invites/InviteReceived.tsx
@@ -13,7 +13,6 @@ import {
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {UIActivityIndicator} from 'react-native-indicators';
-import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreContext';
 import * as Sentry from '@sentry/react-native';
 import {useListenToInviteCancel} from '../../hooks/useListenToInviteCancel';
 import {BLACK, NEW_DARK_GREY, VERY_LIGHT_GREY} from '../../lib/styles';
@@ -65,7 +64,6 @@ export const InviteReceived = ({
 
   const acceptInvite = useAcceptInvite();
   const rejectInvite = useRejectInvite();
-  const {setActiveProjectId} = useActiveProjectIdActions();
   const createProject = useCreateProject();
   const {isTracking} = useTracking();
   const {data: allProjects} = useManyProjects();
@@ -87,8 +85,6 @@ export const InviteReceived = ({
       {inviteId: inviteId},
       {
         onSuccess: projectId => {
-          setActiveProjectId(projectId);
-
           if (!hasDefaultProject) {
             createProject.mutate(undefined, {
               onError: err => {
@@ -96,9 +92,15 @@ export const InviteReceived = ({
               },
             });
           }
-
-          navigation.replace('InviteSuccessfullyAccepted', {
-            projectName: invite.projectName,
+          navigation.reset({
+            index: 1,
+            routes: [
+              {name: 'Home'},
+              {
+                name: 'InviteSuccessfullyAccepted',
+                params: {projectName: invite.projectName, projectId},
+              },
+            ],
           });
         },
         onError: err => {

--- a/src/frontend/screens/Invites/InviteSuccessfullyAccepted.tsx
+++ b/src/frontend/screens/Invites/InviteSuccessfullyAccepted.tsx
@@ -5,6 +5,7 @@ import {defineMessages, useIntl} from 'react-intl';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import SuccessCheck from '../../images/Success.svg';
 import {IconTitleDescription} from '../../sharedComponents/IconTitleDescription';
+import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreContext';
 
 const m = defineMessages({
   done: {
@@ -26,6 +27,7 @@ export const InviteSuccessfullyAccepted = ({
   navigation,
 }: NativeRootNavigationProps<'InviteSuccessfullyAccepted'>) => {
   const {formatMessage} = useIntl();
+  const {setActiveProjectId} = useActiveProjectIdActions();
 
   return (
     <BottomSheetWrapper>
@@ -40,7 +42,10 @@ export const InviteSuccessfullyAccepted = ({
         <>
           <SecondaryButton
             fullSize
-            onPress={() => navigation.popTo('Home', {screen: 'Map'})}
+            onPress={() => {
+              setActiveProjectId(route.params.projectId);
+              navigation.goBack();
+            }}
             text={formatMessage(m.done)}
           />
         </>

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -141,7 +141,7 @@ export type RootStackParamsList = {
     createdAt?: string;
   };
   InviteReceived: {inviteId: string};
-  InviteSuccessfullyAccepted: {projectName: string};
+  InviteSuccessfullyAccepted: {projectName: string; projectId: string};
   InviteCanceled: {projectName: string};
   RemovedFromProjectBottomSheet: {projectId: string};
   ObservationMetadata: {observationId: string};


### PR DESCRIPTION
closes #1705

What was happening is that when accepting a new a project invite, we updated the project but didn't navigate away from the page they were on. So when a user was viewing an observation and the project was switched, we were attempting to fetch the observation (via the` observationId`) but in a new project where that observation did not exist.

I fixed this by resetting the navigation when the user accepts an invite. I reset the stack so only the Home Screen and the `InviteSuccessfullyAccepted` screen are the only 2 screens on the stack. And when the user closes the `InviteSuccessfullyAccepted` screen, that is when the projectId is switched