### PR TITLE
fix: queuing browserstack tests in github actions

### DIFF
--- a/.github/workflows/e2e-appium-browserstack.yml
+++ b/.github/workflows/e2e-appium-browserstack.yml
@@ -8,10 +8,6 @@ on:
       - 'release/**'
     types: [opened, synchronize, reopened, ready_for_review]
 
-concurrency:
-  group: e2e-tests-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build-apk:
     runs-on: ubuntu-latest
@@ -96,6 +92,9 @@ jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest
     needs: build-apk
+    concurrency:
+      group: browserstack-devices
+      cancel-in-progress: false
 
     steps:
       - name: Checkout Repository

--- a/docs/EndToEndTests/E2ENoGos.md
+++ b/docs/EndToEndTests/E2ENoGos.md
@@ -81,6 +81,12 @@ Unfortunately this can't be totally controlled through Appium tests. It does sho
 - Cannot test the actual view on the screen when devices are available
 - Cannot test the sync/ exchange process itself
 
+#### Map Sharing
+
+- Cannot upload a map onto a device
+- Cannot run two devices at once, so cannot test sharing
+- Basically nothing about it can be tested
+
 #### Other
 
 - If category names are long, text wraps using hyphenation at expected points (none are long enough to wrap)

--- a/wdio.ci.config.js
+++ b/wdio.ci.config.js
@@ -65,7 +65,7 @@ const config = {
   ],
   logLevel: 'error',
   waitforTimeout: 5000,
-  connectionRetryTimeout: 180000,
+  connectionRetryTimeout: 240000,
   connectionRetryCount: 3,
   framework: 'mocha',
   mochaOpts: {


### PR DESCRIPTION
We are running out of devices on Browserstack when we push more than one PR at once. This is an attempt to make it so that both build the APK at the same time, but only run the browserstack tests one at a time.