### PR TITLE
chore: remove conditional navigators

### DIFF
--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -74,7 +74,15 @@ export const RootStackNavigator = () => {
             navigation.navigate('MapReceivedBottomSheet', {shareId})
           }
         />
-        {children}
+        {/* Wrap here so app screens get ActiveProjectProvider without a separate navigator.
+            activeProjectId is always set before any app screen renders. */}
+        {activeProjectId ? (
+          <ActiveProjectProvider activeProjectId={activeProjectId}>
+            {children}
+          </ActiveProjectProvider>
+        ) : (
+          children
+        )}
       </React.Suspense>
     </SafeAreaView>
   );
@@ -89,42 +97,30 @@ export const RootStackNavigator = () => {
     screenOptions: NavigatorScreenOptions,
   } as const;
 
-  if (
-    security.authState === 'unauthenticated' ||
-    !deviceInfo.name ||
-    !activeProjectId
-  ) {
-    const initialRouteName = getInitialRoute(
-      security.authState,
-      deviceInfo.name,
-      activeProjectId,
-    );
-
-    return (
-      <RootStack.Navigator
-        {...commonNavigatorProps}
-        initialRouteName={initialRouteName}>
-        {security.authState === 'unauthenticated' ? (
-          <RootStack.Screen
-            name="AuthScreen"
-            component={AuthScreen}
-            options={{
-              headerShown: false,
-              animation: 'fade',
-            }}
-          />
-        ) : (
-          createOnboardingScreens({intl: formatMessage})
-        )}
-      </RootStack.Navigator>
-    );
-  }
+  const initialRouteName = getInitialRoute(
+    security.authState,
+    deviceInfo.name,
+    activeProjectId,
+  );
 
   return (
-    <ActiveProjectProvider activeProjectId={activeProjectId}>
-      <RootStack.Navigator {...commonNavigatorProps}>
-        {createAppScreens({intl: formatMessage})}
-      </RootStack.Navigator>
-    </ActiveProjectProvider>
+    <RootStack.Navigator
+      {...commonNavigatorProps}
+      initialRouteName={initialRouteName}>
+      {security.authState === 'unauthenticated' ? (
+        <RootStack.Screen
+          name="AuthScreen"
+          component={AuthScreen}
+          options={{
+            headerShown: false,
+            animation: 'fade',
+          }}
+        />
+      ) : !deviceInfo.name || !activeProjectId ? (
+        createOnboardingScreens({intl: formatMessage})
+      ) : (
+        createAppScreens({intl: formatMessage})
+      )}
+    </RootStack.Navigator>
   );
 };

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -48,7 +48,7 @@ function getInitialRoute(
   if (!projectId) {
     return 'Success';
   }
-  return 'Success';
+  return 'Home';
 }
 
 export const RootStackNavigator = () => {

--- a/tests/e2e/specs/onboarding/map-on-your-own-intro.test.ts
+++ b/tests/e2e/specs/onboarding/map-on-your-own-intro.test.ts
@@ -46,4 +46,10 @@ describe('Onboarding - Map On Your Own Intro Screen', () => {
     await driver.pause(2000);
     await expect($(byResourceId('MAIN.map-screen'))).toBeDisplayed();
   });
+  it('should still be on Map screen after closing app and reopening', async () => {
+    await driver.terminateApp('com.comapeo.rc');
+    await driver.activateApp('com.comapeo.rc');
+    await driver.pause(2000);
+    await expect($(byResourceId('MAIN.map-screen'))).toBeDisplayed();
+  });
 });


### PR DESCRIPTION
Removes conditional root stack navigator.
Uses Layout instead to wrap the necessary screens with the active project provider, thus guaranteeing a project in the screens that need it