### PR TITLE
fix: basic ftp override for security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12003,9 +12003,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -196,5 +196,8 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.50.0",
     "webdriverio": "9.21.0"
+  },
+  "overrides": {
+    "basic-ftp": "5.2.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds an `overrides` entry to force `basic-ftp` to `5.2.0`, patching a critical path traversal CVE (GHSA-5rq4-664w-9x2c) in its `downloadToDir()` method (as seen in Socket Security, see screenshot below)
- `basic-ftp` is a dev-only dependency pulled in via `@wdio/browserstack-service` → `proxy-agent` → `get-uri` → `basic-ftp` — it is never bundled or shipped in the app

## Notes

I think the vulnerability has no exploitable attack surface in this project since `downloadToDir()` is never called, but the override keeps Socket Security warning resolved.

### Screenshot from socket warning

<img width="1562" height="682" alt="image" src="https://github.com/user-attachments/assets/79c179d3-0fac-4127-9124-81b5e4f74e69" />


