### PR TITLE
fix: audio recording time display

### DIFF
--- a/src/frontend/screens/Audio/AudioRecording/AnimatedBackground.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/AnimatedBackground.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Dimensions, StyleSheet} from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -10,8 +9,9 @@ import {MAX_RECORDING_DURATION_MS} from '../shared';
 import {COMAPEO_BLUE} from '../../../lib/styles';
 
 export function AnimatedBackground({timeElapsed}: {timeElapsed: number}) {
-  const {top, bottom} = useSafeAreaInsets();
+  const {bottom} = useSafeAreaInsets();
   const {height} = Dimensions.get('window');
+  const targetHeight = height - bottom;
 
   const elapsedTimeValue = useDerivedValue(() => {
     return withTiming(timeElapsed, {duration: 500});
@@ -19,8 +19,7 @@ export function AnimatedBackground({timeElapsed}: {timeElapsed: number}) {
 
   const animatedStyles = useAnimatedStyle(() => ({
     height:
-      (height + top + bottom) *
-      (elapsedTimeValue.value * (1 / MAX_RECORDING_DURATION_MS)),
+      targetHeight * (elapsedTimeValue.value * (1 / MAX_RECORDING_DURATION_MS)),
     backgroundColor: COMAPEO_BLUE,
   }));
 

--- a/src/frontend/screens/Audio/shared.tsx
+++ b/src/frontend/screens/Audio/shared.tsx
@@ -3,7 +3,11 @@ import {WHITE, BLACK, BLUE_GREY, NEW_DARK_GREY} from '../../lib/styles';
 
 export const PRIMARY_CONTROL_DIAMETER = 96;
 export const SIDE_ICON_BUTTON_WIDTH = 60;
-export const MAX_RECORDING_DURATION_MS = 5 * 60_000;
+
+// Target 5 min max. Extra 150ms compensates for codec frame boundary loss,
+// which causes the final file to be ~50-150ms shorter than recorded duration.
+// which rounds only to 4:59 instead of 5:00 for display.
+export const MAX_RECORDING_DURATION_MS = 5 * 60_030;
 
 export const audioStyles = StyleSheet.create({
   basePressable: {


### PR DESCRIPTION
closes #1745 
## Changes
### For the Timing
Increases the default maximum time to account for frame loss. 
We need to account for codec (Short for coder/decoder - the algorithm that converts raw audio into a compressed file and back again) frame boundary loss, which causes the final audio file to be ~50-150ms shorter than the recorder's reported duration. Without this small adjustment (consider it a buffer), a 5-minute recording consistently displays as 4:59.
Why that is true...
`RecordingPresets.HIGH_QUALITY` (which we have set [expo-audio](https://docs.expo.dev/versions/v54.0.0/sdk/audio/#constants) to use) uses AAC - the type of codec.
AAC (Advanced Audio Coding) always encodes 1024 samples per frame, and at 44,100 samples/sec (also specified in the expo docs) that's 1024 / 44100 ≈ 23.2ms per frame. That's why the file duration is always a multiple of ~23.2ms and can't land exactly on 300,000ms.
When recorder.stop() is called, the codec discards the last partial frame,  and the file consistently ends up 50-150ms shorter than the recorder reported. So I added that back...

### For the recording screen
While I was testing the five minute recordings, I was getting really annoyed that my phone screen was fully blue at 4:20 instead of at 5:00.
The change is related to the changes in React Native and screen size when Android Edge to Edge became mandatory when we upgraded to Expo 54. The top and bottom dimensions are now included in our window height.
As a result, we no longer need to add in the top and bottom insets to get the total screen height, so the AnimatedBackground component thought our screen was bigger than it actually now is.
After Edge to Edge, we set our app to exclude the bottom nav bar (in our Navigation/Stack) so I subtracted that value from the total screen size in AnimatedBackground.
However, the screen does include the status bar (edge to edge) so that is left in but does not need to be added in as it was before...
So, in sum, this PR also decreases the screen size for the animated background of audio to better fit the actual screen size as it is shown in Edge to Edge mode.