### PR TITLE
fix: close keyboard on discard observation

### DIFF
--- a/src/frontend/hooks/useKeyboardListener.ts
+++ b/src/frontend/hooks/useKeyboardListener.ts
@@ -1,26 +1,33 @@
-import {useEffect, useState} from 'react';
+import {useFocusEffect} from '@react-navigation/native';
+import {useCallback, useState} from 'react';
 import {Keyboard} from 'react-native';
 
 export function useKeyboardListener() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
-  useEffect(() => {
-    const keyboardHideUnsub = Keyboard.addListener('keyboardDidHide', () => {
-      setKeyboardVisible(false);
-      setKeyboardHeight(0);
-    });
+  useFocusEffect(
+    useCallback(() => {
+      const keyboardHideUnsub = Keyboard.addListener('keyboardDidHide', () => {
+        setKeyboardVisible(false);
+        setKeyboardHeight(0);
+      });
 
-    const keyboardShowUnsub = Keyboard.addListener('keyboardDidShow', e => {
-      setKeyboardVisible(true);
-      setKeyboardHeight(e.endCoordinates.height);
-    });
+      const keyboardShowUnsub = Keyboard.addListener('keyboardDidShow', e => {
+        setKeyboardVisible(true);
+        setKeyboardHeight(e.endCoordinates.height);
+      });
 
-    return () => {
-      keyboardHideUnsub.remove();
-      keyboardShowUnsub.remove();
-    };
-  }, []);
+      return () => {
+        // when the user navigates away, close keyboard
+        Keyboard.dismiss();
+        setKeyboardVisible(false);
+        setKeyboardHeight(0);
+        keyboardHideUnsub.remove();
+        keyboardShowUnsub.remove();
+      };
+    }, []),
+  );
 
   return {keyboardVisible, keyboardHeight};
 }

--- a/src/frontend/hooks/useKeyboardListener.ts
+++ b/src/frontend/hooks/useKeyboardListener.ts
@@ -1,29 +1,26 @@
-import {useFocusEffect} from '@react-navigation/native';
-import {useCallback, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {Keyboard} from 'react-native';
 
 export function useKeyboardListener() {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
-  useFocusEffect(
-    useCallback(() => {
-      const keyboardHideUnsub = Keyboard.addListener('keyboardDidHide', () => {
-        setKeyboardVisible(false);
-        setKeyboardHeight(0);
-      });
+  useEffect(() => {
+    const keyboardHideUnsub = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardVisible(false);
+      setKeyboardHeight(0);
+    });
 
-      const keyboardShowUnsub = Keyboard.addListener('keyboardDidShow', e => {
-        setKeyboardVisible(true);
-        setKeyboardHeight(e.endCoordinates.height);
-      });
+    const keyboardShowUnsub = Keyboard.addListener('keyboardDidShow', e => {
+      setKeyboardVisible(true);
+      setKeyboardHeight(e.endCoordinates.height);
+    });
 
-      return () => {
-        keyboardHideUnsub.remove();
-        keyboardShowUnsub.remove();
-      };
-    }, []),
-  );
+    return () => {
+      keyboardHideUnsub.remove();
+      keyboardShowUnsub.remove();
+    };
+  }, []);
 
   return {keyboardVisible, keyboardHeight};
 }

--- a/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
+++ b/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
@@ -4,6 +4,7 @@ import {HeaderBackButtonProps} from '@react-navigation/elements';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useFocusEffect} from '@react-navigation/native';
 import {BackHandler} from 'react-native';
+import {Keyboard} from 'react-native';
 
 type HeaderLeftProps = {
   headerBackButtonProps: HeaderBackButtonProps;
@@ -13,6 +14,7 @@ export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
   const navigation = useNavigationFromRoot();
 
   const handlePress = React.useCallback(() => {
+    Keyboard.dismiss();
     navigation.navigate('ConfirmDiscardObservationEditBottomSheet');
   }, [navigation]);
 

--- a/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
+++ b/src/frontend/screens/ObservationEdit/HeaderLeft.tsx
@@ -4,7 +4,6 @@ import {HeaderBackButtonProps} from '@react-navigation/elements';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useFocusEffect} from '@react-navigation/native';
 import {BackHandler} from 'react-native';
-import {Keyboard} from 'react-native';
 
 type HeaderLeftProps = {
   headerBackButtonProps: HeaderBackButtonProps;
@@ -14,7 +13,6 @@ export const HeaderLeft = ({headerBackButtonProps}: HeaderLeftProps) => {
   const navigation = useNavigationFromRoot();
 
   const handlePress = React.useCallback(() => {
-    Keyboard.dismiss();
     navigation.navigate('ConfirmDiscardObservationEditBottomSheet');
   }, [navigation]);
 


### PR DESCRIPTION
closes #1853 

I also had `useKeyboardListener` use `useEffect` instead of the `useFocusEffect`. The `useFocusEffect` was used for turning on and off 2 subscriptions: 1 listening to the keyboard being visible, and the other listening to when the keyboard was being hidden. Based on whether the keyboard was visible or not, we change the ui in the <ActionsRow/> inside these listeners. 

This PR closes the keyboard when the user clicks on the `<headerLeft/>` while also opening the bottoms sheet. When the bottom sheet opens, the `useFocusEffect` return statement is being run, closing the subscriptions. But it seems to close the subscriptions before the action inside the subscription can run. In otherwords the actions row was still showing the UI as if the keyboard was open, even though the keyboard was closed.

By changing it to a useEffect, since the screen is still open in the background, the return statement is NOT run (aka the subscriptions are not closed) when the user navigates away, fixing that problem, as the actions inside the listeners are still running.

https://github.com/user-attachments/assets/ff42ab00-5149-4553-a49a-c4b5ca1246b7

