### PR TITLE
fix: something went wrong navigation bar padding

### DIFF
--- a/src/frontend/screens/FatalError.tsx
+++ b/src/frontend/screens/FatalError.tsx
@@ -49,6 +49,7 @@ const styles = StyleSheet.create({
     height: '100%',
     padding: 20,
     paddingTop: 80,
+    paddingBottom: 60,
     alignItems: 'center',
     justifyContent: 'space-between',
     backgroundColor: WHITE,

--- a/src/frontend/screens/FatalErrorUntranslated.tsx
+++ b/src/frontend/screens/FatalErrorUntranslated.tsx
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
     height: '100%',
     padding: 20,
     paddingTop: 80,
+    paddingBottom: 60,
     alignItems: 'center',
     justifyContent: 'space-between',
     backgroundColor: WHITE,


### PR DESCRIPTION
closes #1834 
Adds padding on the bottom to make the button above the bottom navigation bar.

I would have preferred to use the the SafeAreaView from react-native-safe-area-context but for that we would need to move the SafeAreaProvider to the very top/ outside of the App and I wasn't sure of the consequences of that and if that would work. Seems risky... But let me know if you believe otherwise.

We can't use the react native SafeAreaView from React Native because it is deprecated and only works on iOS.

Google Pixel:
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/69720bb5-525a-497f-a3b1-7f280d5cdc5b" />

Samsung Galaxy A25
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ca24205b-f589-4767-bfa4-72540c38c8af" />


---
It is tricky to get to see this screen. What you can do temporarily...
What I did was load the app then in the return of App.tsx put
`<FatalErrorUntranslated />` instead of the usual content (I just commented it out).

**You have to load the app first** though or it just won't work. Or at least I couldn't get it to.

And even though it is the same styling you could also do the same with:
```
return (
    <LocaleStoreProvider value={persistedLocaleStore}>
      <IntlProvider>
        <FatalError />
      </IntlProvider>
    </LocaleStoreProvider>
  );
```



