### PR TITLE
fix: observation title truncated

### DIFF
--- a/src/frontend/screens/ObservationsList/ObservationListItem.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationListItem.tsx
@@ -43,7 +43,7 @@ function ObservationListItemNotMemoized({
     <TouchableOpacity
       onPress={() => onPress(observation.docId)}
       testID={testID}
-      style={{flex: 1, height: 80}}>
+      style={{flex: 1, minHeight: 80}}>
       <React.Suspense
         fallback={
           <View style={[styles.container, style]}>
@@ -136,7 +136,7 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingHorizontal: 20,
     flex: 1,
-    height: 80,
+    minHeight: 80,
   },
   text: {
     flex: 1,

--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {View, FlatList, Dimensions, StyleSheet} from 'react-native';
+import {View, FlatList, StyleSheet} from 'react-native';
 import {Observation, Track} from '@comapeo/schema';
 import {MessageDescriptor, defineMessages} from 'react-intl';
 import {useFocusEffect} from '@react-navigation/native';
@@ -36,16 +36,7 @@ const m = defineMessages({
   },
 });
 
-const OBSERVATION_CELL_HEIGHT = 80;
 const ONE_HOUR = 60 * 60 * 1000;
-
-function getItemLayout(_data: unknown, index: number) {
-  return {
-    length: OBSERVATION_CELL_HEIGHT,
-    offset: OBSERVATION_CELL_HEIGHT * index,
-    index,
-  };
-}
 
 const keyExtractor = (item: Observation | Track) => item.docId;
 
@@ -79,10 +70,6 @@ export const ObservationsList: React.FC<
     setFilterMode(mode);
     lastInteractionRef.current = mode === 'mine' ? Date.now() : null;
   }
-
-  const rowsPerWindow = Math.ceil(
-    (Dimensions.get('window').height - 65) / OBSERVATION_CELL_HEIGHT,
-  );
 
   const filteredData = React.useMemo(() => {
     const allData = [...observations, ...tracks];
@@ -123,8 +110,6 @@ export const ObservationsList: React.FC<
       )}
       {/* re: https://github.com/digidem/comapeo-mobile/issues/586  */}
       <FlatList
-        initialNumToRender={rowsPerWindow}
-        getItemLayout={getItemLayout}
         keyExtractor={keyExtractor}
         style={styles.container}
         windowSize={3}
@@ -173,6 +158,6 @@ const styles = StyleSheet.create({
     backgroundColor: WHITE,
   },
   listItem: {
-    height: OBSERVATION_CELL_HEIGHT,
+    minHeight: 80,
   },
 });


### PR DESCRIPTION
closes #1873
**Changes**
Removes fixed height from observation list so also have to remove getItemLayout optimization.

---
The reason we had fixed height was so that we could use this https://reactnative.dev/docs/flatlist#getitemlayout.
getItemLayout matters most when users scroll quickly through large lists — without it, FlatList has to measure every item lazily as it comes into view, which can cause blank frames and weirdness on fast scrolls.
So this is what it had looked like for some with large fonts:

---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/695d6257-207d-473c-8f9b-7d6d77b85470" />

---
However, even if we picked a super large magic number for height to allow for the most narrow of phones and the largest text (so we would have fixed height list items and could use getItemLayout) that doesn't seem like it would be optimal behavior. For most people the observation item would be too big. And even if we made it really big, for some it would still be too small.

So, instead, I opted to get rid of the getItemLayout feature and instead use a minHeight of 80 pixels. Now the height of each list item is variable depending on the content.

Please let me know if you would rather go a different way.

---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/c08dd0ba-7727-45b0-9fa7-1562f5bb50d6" />

