### PR TITLE
fix: build international polyfills

### DIFF
--- a/scripts/build-intl-polyfills.mjs
+++ b/scripts/build-intl-polyfills.mjs
@@ -8,10 +8,19 @@ import languages from '../src/frontend/languages.json' with {type: 'json'};
 import messages from '../translations/messages.json' with {type: 'json'};
 
 const relativeTimeFormatSupportedLocales = getSupportedLocalesFromDir(
-  path.dirname(fileURLToPath(import.meta.resolve('@formatjs/intl-relativetimeformat/polyfill-force.js'))),
+  path.dirname(
+    fileURLToPath(
+      import.meta
+        .resolve('@formatjs/intl-relativetimeformat/polyfill-force.js'),
+    ),
+  ),
 );
 const pluralRulesSupportedLocales = getSupportedLocalesFromDir(
-  path.dirname(fileURLToPath(import.meta.resolve('@formatjs/intl-pluralrules/polyfill-force.js'))),
+  path.dirname(
+    fileURLToPath(
+      import.meta.resolve('@formatjs/intl-pluralrules/polyfill-force.js'),
+    ),
+  ),
 );
 
 build();
@@ -46,7 +55,8 @@ function getPolyfillableLocales() {
   const localesToPolyfill = [];
 
   for (const locale of comapeoSupportedLocales) {
-    const canPolyfillLocale = isFullySupportedLocale(locale);
+    const baseTag = locale.split('-')[0];
+    const canPolyfillLocale = isFullySupportedLocale(baseTag);
 
     if (!canPolyfillLocale) {
       console.warn(`Cannot polyfill data for locale: ${locale}`);
@@ -73,9 +83,13 @@ function writePolyfillFile(locales, outputPath) {
 
   // Write lines to load base polyfills
   writer.write(
-    createImportStatement('@formatjs/intl-getcanonicallocales/polyfill-force.js'),
+    createImportStatement(
+      '@formatjs/intl-getcanonicallocales/polyfill-force.js',
+    ),
   );
-  writer.write(createImportStatement('@formatjs/intl-locale/polyfill-force.js'));
+  writer.write(
+    createImportStatement('@formatjs/intl-locale/polyfill-force.js'),
+  );
 
   writer.write('\n');
 
@@ -85,7 +99,9 @@ function writePolyfillFile(locales, outputPath) {
   );
   for (const locale of locales) {
     writer.write(
-      createImportStatement(`@formatjs/intl-pluralrules/locale-data/${locale}.js`),
+      createImportStatement(
+        `@formatjs/intl-pluralrules/locale-data/${locale}.js`,
+      ),
     );
   }
 
@@ -93,7 +109,9 @@ function writePolyfillFile(locales, outputPath) {
 
   // Write lines to load relative time format polyfill
   writer.write(
-    createImportStatement('@formatjs/intl-relativetimeformat/polyfill-force.js'),
+    createImportStatement(
+      '@formatjs/intl-relativetimeformat/polyfill-force.js',
+    ),
   );
   for (const locale of locales) {
     writer.write(

--- a/src/frontend/languages.json
+++ b/src/frontend/languages.json
@@ -339,9 +339,13 @@
     "nativeName": "Avañe'ẽ",
     "englishName": "Guarani"
   },
-  "gu-IN": {
+  "gu": {
     "nativeName": "ગુજરાતી",
     "englishName": "Gujarati"
+  },
+  "gu-IN": {
+    "nativeName": "ગુજરાતી",
+    "englishName": "Gujarati (India)"
   },
   "gx-GR": {
     "nativeName": "Ἑλληνική ἀρχαία",
@@ -547,9 +551,13 @@
     "nativeName": "മലയാളം",
     "englishName": "Malayalam"
   },
-  "mn-MN": {
+  "mn": {
     "nativeName": "Монгол",
     "englishName": "Mongolian"
+  },
+  "mn-MN": {
+    "nativeName": "Монгол",
+    "englishName": "Mongolian (Mongolia)"
   },
   "mpq": {
     "nativeName": "Matis",

--- a/src/frontend/languages.json
+++ b/src/frontend/languages.json
@@ -583,6 +583,10 @@
     "nativeName": "ဗမာစကာ",
     "englishName": "Burmese"
   },
+  "my-MM": {
+    "nativeName": "ဗမာစကာ",
+    "englishName": "Burmese (Myanmar)"
+  },
   "mzr": {
     "nativeName": "Marúbo",
     "englishName": "Marubo"


### PR DESCRIPTION
Removes the region tag when building international polyfills.
Most of the changes are just linting based.
Adds Burmese (language of Myanmar) as a possibly language.