### PR TITLE
chore: update jest setup

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -24,6 +24,49 @@ jest.mock('expo/src/winter/ImportMetaRegistry', () => ({
 
 jest.mock('react-native-nitro-modules', () => {});
 
+jest.mock('expo-audio', () => {
+  const grantedPermission = {
+    status: 'granted',
+    expires: 'never',
+    granted: true,
+    canAskAgain: true,
+  };
+  const mockRecorder = {
+    prepareToRecordAsync: jest.fn(() => Promise.resolve()),
+    record: jest.fn(),
+    stop: jest.fn(() => Promise.resolve()),
+    uri: null,
+  };
+  return {
+    getRecordingPermissionsAsync: jest.fn(() =>
+      Promise.resolve(grantedPermission),
+    ),
+    requestRecordingPermissionsAsync: jest.fn(() =>
+      Promise.resolve(grantedPermission),
+    ),
+    useAudioRecorder: jest.fn(() => mockRecorder),
+    useAudioRecorderState: jest.fn(() => ({
+      isRecording: false,
+      durationMillis: 0,
+    })),
+    useAudioPlayer: jest.fn(() => ({
+      play: jest.fn(),
+      pause: jest.fn(),
+      seekTo: jest.fn(),
+    })),
+    useAudioPlayerStatus: jest.fn(() => ({
+      isLoaded: false,
+      isPlaying: false,
+      currentTime: 0,
+      duration: 0,
+    })),
+    RecordingPresets: {
+      HIGH_QUALITY: {ios: {}, android: {}, web: {}},
+      LOW_QUALITY: {ios: {}, android: {}, web: {}},
+    },
+  };
+});
+
 jest.mock('@lodev09/react-native-exify', () => ({
   read: jest.fn(() => Promise.resolve(null)),
 }));
@@ -50,6 +93,29 @@ NativeModules.FlagSecureModule = {
   activate: () => {},
   deactivate: () => {},
 };
+
+// MLRNModule crashes at load time when NativeModules.MLRNModule is absent.
+jest.mock('@maplibre/maplibre-react-native', () => ({
+  MapView: 'MapView',
+  Camera: 'Camera',
+  MarkerView: 'MarkerView',
+  UserLocation: 'UserLocation',
+  ShapeSource: 'ShapeSource',
+  LineLayer: 'LineLayer',
+  setAccessToken: jest.fn(),
+  setTelemetryEnabled: jest.fn(),
+  LineJoin: {Round: 'round', Bevel: 'bevel', Miter: 'miter'},
+  LineCap: {Round: 'round', Butt: 'butt', Square: 'square'},
+}));
+
+jest.mock('react-native-vision-camera', () => ({
+  Camera: 'Camera',
+  useCameraDevice: jest.fn(() => undefined),
+  useCameraPermission: jest.fn(() => ({
+    hasPermission: true,
+    requestPermission: jest.fn(() => Promise.resolve(true)),
+  })),
+}));
 
 function temporaryDirectory() {
   const result = path.join(

--- a/src/frontend/screens/ComapeoSettings/index.test.tsx
+++ b/src/frontend/screens/ComapeoSettings/index.test.tsx
@@ -1,83 +1,26 @@
-import {render, screen, userEvent} from '@testing-library/react-native';
-import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
-import {
-  createManager,
-  setUpIPC,
-} from '../../../../tests/integration/helpers/core';
-import {createAppProvidersWrapper} from '../../../../tests/integration/helpers/react';
-import {MockedAppNavigator} from '../../../../tests/integration/helpers/navigation';
-import {sleep} from '../../lib/sleep';
-import React from 'react';
-
-jest.mock('../../hooks/useCurrentTime');
+import {screen, userEvent} from '@testing-library/react-native';
+import {setupIntegrationTest} from '../../../../tests/integration/helpers/setupIntegrationTest';
 
 describe('CoMapeo Settings Screen', () => {
-  let manager: MapeoManager;
-  let client: MapeoClientApi;
-  let onTeardown: Array<() => unknown> = [];
-  let projectId: string;
-
-  beforeEach(async () => {
-    onTeardown = [];
-
-    const managerSetup = await createManager({
-      name: 'test',
-      deviceType: 'mobile',
-    });
-    ({manager} = managerSetup);
-    const {fastifyController} = managerSetup;
-
-    const ipcSetup = setUpIPC({manager});
-    ({client} = ipcSetup);
-    const {stop} = ipcSetup;
-    onTeardown.push(stop);
-
-    await fastifyController.start();
-    onTeardown.push(() => fastifyController.stop());
-    projectId = await client.createProject({name: undefined});
-  });
-
-  afterEach(async () => {
-    for (const fn of onTeardown) await fn();
-  });
-
-  const renderNavigation = ({
-    isOnline = true,
-    activeProjectId = projectId,
-  }: Readonly<{isOnline?: boolean; activeProjectId?: string}> = {}) => {
-    const appProviders = createAppProvidersWrapper({
-      mapeoApi: client,
-      isOnline,
-      activeProjectId,
-    });
-    onTeardown.push(appProviders.teardown);
-
-    const {unmount} = render(<MockedAppNavigator />, {
-      wrapper: appProviders.wrapper,
-    });
-    const actualTeardown = async () => {
-      unmount();
-      await sleep(0);
-    };
-
-    onTeardown.unshift(actualTeardown);
-
-    return () => {
-      const result = actualTeardown();
-      onTeardown = onTeardown.filter(fn => fn !== actualTeardown);
-      return result;
-    };
-  };
+  const integrationSetup = setupIntegrationTest();
 
   test('opens drawer when header button is pressed', async () => {
     const user = userEvent.setup();
-    renderNavigation({activeProjectId: projectId});
+    integrationSetup.renderNavigation({
+      activeProjectId: integrationSetup.projectId,
+    });
 
     const headerButton = await screen.findByTestId('HOME.header-button');
     await expect(headerButton).toBeVisible();
     await user.press(headerButton);
 
-    await screen.findByTestId('MENU.main-action-button');
+    const settings = await screen.findByText('CoMapeo Settings');
+
+    await expect(settings).toBeVisible();
+
+    await user.press(settings);
+
+    await expect(await screen.findByText('test')).toBeVisible();
+    expect(screen.queryByText('NOT HERE')).toBeNull();
   });
 });

--- a/src/frontend/screens/ComapeoSettings/index.test.tsx
+++ b/src/frontend/screens/ComapeoSettings/index.test.tsx
@@ -1,0 +1,83 @@
+import {render, screen, userEvent} from '@testing-library/react-native';
+import type {MapeoManager} from '@comapeo/core';
+import type {MapeoClientApi} from '@comapeo/ipc';
+import {
+  createManager,
+  setUpIPC,
+} from '../../../../tests/integration/helpers/core';
+import {createAppProvidersWrapper} from '../../../../tests/integration/helpers/react';
+import {MockedAppNavigator} from '../../../../tests/integration/helpers/navigation';
+import {sleep} from '../../lib/sleep';
+import React from 'react';
+
+jest.mock('../../hooks/useCurrentTime');
+
+describe('CoMapeo Settings Screen', () => {
+  let manager: MapeoManager;
+  let client: MapeoClientApi;
+  let onTeardown: Array<() => unknown> = [];
+  let projectId: string;
+
+  beforeEach(async () => {
+    onTeardown = [];
+
+    const managerSetup = await createManager({
+      name: 'test',
+      deviceType: 'mobile',
+    });
+    ({manager} = managerSetup);
+    const {fastifyController} = managerSetup;
+
+    const ipcSetup = setUpIPC({manager});
+    ({client} = ipcSetup);
+    const {stop} = ipcSetup;
+    onTeardown.push(stop);
+
+    await fastifyController.start();
+    onTeardown.push(() => fastifyController.stop());
+    projectId = await client.createProject({name: undefined});
+  });
+
+  afterEach(async () => {
+    for (const fn of onTeardown) await fn();
+  });
+
+  const renderNavigation = ({
+    isOnline = true,
+    activeProjectId = projectId,
+  }: Readonly<{isOnline?: boolean; activeProjectId?: string}> = {}) => {
+    const appProviders = createAppProvidersWrapper({
+      mapeoApi: client,
+      isOnline,
+      activeProjectId,
+    });
+    onTeardown.push(appProviders.teardown);
+
+    const {unmount} = render(<MockedAppNavigator />, {
+      wrapper: appProviders.wrapper,
+    });
+    const actualTeardown = async () => {
+      unmount();
+      await sleep(0);
+    };
+
+    onTeardown.unshift(actualTeardown);
+
+    return () => {
+      const result = actualTeardown();
+      onTeardown = onTeardown.filter(fn => fn !== actualTeardown);
+      return result;
+    };
+  };
+
+  test('opens drawer when header button is pressed', async () => {
+    const user = userEvent.setup();
+    renderNavigation({activeProjectId: projectId});
+
+    const headerButton = await screen.findByTestId('HOME.header-button');
+    await expect(headerButton).toBeVisible();
+    await user.press(headerButton);
+
+    await screen.findByTestId('MENU.main-action-button');
+  });
+});

--- a/tests/integration/helpers/navigation.tsx
+++ b/tests/integration/helpers/navigation.tsx
@@ -1,0 +1,16 @@
+import {AppNavigator} from '../../../src/frontend/AppNavigator';
+
+type MockedAppNavigatorProps = {
+  permissionAsked?: boolean;
+};
+
+export const MockedAppNavigator = ({
+  permissionAsked = true,
+}: MockedAppNavigatorProps = {}) => {
+  return (
+    <AppNavigator
+      permissionAsked={permissionAsked}
+      navigationIntegration={undefined}
+    />
+  );
+};

--- a/tests/integration/helpers/setupIntegrationTest.tsx
+++ b/tests/integration/helpers/setupIntegrationTest.tsx
@@ -1,0 +1,80 @@
+import {render} from '@testing-library/react-native';
+import type {MapeoManager} from '@comapeo/core';
+import type {MapeoClientApi} from '@comapeo/ipc';
+import {createManager, setUpIPC} from './core';
+import {createAppProvidersWrapper} from './react';
+import {MockedAppNavigator} from './navigation';
+import {sleep} from '../../../src/frontend/lib/sleep';
+import React from 'react';
+
+export function setupIntegrationTest() {
+  let manager: MapeoManager;
+  let client: MapeoClientApi;
+  let onTeardown: Array<() => unknown> = [];
+  let projectId: string;
+
+  beforeEach(async () => {
+    onTeardown = [];
+
+    const managerSetup = await createManager({
+      name: 'test',
+      deviceType: 'mobile',
+    });
+    ({manager} = managerSetup);
+    const {fastifyController} = managerSetup;
+
+    const ipcSetup = setUpIPC({manager});
+    ({client} = ipcSetup);
+    const {stop} = ipcSetup;
+    onTeardown.push(stop);
+
+    await fastifyController.start();
+    onTeardown.push(() => fastifyController.stop());
+    projectId = await client.createProject({name: undefined});
+  });
+
+  afterEach(async () => {
+    for (const fn of onTeardown) await fn();
+  });
+
+  const renderNavigation = ({
+    isOnline = true,
+    activeProjectId = projectId,
+  }: Readonly<{isOnline?: boolean; activeProjectId?: string}> = {}) => {
+    const appProviders = createAppProvidersWrapper({
+      mapeoApi: client,
+      isOnline,
+      activeProjectId,
+    });
+    onTeardown.push(appProviders.teardown);
+
+    const {unmount} = render(<MockedAppNavigator />, {
+      wrapper: appProviders.wrapper,
+    });
+    const actualTeardown = async () => {
+      unmount();
+      await sleep(0);
+    };
+
+    onTeardown.unshift(actualTeardown);
+
+    return () => {
+      const result = actualTeardown();
+      onTeardown = onTeardown.filter(fn => fn !== actualTeardown);
+      return result;
+    };
+  };
+
+  return {
+    renderNavigation,
+    get projectId() {
+      return projectId;
+    },
+    get client() {
+      return client;
+    },
+    get manager() {
+      return manager;
+    },
+  };
+}


### PR DESCRIPTION
Updates Jest setup to automatically create a render function that mounts the entire navigation with a project already setup (as this will be needed for the majority of tests)

Writes a test of the setting screen to show how this helper function should be used.