### PR TITLE
fix: invisible text privacy policy

### DIFF
--- a/src/frontend/screens/DataAndPrivacy/SettingsPrivacyPolicy.tsx
+++ b/src/frontend/screens/DataAndPrivacy/SettingsPrivacyPolicy.tsx
@@ -22,7 +22,6 @@ SettingsPrivacyPolicy.navTitle = m.navTitle;
 
 const styles = StyleSheet.create({
   scrollContent: {
-    backgroundColor: 'white',
     paddingVertical: 20,
     paddingHorizontal: 30,
   },

--- a/src/frontend/screens/Onboarding/OnboardingPrivacyPolicy.tsx
+++ b/src/frontend/screens/Onboarding/OnboardingPrivacyPolicy.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import {View, Text, ScrollView, StyleSheet} from 'react-native';
+import {View, ScrollView, StyleSheet} from 'react-native';
 import {useIntl, defineMessages} from 'react-intl';
 import {PrivacyPolicy} from '../PrivacyPolicy';
 import {BLUE_GREY, WHITE} from '../../lib/styles';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {MetricsDiagnosticsPermissionToggle} from '../../sharedComponents/MetricsDiagnosticsPermissionToggle';
 
 const m = defineMessages({
@@ -23,7 +24,9 @@ export const OnboardingPrivacyPolicy = () => {
     <ScrollView contentContainerStyle={styles.scrollContent}>
       <PrivacyPolicy />
       <View style={styles.horizontalLine} />
-      <Text style={styles.header}>{formatMessage(m.permissionsTitle)}</Text>
+      <HeaderText variant="header2" style={styles.header}>
+        {formatMessage(m.permissionsTitle)}
+      </HeaderText>
       <View style={styles.permissionToggleContainer}>
         <MetricsDiagnosticsPermissionToggle />
       </View>
@@ -35,7 +38,6 @@ OnboardingPrivacyPolicy.navTitle = m.navTitle;
 
 const styles = StyleSheet.create({
   scrollContent: {
-    backgroundColor: 'white',
     paddingVertical: 20,
     paddingHorizontal: 30,
   },
@@ -45,8 +47,6 @@ const styles = StyleSheet.create({
     marginVertical: 20,
   },
   header: {
-    fontSize: 24,
-    fontWeight: 'bold',
     marginBottom: 20,
   },
   permissionToggleContainer: {

--- a/src/frontend/screens/PrivacyPolicy/DiagnosticItem.tsx
+++ b/src/frontend/screens/PrivacyPolicy/DiagnosticItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View, Text} from 'react-native';
 import MaterialIcons from '@react-native-vector-icons/material-icons';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {styles} from './styles';
 import {NEW_DARK_GREY} from '../../lib/styles';
 
@@ -21,10 +22,10 @@ export const DiagnosticItem: React.FC<DiagnosticItemProps> = ({
         color={NEW_DARK_GREY}
         style={styles.bulletIcon}
       />
-      <Text style={styles.boldText}>
+      <HeaderText variant="header6" style={{color: NEW_DARK_GREY}}>
         {title}:{' '}
         <Text style={styles.diagnosticsDescription}>{description}</Text>
-      </Text>
+      </HeaderText>
     </View>
   );
 };

--- a/src/frontend/screens/PrivacyPolicy/PointContainer.tsx
+++ b/src/frontend/screens/PrivacyPolicy/PointContainer.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import {View, Text} from 'react-native';
+import {View} from 'react-native';
 import {SvgProps} from 'react-native-svg';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {styles} from './styles';
+import {BLACK, NEW_DARK_GREY} from '../../lib/styles';
 
 interface PointContainerProps {
   icon: React.FC<SvgProps>;
@@ -18,9 +21,13 @@ export const PointContainer: React.FC<PointContainerProps> = ({
     <View style={styles.pointContainer}>
       <View style={styles.pointHeader}>
         <IconComponent width={16} height={16} />
-        <Text style={styles.pointTitle}>{title}</Text>
+        <HeaderText variant="header5" style={{color: BLACK}}>
+          {title}
+        </HeaderText>
       </View>
-      <Text style={styles.pointDescription}>{description}</Text>
+      <BodyText variant="smallMeta" style={{color: NEW_DARK_GREY}}>
+        {description}
+      </BodyText>
     </View>
   );
 };

--- a/src/frontend/screens/PrivacyPolicy/index.tsx
+++ b/src/frontend/screens/PrivacyPolicy/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import {View, Text, ScrollView, TouchableOpacity} from 'react-native';
+import {View, ScrollView, TouchableOpacity} from 'react-native';
+import {HeaderText} from '../../sharedComponents/Text/HeaderText';
+import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {useIntl} from 'react-intl';
 import {m} from './privacyPolicyMessages';
 import {PointContainer} from './PointContainer';
@@ -29,13 +31,15 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
   return (
     <ScrollView>
       <View style={styles.overviewBox}>
-        <Text style={styles.overviewText}>{formatMessage(m.overview)}</Text>
+        <BodyText variant="smallMeta">{formatMessage(m.overview)}</BodyText>
       </View>
       <View style={[styles.toggleContainer, styles.topToggleContainer]}>
         <TouchableOpacity
           onPress={() => setAwanaExpanded(prev => !prev)}
           style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>{formatMessage(m.aboutAwana)}</Text>
+          <HeaderText variant="header5" style={styles.sectionTitle}>
+            {formatMessage(m.aboutAwana)}
+          </HeaderText>
           {awanaExpanded ? (
             <ChevronUp width={20} height={20} />
           ) : (
@@ -44,9 +48,9 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
         </TouchableOpacity>
         {awanaExpanded && (
           <View style={styles.sectionContent}>
-            <Text style={styles.sectionText}>
+            <BodyText variant="smallMeta" style={styles.newDarkGrey}>
               {formatMessage(m.aboutAwanaContent)}
-            </Text>
+            </BodyText>
           </View>
         )}
       </View>
@@ -54,7 +58,9 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
         <TouchableOpacity
           onPress={() => setOpenSourceExpanded(prev => !prev)}
           style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>{formatMessage(m.openSource)}</Text>
+          <HeaderText variant="header5" style={styles.sectionTitle}>
+            {formatMessage(m.openSource)}
+          </HeaderText>
           {openSourceExpanded ? (
             <ChevronUp width={20} height={20} />
           ) : (
@@ -63,13 +69,15 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
         </TouchableOpacity>
         {openSourceExpanded && (
           <View style={styles.sectionContent}>
-            <Text style={styles.sectionText}>
+            <BodyText variant="smallMeta" style={styles.newDarkGrey}>
               {formatMessage(m.openSourceContent)}
-            </Text>
+            </BodyText>
           </View>
         )}
       </View>
-      <Text style={styles.header}>{formatMessage(m.privacyPolicyTitle)}</Text>
+      <HeaderText variant="header2" style={styles.header}>
+        {formatMessage(m.privacyPolicyTitle)}
+      </HeaderText>
       <PointContainer
         icon={RedDot}
         title={formatMessage(m.privateByDefault)}
@@ -86,16 +94,18 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
         description={formatMessage(m.controlDescription)}
       />
       <View style={styles.horizontalLine} />
-      <Text style={styles.header}>{formatMessage(m.dataCollection)}</Text>
+      <HeaderText variant="header2" style={styles.header}>
+        {formatMessage(m.dataCollection)}
+      </HeaderText>
       <PointContainer
         icon={BarChart}
         title={formatMessage(m.whatIsCollected)}
         description={formatMessage(m.whatIsCollectedDescription)}
       />
       <View style={styles.diagnosticsContainer}>
-        <Text style={[styles.pointTitle, {marginTop: 20}]}>
+        <HeaderText variant="header5" style={styles.diagnosticsTitle}>
           {formatMessage(m.diagnosticsTitle)}
-        </Text>
+        </HeaderText>
         <View style={styles.diagnosticsContent}>
           <DiagnosticItem
             title={formatMessage(m.crashData)}
@@ -118,9 +128,9 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
             description={formatMessage(m.appInfoDescription)}
           />
           <View style={styles.horizontalLineSmall} />
-          <Text style={[styles.pointTitle, {marginBottom: 20}]}>
+          <HeaderText variant="header5" style={styles.appUsageTitle}>
             {formatMessage(m.appUsageTitle)}
-          </Text>
+          </HeaderText>
           <DiagnosticItem
             title={formatMessage(m.userCount)}
             description={formatMessage(m.userCountDescription)}

--- a/src/frontend/screens/PrivacyPolicy/index.tsx
+++ b/src/frontend/screens/PrivacyPolicy/index.tsx
@@ -94,7 +94,7 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
         description={formatMessage(m.controlDescription)}
       />
       <View style={styles.horizontalLine} />
-      <HeaderText variant="header2" style={styles.header}>
+      <HeaderText variant="header2" style={styles.collectionHeader}>
         {formatMessage(m.dataCollection)}
       </HeaderText>
       <PointContainer
@@ -128,7 +128,7 @@ export const PrivacyPolicy: React.FC<PrivacyPolicyProps> = () => {
             description={formatMessage(m.appInfoDescription)}
           />
           <View style={styles.horizontalLineSmall} />
-          <HeaderText variant="header5" style={styles.appUsageTitle}>
+          <HeaderText variant="header5">
             {formatMessage(m.appUsageTitle)}
           </HeaderText>
           <DiagnosticItem

--- a/src/frontend/screens/PrivacyPolicy/styles.ts
+++ b/src/frontend/screens/PrivacyPolicy/styles.ts
@@ -29,6 +29,10 @@ export const styles = StyleSheet.create({
     marginTop: 50,
     marginBottom: 30,
   },
+  collectionHeader: {
+    marginTop: 10,
+    marginBottom: 30,
+  },
   sectionHeader: {
     paddingHorizontal: 20,
     flexDirection: 'row',
@@ -59,9 +63,6 @@ export const styles = StyleSheet.create({
   },
   diagnosticsTitle: {
     marginTop: 20,
-  },
-  appUsageTitle: {
-    marginBottom: 20,
   },
   horizontalLine: {
     borderBottomColor: BLUE_GREY,

--- a/src/frontend/screens/PrivacyPolicy/styles.ts
+++ b/src/frontend/screens/PrivacyPolicy/styles.ts
@@ -1,9 +1,4 @@
-import {
-  BLACK,
-  BLUE_GREY,
-  NEW_DARK_GREY,
-  VERY_LIGHT_GREY,
-} from '../../lib/styles';
+import {BLUE_GREY, NEW_DARK_GREY, VERY_LIGHT_GREY} from '../../lib/styles';
 import {StyleSheet} from 'react-native';
 
 export const styles = StyleSheet.create({
@@ -14,10 +9,6 @@ export const styles = StyleSheet.create({
     borderRadius: 10,
     backgroundColor: VERY_LIGHT_GREY,
     marginBottom: 20,
-  },
-  overviewText: {
-    fontSize: 14,
-    marginBottom: 10,
   },
   toggleContainer: {
     borderWidth: 1,
@@ -36,8 +27,6 @@ export const styles = StyleSheet.create({
   },
   header: {
     marginTop: 50,
-    fontSize: 24,
-    fontWeight: 'bold',
     marginBottom: 30,
   },
   sectionHeader: {
@@ -48,7 +37,6 @@ export const styles = StyleSheet.create({
     borderRadius: 10,
   },
   sectionTitle: {
-    fontSize: 16,
     textAlign: 'left',
     width: '75%',
   },
@@ -57,8 +45,7 @@ export const styles = StyleSheet.create({
     paddingTop: 10,
     paddingBottom: 10,
   },
-  sectionText: {
-    fontSize: 14,
+  newDarkGrey: {
     color: NEW_DARK_GREY,
   },
   pointContainer: {
@@ -70,13 +57,11 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 10,
   },
-  pointTitle: {
-    fontSize: 16,
-    color: BLACK,
+  diagnosticsTitle: {
+    marginTop: 20,
   },
-  pointDescription: {
-    fontSize: 14,
-    color: NEW_DARK_GREY,
+  appUsageTitle: {
+    marginBottom: 20,
   },
   horizontalLine: {
     borderBottomColor: BLUE_GREY,
@@ -104,15 +89,11 @@ export const styles = StyleSheet.create({
   bulletIcon: {
     marginTop: 8,
   },
-  boldText: {
-    fontWeight: 'bold',
-    color: NEW_DARK_GREY,
-  },
   diagnosticsDescription: {
     fontSize: 14,
     color: NEW_DARK_GREY,
-    textAlign: 'left',
     fontWeight: 'normal',
+    fontFamily: undefined,
   },
   horizontalLineSmall: {
     borderBottomColor: BLUE_GREY,


### PR DESCRIPTION
closes #1819 
Updates the privacy policy text to use our shared text components and to make sure all of the text is visible, which it was not before in dark mode! You can see this screen during on boarding by pressing Learn More on the first screen after Get Started, but also from the Settings -> Data & Privacy -> Learn More once your app is onboarded

I also checked through the whole rest of the app for any RN Text components that do not have an explicit color and there are none others that need to be fixed.

<img width="250" alt="DataPrivacyNotInvisible" src="https://github.com/user-attachments/assets/9680d57a-7e32-4697-8df7-a98a3cd110a5" />
