### PR TITLE
chore: update copy leave project

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1026,13 +1026,13 @@
     "message": "Cancel"
   },
   "screens.LeaveProject.leaveProjectDescriptionCoordinator": {
-    "message": "Device will no longer be able to view, contribute to, or adjust this project."
+    "message": "Device will no longer be able to view, contribute to, or adjust the project {projectName}."
   },
   "screens.LeaveProject.leaveProjectDescriptionParticipant": {
-    "message": "Device will no longer be able to view or contribute to this project."
+    "message": "Device will no longer be able to view or contribute to the project {projectName}."
   },
   "screens.LeaveProject.leaveProjectTitle": {
-    "message": "Leave {projectName}?"
+    "message": "Leave this project?"
   },
   "screens.LeaveProject.yesLeave": {
     "message": "Yes, Leave"
@@ -1065,7 +1065,7 @@
     "message": "Open {deviceName}"
   },
   "screens.LeftProjectConfirmation.youveLeftProject": {
-    "message": "You've left the project."
+    "message": "This device has left the project {projectName}."
   },
   "screens.LocationInfoScreen.details": {
     "description": "Section title for details about current position",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1026,10 +1026,10 @@
     "message": "Cancel"
   },
   "screens.LeaveProject.leaveProjectDescriptionCoordinator": {
-    "message": "Device will no longer be able to view, contribute to, or adjust the project {projectName}."
+    "message": "This device will no longer be able to view, contribute to, or adjust the project {projectName}."
   },
   "screens.LeaveProject.leaveProjectDescriptionParticipant": {
-    "message": "Device will no longer be able to view or contribute to the project {projectName}."
+    "message": "This device will no longer be able to view or contribute to the project {projectName}."
   },
   "screens.LeaveProject.leaveProjectTitle": {
     "message": "Leave this project?"

--- a/src/frontend/screens/YourTeam/LeaveProject.tsx
+++ b/src/frontend/screens/YourTeam/LeaveProject.tsx
@@ -21,17 +21,17 @@ import {toError} from '../../utils/errors';
 const m = defineMessages({
   leaveProjectTitle: {
     id: 'screens.LeaveProject.leaveProjectTitle',
-    defaultMessage: 'Leave {projectName}?',
+    defaultMessage: 'Leave this project?',
   },
   leaveProjectDescriptionCoordinator: {
     id: 'screens.LeaveProject.leaveProjectDescriptionCoordinator',
     defaultMessage:
-      'Device will no longer be able to view, contribute to, or adjust this project.',
+      'Device will no longer be able to view, contribute to, or adjust the project {projectName}.',
   },
   leaveProjectDescriptionParticipant: {
     id: 'screens.LeaveProject.leaveProjectDescriptionParticipant',
     defaultMessage:
-      'Device will no longer be able to view or contribute to this project.',
+      'Device will no longer be able to view or contribute to the project {projectName}.',
   },
   yesLeave: {
     id: 'screens.LeaveProject.yesLeave',
@@ -62,7 +62,9 @@ export const LeaveProject = ({
       {
         onSuccess: () => {
           try {
-            navigation.replace('LeftProjectConfirmation');
+            navigation.replace('LeftProjectConfirmation', {
+              projectName: projectSettings.name ?? '',
+            });
             const defaultProject = projects?.find(
               project => project.name === undefined,
             );
@@ -90,15 +92,14 @@ export const LeaveProject = ({
         <View style={styles.deviceInfo}>
           <MaterialDesignIcons name="export" size={60} color={BLUE_GREY} />
           <HeaderText variant="header2" style={styles.title}>
-            {formatMessage(m.leaveProjectTitle, {
-              projectName: projectSettings?.name || '',
-            })}
+            {formatMessage(m.leaveProjectTitle)}
           </HeaderText>
           <BodyText style={styles.description}>
             {formatMessage(
               isCoordinator
                 ? m.leaveProjectDescriptionCoordinator
                 : m.leaveProjectDescriptionParticipant,
+              {projectName: projectSettings.name ?? ''},
             )}
           </BodyText>
         </View>

--- a/src/frontend/screens/YourTeam/LeaveProject.tsx
+++ b/src/frontend/screens/YourTeam/LeaveProject.tsx
@@ -26,12 +26,12 @@ const m = defineMessages({
   leaveProjectDescriptionCoordinator: {
     id: 'screens.LeaveProject.leaveProjectDescriptionCoordinator',
     defaultMessage:
-      'Device will no longer be able to view, contribute to, or adjust the project {projectName}.',
+      'This device will no longer be able to view, contribute to, or adjust the project {projectName}.',
   },
   leaveProjectDescriptionParticipant: {
     id: 'screens.LeaveProject.leaveProjectDescriptionParticipant',
     defaultMessage:
-      'Device will no longer be able to view or contribute to the project {projectName}.',
+      'This device will no longer be able to view or contribute to the project {projectName}.',
   },
   yesLeave: {
     id: 'screens.LeaveProject.yesLeave',

--- a/src/frontend/screens/YourTeam/LeftProjectConfirmation.tsx
+++ b/src/frontend/screens/YourTeam/LeftProjectConfirmation.tsx
@@ -13,7 +13,7 @@ import {useFocusEffect} from '@react-navigation/native';
 const m = defineMessages({
   youveLeftProject: {
     id: 'screens.LeftProjectConfirmation.youveLeftProject',
-    defaultMessage: "You've left the project.",
+    defaultMessage: 'This device has left the project {projectName}.',
   },
   openDefaultProject: {
     id: 'screens.LeftProjectConfirmation.openDefaultProject',
@@ -23,7 +23,9 @@ const m = defineMessages({
 
 export const LeftProjectConfirmation = ({
   navigation,
+  route,
 }: NativeRootNavigationProps<'LeftProjectConfirmation'>) => {
+  const projectName = route.params.projectName;
   const {formatMessage} = useIntl();
   const {data} = useOwnDeviceInfo();
   const deviceName = data?.name;
@@ -52,7 +54,7 @@ export const LeftProjectConfirmation = ({
           color={DARK_ORANGE}
         />
         <HeaderText variant="header2" style={styles.title}>
-          {formatMessage(m.youveLeftProject)}
+          {formatMessage(m.youveLeftProject, {projectName})}
         </HeaderText>
       </View>
 

--- a/src/frontend/sharedTypes/navigation.ts
+++ b/src/frontend/sharedTypes/navigation.ts
@@ -177,7 +177,7 @@ export type RootStackParamsList = {
   LeaveProject: {
     memberType: 'coordinator' | 'participant';
   };
-  LeftProjectConfirmation: undefined;
+  LeftProjectConfirmation: {projectName: string};
   CollaboratorInfo: {
     deviceId: string;
     isOwnDevice: boolean;

--- a/tests/e2e/specs/team/leave-project-warning.test.ts
+++ b/tests/e2e/specs/team/leave-project-warning.test.ts
@@ -52,7 +52,7 @@ describe('Team - Leave Project Warning Screen', () => {
 
     const leaveConfirmationDescription = await $(
       byTextMatches(
-        'Device will no longer be able to view, contribute to, or adjust this project',
+        `Device will no longer be able to view, contribute to, or adjust the project ${output.names.secondProject}.`,
       ),
     );
     await expect(leaveConfirmationDescription).toBeDisplayed();


### PR DESCRIPTION
closes #1763 
This Notion doc provides more clarity: https://www.notion.so/digidem/Copy-edit-for-Leave-Project-screens-on-Mobile-31a1b08162d5808c8adbdec9fe2b42b2
Even more clarification is in the Slack conversation that is referenced.

### Changes
Updates the copy on the leave project screen for both coordinator and participant.
Updates the copy on the left project confirmation and also now includes the project name, which it didn't before. 
- Because the user is no longer in that project, I pass the project name from the Leave Project screen through nav params.
- Because the project will always have a name even though by typescript standards it might not (default projects are unnamed but a default project will not ever see this screen), I just use an empty string to satisfy the type checker.

Updates the E2E test to match

### Screenshots
<img width="250" alt="image" src="https://github.com/user-attachments/assets/6118dcae-e03f-4ed0-82cb-4c71b450b2d9" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/84aa2c8a-634d-46b3-bf6c-11f150461bef" />


**The button on the above screen is addressed in #1765** 

