### PR TITLE
fix: project removal listener wait for pending done

### DIFF
--- a/src/frontend/sharedComponents/ProjectRemovalListener.tsx
+++ b/src/frontend/sharedComponents/ProjectRemovalListener.tsx
@@ -15,6 +15,7 @@ export const ProjectRemovalListener = () => {
   const {projectId} = useActiveProject();
   const {
     data: {roleId},
+    isRefetching: isRoleRefetching,
   } = useOwnRoleInProject({projectId});
 
   const navigation = useNavigationFromHomeTabs();
@@ -41,11 +42,17 @@ export const ProjectRemovalListener = () => {
   React.useEffect(() => {
     if (
       roleId === BLOCKED_ROLE_ID &&
+      !isRoleRefetching &&
       currentRouteName !== 'RemovedFromProjectBottomSheet'
     ) {
       dispatchToRemovedProjectBottomSheet();
     }
-  }, [roleId, dispatchToRemovedProjectBottomSheet, currentRouteName]);
+  }, [
+    roleId,
+    isRoleRefetching,
+    dispatchToRemovedProjectBottomSheet,
+    currentRouteName,
+  ]);
 
   useProjectOwnRoleChangeListener({projectId});
 


### PR DESCRIPTION
closes #1747 
I was not able to reproduce the problem in a ticket but I did see another one.

What I saw a couple of times, was that when I was removed from a project (successfully) and then reinvited, on two occasions (out of 20) I saw the removed-from-project bottom sheet after successfully accepting the invite. I then close the bottom sheet and am removed from the project I was just invited to. No something went wrong or endless loop, but not ideal, and possibly related.
From logging I saw that a couple of times, when a device was re-invited to a project, the role query cache still held
the previous BLOCKED_ROLE_ID value while refetching the new role. This caused the removed-from-project sheet to
appear. So, I am now checking for isRoleRefetching and don't navigate if we are/ until that is done.

Also, of note, the changes in comapeo-core-react may address issues as it has not been upgraded in the front end yet.