### PR TITLE
fix: fix missing observations details on some phones

### DIFF
--- a/src/frontend/screens/Observation/FieldDetails.tsx
+++ b/src/frontend/screens/Observation/FieldDetails.tsx
@@ -29,7 +29,7 @@ export const FieldDetails = ({
               <FormattedFieldProp field={field} propName="label" />
             </HeaderText>
             <BodyText
-              style={{color: value === undefined ? MEDIUM_GREY : undefined}}>
+              style={value === undefined ? {color: MEDIUM_GREY} : undefined}>
               <FormattedFieldValue value={value} field={field} />
             </BodyText>
           </View>


### PR DESCRIPTION
Attempt at fixing https://github.com/digidem/comapeo-mobile/issues/1813. I think maybe setting `color: undefined` is being interpreted on some versions of Android as transparent text. We don't have this pattern anywhere else, so I think it's good to avoid this here even if it is not the cause of the bug.