### PR TITLE
fix: color dot on inset map

### DIFF
--- a/src/frontend/images/OrangeDot.svg
+++ b/src/frontend/images/OrangeDot.svg
@@ -1,3 +1,0 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="10" cy="10" r="8.5" fill="#E86826" stroke="white" stroke-width="3"/>
-</svg>

--- a/src/frontend/screens/Observation/InsetMapView.tsx
+++ b/src/frontend/screens/Observation/InsetMapView.tsx
@@ -1,12 +1,11 @@
 import MapboxGL from '@rnmapbox/maps';
 import React from 'react';
 import {View, StyleSheet, TouchableOpacity} from 'react-native';
-import {WHITE} from '../../lib/styles';
+import {WHITE, DARK_ORANGE} from '../../lib/styles';
 import {FormattedCoords} from '../../sharedComponents/FormattedData';
 import {useMapStyleJsonUrl} from '../../hooks/server/maps';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import MapPin from '../../images/MapPin.svg';
-import OrangeDot from '../../images/OrangeDot.svg';
 import {MarkerView} from '@rnmapbox/maps';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {useCoordinateFormat} from '../../contexts/CoordinateFormatStoreContext';
@@ -18,10 +17,11 @@ type MapProps = {
   lat: number;
   observationId: string;
   accuracy?: number;
+  color?: string;
 };
 
 export const InsetMapView = React.memo<MapProps>(
-  ({lon, lat, observationId, accuracy}: MapProps) => {
+  ({lon, lat, observationId, accuracy, color}: MapProps) => {
     const coordinateFormat = useCoordinateFormat();
     const styleUrlQuery = useMapStyleJsonUrl();
     const {navigate} = useNavigationFromRoot();
@@ -61,7 +61,9 @@ export const InsetMapView = React.memo<MapProps>(
               </BodyText>
             </View>
             <View style={styles.arrow} />
-            <OrangeDot style={{alignSelf: 'center'}} />
+            <View
+              style={[styles.dot, {backgroundColor: color ?? DARK_ORANGE}]}
+            />
           </TouchableOpacity>
         </MarkerView>
       </MapboxGL.MapView>
@@ -91,5 +93,13 @@ const styles = StyleSheet.create({
   },
   map: {
     height: MAP_HEIGHT,
+  },
+  dot: {
+    alignSelf: 'center',
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 3,
+    borderColor: WHITE,
   },
 });

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -105,6 +105,7 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
             observationId={observationId}
             lat={lat}
             lon={lon}
+            color={preset?.color}
           />
         )}
         <TouchableOpacity


### PR DESCRIPTION
closes #1744 
- Passes the preset color to map inset 
- Makes a dot using css instead of using the orange dot svg.  I used the styling in the SVG to determine what css to use (size, border width, etc)
- Removes the orange dot svg since it is not used anywhere.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/978c0d60-9566-4d4e-94ee-d6509f2d78c9" />
