### PR TITLE
chore: update permission in manifest

### DIFF
--- a/expo-config-plugins/removeMediaPlaybackPermission.js
+++ b/expo-config-plugins/removeMediaPlaybackPermission.js
@@ -8,12 +8,24 @@ const {withAndroidManifest} = require('@expo/config-plugins');
 module.exports = function removeMediaPlaybackPermission(config) {
   return withAndroidManifest(config, config => {
     const manifest = config.modResults.manifest;
+
     const permissions = manifest['uses-permission'] ?? [];
     manifest['uses-permission'] = permissions.filter(
       p =>
         p.$['android:name'] !==
         'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
     );
+
+    const application = manifest.application?.[0];
+    if (application) {
+      const services = application.service ?? [];
+      application.service = services.filter(
+        s =>
+          s.$['android:name'] !==
+          'expo.modules.audio.service.AudioControlsService',
+      );
+    }
+
     return config;
   });
 };


### PR DESCRIPTION
Towards #1770 

I thought i fixed the problem initially with #1771. This originally removeMediaPlaybackPermission plugin stripped the FOREGROUND_SERVICE_MEDIA_PLAYBACK <uses-permission> tag from the manifest. But when i submitted it o the Google Play Console it continued to flag the permission as present.

This happened because expo-audio ships its own AndroidManifest.xml inside its AAR that declares AudioControlsService with android:foregroundServiceType="mediaPlayback". During the Gradle manifest merge step, this service declaration gets merged in after the Expo config plugin runs — and on Android 14+, any service declaring foregroundServiceType="mediaPlayback" implicitly requires FOREGROUND_SERVICE_MEDIA_PLAYBACK, causing Play Console to infer the permission even if the <uses-permission> tag is absent.

I fixed this by also updated the plugin to also filter out expo.modules.audio.service.AudioControlsService from the <application> block during prebuild. Since the app does not play audio in the background, this service is not needed. Removing it eliminates the implicit permission requirement entirely.