### PR TITLE
fix: inconsistent dropdown toggle

### DIFF
--- a/src/frontend/sharedComponents/Accordian.tsx
+++ b/src/frontend/sharedComponents/Accordian.tsx
@@ -22,7 +22,7 @@ export function Accordian({
   style,
 }: AccordianProps) {
   const [expanded, setExpanded] = useState(false);
-  const Icon = expanded ? Chevrondown : ChevrondownDefault;
+  const Icon = expanded ? ChevrondownDefault : Chevrondown;
 
   return (
     <Animated.View


### PR DESCRIPTION
closes #1762
Fixes direction of the chevron for toggle. TLDR: Down is closed, up is expanded...

The Accordian shared component was the one that was in the wrong so once I corrected that, all of the usages noted are corrected.
There are three other dropdowns but they are all already in the correct direction 
- The project chooser in the drawer menu
- The privacy learn more
- The new error bottom sheet

Here are the ones that are now updated because of the change in the Accordian [sic]

<img width="250" alt="image" src="https://github.com/user-attachments/assets/270e68c1-1662-4a4b-b950-dcbd4cdfa863" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e125fd86-732a-4d5b-8697-415a2307df18" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/cb70f028-72d2-40b4-a7ce-c4e9f8799d5e" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5f68b612-021c-4b67-8ea0-c6af37ba5887" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/6baf2d67-a0f1-47ec-8f1f-13000cbfac03" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ddc69db0-d600-4ecb-a16e-dfcc9ce0702e" />




