### PR TITLE
fix: nav back to camera after discarding observation

### DIFF
--- a/src/frontend/screens/ObservationCreate/ConfirmDiscardObservationBottomSheet.tsx
+++ b/src/frontend/screens/ObservationCreate/ConfirmDiscardObservationBottomSheet.tsx
@@ -11,8 +11,8 @@ import {
   DestructiveButton,
   SecondaryButton,
 } from '../../sharedComponents/Buttons';
-import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDraftObservationActions} from '../../contexts/DraftObservationContext';
+import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 
 const m = defineMessages({
   discardTitle: {
@@ -37,14 +37,27 @@ const m = defineMessages({
   },
 });
 
-export const ConfirmDiscardObservationBottomSheet = () => {
+export const ConfirmDiscardObservationBottomSheet = ({
+  navigation,
+}: NativeRootNavigationProps<'ConfirmDiscardObservationBottomSheet'>) => {
   const {formatMessage: t} = useIntl();
-  const navigation = useNavigationFromRoot();
   const {clearDraft} = useDraftObservationActions();
 
   function handleDiscard() {
     clearDraft();
-    navigation.popTo('Home', {screen: 'Map'});
+    // find the screen with the name "home"
+    const homeTabRoute = navigation
+      .getState()
+      .routes.find(route => route.name === 'Home');
+    // the home screen is a nested navigator (the tabs)
+    // find the latest open tab in the nested tab navigator
+    const lastOpenedTab =
+      homeTabRoute?.state?.routes[homeTabRoute.state.index || 0]?.name;
+    // This assumes that the user can only navigate to this screen via the Camera or Map Screen
+    // If that changes, this will naively go back to the map screen.
+    navigation.popTo('Home', {
+      screen: lastOpenedTab === 'Camera' ? 'Camera' : 'Map',
+    });
   }
 
   return (

--- a/tests/e2e/specs/observations/create-observation.test.ts
+++ b/tests/e2e/specs/observations/create-observation.test.ts
@@ -92,4 +92,23 @@ describe('Observations - Create Observation Flow', () => {
     const mapBtn = await $('~Go to map.');
     await mapBtn.click();
   });
+
+  it('should return to camera screen when discarding an observation', async () => {
+    const cameraBtn = await $('~Go to camera.');
+    await cameraBtn.click();
+    const addObsBtn = await $('~Add Observation');
+    await addObsBtn.click();
+    await expect($(byTextMatches('Choose a category'))).toBeDisplayed();
+    const closeIcon = await $(byResourceId('close-icon'));
+    await closeIcon.click();
+
+    const discardObs = await $(byText('Discard'));
+    await expect(discardObs).toBeDisplayed();
+
+    await discardObs.click();
+
+    await expect($(byResourceId('MAIN.mapbox-map-view'))).not.toBeDisplayed();
+
+    await expect($(byResourceId('MAIN.camera-scrn'))).toBeDisplayed();
+  });
 });


### PR DESCRIPTION
closes #290.

While the fix only adds a few lines of code, the logic is a little naive (and kind of convoluted to follow). We originally did not do this to avoid this added complication, but it seems like it was identified by enough people to be a problem.