### PR TITLE
chore: simplify intl.ts structure

### DIFF
--- a/src/frontend/__mocks__/expo-localization.ts
+++ b/src/frontend/__mocks__/expo-localization.ts
@@ -4,20 +4,18 @@ import {
   type Locale,
 } from 'expo-localization';
 
-import {extractLanguageCode} from '../lib/intl';
-
 export const getLocales: typeof _getLocales = () => {
-  return [createBaseLocale('en-US')];
+  return [createBaseLocale('en')];
 };
 
 export const useLocales: typeof _useLocales = () => {
-  return [createBaseLocale('en-US')];
+  return [createBaseLocale('en')];
 };
 
 function createBaseLocale(languageTag: string): Locale {
   return {
     languageTag,
-    languageCode: extractLanguageCode(languageTag),
+    languageCode: languageTag,
     languageCurrencyCode: null,
     languageCurrencySymbol: null,
     languageRegionCode: null,

--- a/src/frontend/contexts/IntlContext.tsx
+++ b/src/frontend/contexts/IntlContext.tsx
@@ -5,7 +5,7 @@ import {useLocales} from 'expo-localization';
 
 import messages from '../../../translations/messages.json';
 import {useLocaleState} from './LocaleStoreContext';
-import {getUsableLanguageTag, TranslatedLanguageTag} from '../lib/intl';
+import {getUsableLanguageTag, AvailableLanguageTag} from '../lib/intl';
 
 export const formats: CustomFormats = {
   date: {
@@ -32,7 +32,7 @@ export const IntlProvider = ({children}: {children: React.ReactNode}) => {
   const messagesToUse = React.useMemo(() => {
     const usableSystemLanguageTags = systemLocales
       .map(l => getUsableLanguageTag(l.languageTag))
-      .filter((tag): tag is TranslatedLanguageTag => tag !== undefined);
+      .filter((tag): tag is AvailableLanguageTag => tag !== undefined);
     const languages = [languageTag, ...usableSystemLanguageTags];
     const merged = {};
     // Merge messages in order of priority: specific system locales, app language code, full app language tag

--- a/src/frontend/contexts/IntlContext.tsx
+++ b/src/frontend/contexts/IntlContext.tsx
@@ -5,7 +5,7 @@ import {useLocales} from 'expo-localization';
 
 import messages from '../../../translations/messages.json';
 import {useLocaleState} from './LocaleStoreContext';
-import {extractLanguageCode, TranslatedLanguageTag} from '../lib/intl';
+import {getUsableLanguageTag, TranslatedLanguageTag} from '../lib/intl';
 
 export const formats: CustomFormats = {
   date: {
@@ -30,20 +30,14 @@ export const IntlProvider = ({children}: {children: React.ReactNode}) => {
   const systemLocales = useLocales();
 
   const messagesToUse = React.useMemo(() => {
-    // A list of languages in order of preference - regional variants first over general language codes
-    const languages: string[] = [];
-    const systemLanguageTags = systemLocales.map(l => l.languageTag);
-    for (const tag of [languageTag, ...systemLanguageTags]) {
-      languages.push(tag);
-      const languageCode = extractLanguageCode(tag);
-      if (languageCode !== tag) {
-        languages.push(languageCode);
-      }
-    }
+    const usableSystemLanguageTags = systemLocales
+      .map(l => getUsableLanguageTag(l.languageTag))
+      .filter((tag): tag is TranslatedLanguageTag => tag !== undefined);
+    const languages = [languageTag, ...usableSystemLanguageTags];
     const merged = {};
     // Merge messages in order of priority: specific system locales, app language code, full app language tag
     for (const tag of languages.reverse()) {
-      Object.assign(merged, messages[tag as TranslatedLanguageTag] || {});
+      Object.assign(merged, messages[tag] || {});
     }
 
     return merged;

--- a/src/frontend/contexts/LocaleStoreContext.test.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.test.tsx
@@ -39,7 +39,7 @@ test('usage of state and actions hooks', () => {
 
   expect(stateHook.result.current).toStrictEqual({
     useSystemPreferences: false,
-    languageTag: 'pt-BR',
+    languageTag: 'pt',
   });
 
   act(() => {

--- a/src/frontend/contexts/LocaleStoreContext.test.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.test.tsx
@@ -34,7 +34,7 @@ test('usage of state and actions hooks', () => {
   });
 
   act(() => {
-    actionsHook.result.current.setLanguageTag('pt-BR');
+    actionsHook.result.current.setLanguageTag('pt');
   });
 
   expect(stateHook.result.current).toStrictEqual({

--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -9,7 +9,7 @@ import {
 import {MMKVStoreInitializer} from '../hooks/persistedState/createPersistedState';
 import {
   getUsableLanguageTagFromSystemPreferences,
-  SupportedLanguageTag,
+  TranslatedLanguageTag,
 } from '../lib/intl';
 import {type LocaleState} from '../sharedTypes/locale';
 
@@ -34,6 +34,7 @@ function migrate(persistedState: unknown, version: number): LocaleState {
   }
   // version 0: languageTag was null | SupportedLanguageTag
   const legacy = persistedState as {
+    // @ts-expect-error will change
     languageTag: SupportedLanguageTag | null;
     useSystemPreferences: boolean;
   };
@@ -65,7 +66,7 @@ export function createLocaleStore({persist} = {persist: false}) {
 
   const actions = {
     setLanguageTag: (
-      languageTag: SupportedLanguageTag | 'SystemPreference',
+      languageTag: TranslatedLanguageTag | 'SystemPreference',
     ) => {
       if (languageTag === 'SystemPreference') {
         const systemLanguageTags = getLocales().map(l => l.languageTag);

--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -61,6 +61,16 @@ export function createLocaleStore({persist} = {persist: false}) {
         storage: createJSONStorage(() => MMKVStoreInitializer),
         version: 1,
         migrate,
+        // usable language tags can change between app boot ups
+        // this just makes sure the language tag is still usable
+        // if not, then use system preferences
+        onRehydrateStorage: () => state => {
+          if (!state) return;
+          const usable = getUsableLanguageTag(state.languageTag);
+          if (!usable) {
+            store.setState(createInitialState());
+          }
+        },
       }),
     );
   } else {

--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -11,7 +11,7 @@ import {MMKVStoreInitializer} from '../hooks/persistedState/createPersistedState
 import {
   getUsableLanguageTag,
   getUsableLanguageTagFromSystemPreferences,
-  TranslatedLanguageTag,
+  AvailableLanguageTag,
 } from '../lib/intl';
 import {
   LocaleStateSchema,
@@ -79,7 +79,7 @@ export function createLocaleStore({persist} = {persist: false}) {
 
   const actions = {
     setLanguageTag: (
-      languageTag: TranslatedLanguageTag | 'SystemPreference',
+      languageTag: AvailableLanguageTag | 'SystemPreference',
     ) => {
       if (languageTag === 'SystemPreference') {
         const systemLanguageTags = getLocales().map(l => l.languageTag);

--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -5,13 +5,19 @@ import {
   createJSONStorage,
   persist as createPersistedState,
 } from 'zustand/middleware';
+import * as v from 'valibot';
 
 import {MMKVStoreInitializer} from '../hooks/persistedState/createPersistedState';
 import {
+  getUsableLanguageTag,
   getUsableLanguageTagFromSystemPreferences,
   TranslatedLanguageTag,
 } from '../lib/intl';
-import {type LocaleState} from '../sharedTypes/locale';
+import {
+  LocaleStateSchema,
+  LocaleStateSchemaV0,
+  type LocaleState,
+} from '../sharedTypes/locale';
 
 // Do not change!
 export const STORAGE_KEY = 'locale' as const;
@@ -28,23 +34,20 @@ function createInitialState(): LocaleState {
  * Migrates persisted state from version 0 (where languageTag could be null)
  * to version 1 (where languageTag is always resolved).
  */
-function migrate(persistedState: unknown, version: number): LocaleState {
-  if (version === 1) {
-    return persistedState as LocaleState;
+function migrate(persistedState: unknown): LocaleState {
+  const currentSchema = v.safeParse(LocaleStateSchema, persistedState);
+
+  if (currentSchema.success) {
+    return currentSchema.output;
   }
-  // version 0: languageTag was null | SupportedLanguageTag
-  const legacy = persistedState as {
-    // @ts-expect-error will change
-    languageTag: SupportedLanguageTag | null;
-    useSystemPreferences: boolean;
-  };
-  if (legacy.languageTag !== null) {
-    return {
-      languageTag: legacy.languageTag,
-      useSystemPreferences: legacy.useSystemPreferences,
-    };
+
+  const legacyV0 = v.safeParse(LocaleStateSchemaV0, persistedState);
+  if (legacyV0.success && legacyV0.output.languageTag !== null) {
+    const usableLanguageTag = getUsableLanguageTag(legacyV0.output.languageTag);
+    if (usableLanguageTag) {
+      return {languageTag: usableLanguageTag, useSystemPreferences: false};
+    }
   }
-  // null means "use system preferences" — resolve now
   return createInitialState();
 }
 

--- a/src/frontend/lib/intl.test.ts
+++ b/src/frontend/lib/intl.test.ts
@@ -1,37 +1,7 @@
 import {
-  extractLanguageCode,
   getUsableLanguageTagFromSystemPreferences,
-  isSupportedLanguageTag,
   USABLE_LANGUAGES,
 } from './intl';
-
-describe('extractLanguageCode()', () => {
-  test('works with single component language tag', () => {
-    expect(extractLanguageCode('pt')).toBe('pt');
-  });
-
-  test('works with two component language tag', () => {
-    expect(extractLanguageCode('pt-BR')).toBe('pt');
-  });
-});
-
-describe('isSupportedLanguageTag()', () => {
-  test('returns true for a known supported tag', () => {
-    expect(isSupportedLanguageTag('en')).toBe(true);
-  });
-
-  test('returns true for a known regional tag in languages.json', () => {
-    expect(isSupportedLanguageTag('pt-BR')).toBe(true);
-  });
-
-  test('returns false for an unsupported tag', () => {
-    expect(isSupportedLanguageTag('__')).toBe(false);
-  });
-
-  test('returns false for empty string', () => {
-    expect(isSupportedLanguageTag('')).toBe(false);
-  });
-});
 
 describe('USABLE_LANGUAGES', () => {
   test('always includes English', () => {
@@ -43,12 +13,6 @@ describe('USABLE_LANGUAGES', () => {
       expect(typeof lang.languageTag).toBe('string');
       expect(typeof lang.nativeName).toBe('string');
       expect(typeof lang.englishName).toBe('string');
-    }
-  });
-
-  test('every entry has a tag that passes isSupportedLanguageTag', () => {
-    for (const lang of USABLE_LANGUAGES) {
-      expect(isSupportedLanguageTag(lang.languageTag)).toBe(true);
     }
   });
 
@@ -86,10 +50,5 @@ describe('getUsableLanguageTagFromSystemPreferences()', () => {
 
   test('falls back to en when all preferences are unsupported', () => {
     expect(getUsableLanguageTagFromSystemPreferences(['__', '^^'])).toBe('en');
-  });
-
-  test('returned tag passes isSupportedLanguageTag', () => {
-    const result = getUsableLanguageTagFromSystemPreferences(['es-MX']);
-    expect(isSupportedLanguageTag(result)).toBe(true);
   });
 });

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -38,32 +38,6 @@ export function getUsableLanguageTagFromSystemPreferences(
 }
 
 /**
- * @param translatedLanguageTags List of language tags that may have translated messages
- * @returns List of languages that are usable within the app (see {@link UsableLanguage})
- */
-function getUsableLanguages(
-  translatedLanguageTags: Array<TranslatedLanguageTag>,
-): Array<UsableLanguage> {
-  const result: Array<UsableLanguage> = [];
-
-  for (const languageTag of translatedLanguageTags) {
-    const {englishName, nativeName} = LANGUAGES[languageTag];
-
-    result.push({
-      englishName,
-      languageTag,
-      nativeName,
-    });
-  }
-
-  result.sort((a, b) => {
-    return a.englishName.localeCompare(b.englishName);
-  });
-
-  return result;
-}
-
-/**
  * Returns the variant of a language tag that the app can use to show translated messages.
  * If we have translations that match the primary language code component of a specified language tag,
  * we return the language code as the language tag (since all language codes are valid language tags).
@@ -87,6 +61,32 @@ export function getUsableLanguageTag(languageTag: string) {
       return supported.languageTag;
     }
   }
+}
+
+/**
+ * @param translatedLanguageTags List of language tags that may have translated messages
+ * @returns List of languages that are usable within the app (see {@link UsableLanguage})
+ */
+function getUsableLanguages(
+  translatedLanguageTags: Array<TranslatedLanguageTag>,
+): Array<UsableLanguage> {
+  const result: Array<UsableLanguage> = [];
+
+  for (const languageTag of translatedLanguageTags) {
+    const {englishName, nativeName} = LANGUAGES[languageTag];
+
+    result.push({
+      englishName,
+      languageTag,
+      nativeName,
+    });
+  }
+
+  result.sort((a, b) => {
+    return a.englishName.localeCompare(b.englishName);
+  });
+
+  return result;
 }
 
 /**

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -15,7 +15,7 @@ interface UsableLanguage {
 // Language tag that has corresponding translations
 export type TranslatedLanguageTag = keyof typeof MESSAGES;
 
-// A subset of supported languages that have at least one translated message
+// All supported languages
 export const USABLE_LANGUAGES = getUsableLanguages(
   Object.keys(MESSAGES) as Array<TranslatedLanguageTag>,
 );

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -25,7 +25,7 @@ export const USABLE_LANGUAGES = getUsableLanguages(
  * Falls back to `'en'` if no supported tag can be found.
  *
  * @param systemLanguageTags Ordered list of language tags from system preferences (most preferred first)
- * @returns A resolved SupportedLanguageTag
+ * @returns an AvailableLanguageTag
  */
 export function getUsableLanguageTagFromSystemPreferences(
   systemLanguageTags: Array<string>,

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -5,7 +5,7 @@ import LANGUAGES from '../languages.json';
 
 interface UsableLanguage {
   /** IETF BCP 47 language tag (https://en.wikipedia.org/wiki/IETF_language_tag) */
-  languageTag: TranslatedLanguageTag;
+  languageTag: AvailableLanguageTag;
   /** Localized name for language */
   nativeName: string;
   /** English name for language */
@@ -13,11 +13,11 @@ interface UsableLanguage {
 }
 
 // Language tag that has corresponding translations
-export type TranslatedLanguageTag = keyof typeof MESSAGES;
+export type AvailableLanguageTag = keyof typeof MESSAGES;
 
 // All supported languages
 export const USABLE_LANGUAGES = getUsableLanguages(
-  Object.keys(MESSAGES) as Array<TranslatedLanguageTag>,
+  Object.keys(MESSAGES) as Array<AvailableLanguageTag>,
 );
 
 /**
@@ -29,7 +29,7 @@ export const USABLE_LANGUAGES = getUsableLanguages(
  */
 export function getUsableLanguageTagFromSystemPreferences(
   systemLanguageTags: Array<string>,
-): TranslatedLanguageTag {
+): AvailableLanguageTag {
   for (const t of systemLanguageTags) {
     const usable = getUsableLanguageTag(t);
     if (usable) return usable;
@@ -68,7 +68,7 @@ export function getUsableLanguageTag(languageTag: string) {
  * @returns List of languages that are usable within the app (see {@link UsableLanguage})
  */
 function getUsableLanguages(
-  translatedLanguageTags: Array<TranslatedLanguageTag>,
+  translatedLanguageTags: Array<AvailableLanguageTag>,
 ): Array<UsableLanguage> {
   const result: Array<UsableLanguage> = [];
 

--- a/src/frontend/lib/intl.ts
+++ b/src/frontend/lib/intl.ts
@@ -3,31 +3,41 @@ import MESSAGES from '../../../translations/messages.json';
 // Mapping of language tag to corresponding native and english names
 import LANGUAGES from '../languages.json';
 
-// Language tag that has corresponding translations
-export type TranslatedLanguageTag = keyof typeof MESSAGES;
-// Language tag that the app claims to support
-export type SupportedLanguageTag = keyof typeof LANGUAGES;
-
-// A subset of supported languages that have at least one translated message
-export const USABLE_LANGUAGES = getUsableLanguages(
-  Object.keys(MESSAGES) as Array<TranslatedLanguageTag>,
-);
-
 interface UsableLanguage {
   /** IETF BCP 47 language tag (https://en.wikipedia.org/wiki/IETF_language_tag) */
-  languageTag: SupportedLanguageTag;
+  languageTag: TranslatedLanguageTag;
   /** Localized name for language */
   nativeName: string;
   /** English name for language */
   englishName: string;
 }
 
+// Language tag that has corresponding translations
+export type TranslatedLanguageTag = keyof typeof MESSAGES;
+
+// A subset of supported languages that have at least one translated message
+export const USABLE_LANGUAGES = getUsableLanguages(
+  Object.keys(MESSAGES) as Array<TranslatedLanguageTag>,
+);
+
 /**
- * Gets the languages that are usable within the app, meaning:
+ * Resolves a language tag from a list of system-preferred language tags.
+ * Falls back to `'en'` if no supported tag can be found.
  *
- * 1. They have at least one translated string
- * 2. They match a language that is found in the [supported languages file](../languages.json)
- *
+ * @param systemLanguageTags Ordered list of language tags from system preferences (most preferred first)
+ * @returns A resolved SupportedLanguageTag
+ */
+export function getUsableLanguageTagFromSystemPreferences(
+  systemLanguageTags: Array<string>,
+): TranslatedLanguageTag {
+  for (const t of systemLanguageTags) {
+    const usable = getUsableLanguageTag(t);
+    if (usable) return usable;
+  }
+  return 'en';
+}
+
+/**
  * @param translatedLanguageTags List of language tags that may have translated messages
  * @returns List of languages that are usable within the app (see {@link UsableLanguage})
  */
@@ -37,33 +47,6 @@ function getUsableLanguages(
   const result: Array<UsableLanguage> = [];
 
   for (const languageTag of translatedLanguageTags) {
-    // Commenting this out for now. Categories can be translated independently of this app/crowdin.
-    // The user might need translate the categories (which is done via this language code).
-    // So we need to make sure the user has access to languages even if there are no translations
-    // Previously we dealt with this by adding 1 translation to an appropriate language.
-    // We may still want to do that, but we intentionally took out any wrong translations.
-    // "api" had several portuguese translation, and I know understand that those
-    // "portuguese translation" were just for adding it onto the list of available languages,
-    // in order for users to translate there categories. Since we took out those translations
-    // commenting out this code allows for it to still show up in the app without adding "translations"
-
-    // const hasAtLeastOneTranslatedString =
-    //   Object.keys(MESSAGES[languageTag]).length > 0;
-
-    // if (!hasAtLeastOneTranslatedString) continue;
-
-    if (!isSupportedLanguageTag(languageTag)) {
-      if (
-        process.env.APP_VARIANT === 'development' &&
-        process.env.NODE_ENV !== 'test'
-      ) {
-        console.warn(
-          `Language "${languageTag}" is not available in CoMapeo (see \`src/frontend/languages.json\`)`,
-        );
-      }
-      continue;
-    }
-
     const {englishName, nativeName} = LANGUAGES[languageTag];
 
     result.push({
@@ -80,12 +63,6 @@ function getUsableLanguages(
   return result;
 }
 
-export function isSupportedLanguageTag(
-  value: string,
-): value is SupportedLanguageTag {
-  return value in LANGUAGES;
-}
-
 /**
  * Returns the variant of a language tag that the app can use to show translated messages.
  * If we have translations that match the primary language code component of a specified language tag,
@@ -96,7 +73,7 @@ export function isSupportedLanguageTag(
  * @param languageTag Language tag
  * @returns The usable language tag
  */
-function getUsableLanguageTag(languageTag: string) {
+export function getUsableLanguageTag(languageTag: string) {
   for (const supported of USABLE_LANGUAGES) {
     // Check if the language tag has a matching language tag that we support
     if (languageTag === supported.languageTag) {
@@ -113,29 +90,12 @@ function getUsableLanguageTag(languageTag: string) {
 }
 
 /**
- * Resolves a language tag from a list of system-preferred language tags.
- * Falls back to `'en'` if no supported tag can be found.
- *
- * @param systemLanguageTags Ordered list of language tags from system preferences (most preferred first)
- * @returns A resolved SupportedLanguageTag
- */
-export function getUsableLanguageTagFromSystemPreferences(
-  systemLanguageTags: Array<string>,
-): SupportedLanguageTag {
-  for (const t of systemLanguageTags) {
-    const usable = getUsableLanguageTag(t);
-    if (usable) return usable;
-  }
-  return 'en';
-}
-
-/**
  * Really naïve function to get the language code component of a IETF BCP 47 language tag
  *
  * @param languageTag Language tag
  * @returns Language code
  */
-export function extractLanguageCode(languageTag: string): string {
+function extractLanguageCode(languageTag: string): string {
   // The language code is always the first component of a the language tag
   // (https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags)
   return languageTag.split('-')[0]!;

--- a/src/frontend/metrics/AppDiagnosticMetrics.ts
+++ b/src/frontend/metrics/AppDiagnosticMetrics.ts
@@ -7,7 +7,7 @@ import {storage} from '../hooks/persistedState/createPersistedState';
 import {assert} from '../lib/assert';
 import {MINUTE_MS, formatIsoUtc, parseIsoUtc} from '../lib/date';
 import {first} from '../lib/first';
-import {type TranslatedLanguageTag} from '../lib/intl';
+import {type AvailableLanguageTag} from '../lib/intl';
 import {last} from '../lib/last';
 import {maybeJsonParse} from '../lib/maybeJsonParse';
 import {OneAtATimeQueue} from '../lib/OneAtATimeQueue';
@@ -50,7 +50,7 @@ async function generateAppDiagnosticMetricsData({
   appLanguageTag,
   deviceLanguageTag,
 }: {
-  appLanguageTag: TranslatedLanguageTag;
+  appLanguageTag: AvailableLanguageTag;
   deviceLanguageTag: string;
 }): Promise<AppDiagnosticMetricsReport> {
   const result: AppDiagnosticMetricsReport = {
@@ -94,7 +94,7 @@ export class AppDiagnosticMetrics {
     getLocaleInfo,
   }: {
     getLocaleInfo: () => {
-      appLanguageTag: TranslatedLanguageTag;
+      appLanguageTag: AvailableLanguageTag;
       deviceLanguageTag: string;
     };
   }) {

--- a/src/frontend/metrics/AppDiagnosticMetrics.ts
+++ b/src/frontend/metrics/AppDiagnosticMetrics.ts
@@ -7,7 +7,7 @@ import {storage} from '../hooks/persistedState/createPersistedState';
 import {assert} from '../lib/assert';
 import {MINUTE_MS, formatIsoUtc, parseIsoUtc} from '../lib/date';
 import {first} from '../lib/first';
-import {type SupportedLanguageTag} from '../lib/intl';
+import {type TranslatedLanguageTag} from '../lib/intl';
 import {last} from '../lib/last';
 import {maybeJsonParse} from '../lib/maybeJsonParse';
 import {OneAtATimeQueue} from '../lib/OneAtATimeQueue';
@@ -50,7 +50,7 @@ async function generateAppDiagnosticMetricsData({
   appLanguageTag,
   deviceLanguageTag,
 }: {
-  appLanguageTag: SupportedLanguageTag;
+  appLanguageTag: TranslatedLanguageTag;
   deviceLanguageTag: string;
 }): Promise<AppDiagnosticMetricsReport> {
   const result: AppDiagnosticMetricsReport = {
@@ -94,7 +94,7 @@ export class AppDiagnosticMetrics {
     getLocaleInfo,
   }: {
     getLocaleInfo: () => {
-      appLanguageTag: SupportedLanguageTag;
+      appLanguageTag: TranslatedLanguageTag;
       deviceLanguageTag: string;
     };
   }) {

--- a/src/frontend/sharedTypes/locale.ts
+++ b/src/frontend/sharedTypes/locale.ts
@@ -2,6 +2,35 @@ import * as v from 'valibot';
 
 import {TranslatedLanguageTag} from '../lib/intl';
 
+import LANGUAGES from '../languages.json';
+
+type LegacySupportedLanguageTag = keyof typeof LANGUAGES;
+
+function isSupportedLanguageTag(
+  value: string,
+): value is LegacySupportedLanguageTag {
+  return value in LANGUAGES;
+}
+
+export const LocaleStateSchemaV0 = v.variant('languageTag', [
+  v.object({
+    languageTag: v.null(),
+    useSystemPreferences: v.literal(true),
+  }),
+  v.object({
+    languageTag: v.pipe(
+      v.string(),
+      v.transform((value): LegacySupportedLanguageTag => {
+        if (!isSupportedLanguageTag(value)) {
+          throw new Error(`Value is not a supported language tag: ${value}`);
+        }
+        return value;
+      }),
+    ),
+    useSystemPreferences: v.literal(false),
+  }),
+]);
+
 // Do not change! Bump version in LocaleStoreContext when modifying this schema.
 export const LocaleStateSchema = v.object({
   languageTag: v.pipe(

--- a/src/frontend/sharedTypes/locale.ts
+++ b/src/frontend/sharedTypes/locale.ts
@@ -3,6 +3,7 @@ import * as v from 'valibot';
 import {TranslatedLanguageTag} from '../lib/intl';
 
 import LANGUAGES from '../languages.json';
+import MESSAGES from '../../../translations/messages.json';
 
 type LegacySupportedLanguageTag = keyof typeof LANGUAGES;
 
@@ -33,9 +34,11 @@ export const LocaleStateSchemaV0 = v.variant('languageTag', [
 
 // Do not change! Bump version in LocaleStoreContext when modifying this schema.
 export const LocaleStateSchema = v.object({
-  languageTag: v.pipe(
-    v.string(),
-    v.transform(value => value as TranslatedLanguageTag),
+  languageTag: v.picklist(
+    Object.keys(MESSAGES) as [
+      TranslatedLanguageTag,
+      ...TranslatedLanguageTag[],
+    ],
   ),
   useSystemPreferences: v.boolean(),
 });

--- a/src/frontend/sharedTypes/locale.ts
+++ b/src/frontend/sharedTypes/locale.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot';
 
-import {TranslatedLanguageTag} from '../lib/intl';
+import {AvailableLanguageTag} from '../lib/intl';
 
 import LANGUAGES from '../languages.json';
 import MESSAGES from '../../../translations/messages.json';
@@ -35,10 +35,7 @@ export const LocaleStateSchemaV0 = v.variant('languageTag', [
 // Do not change! Bump version in LocaleStoreContext when modifying this schema.
 export const LocaleStateSchema = v.object({
   languageTag: v.picklist(
-    Object.keys(MESSAGES) as [
-      TranslatedLanguageTag,
-      ...TranslatedLanguageTag[],
-    ],
+    Object.keys(MESSAGES) as [AvailableLanguageTag, ...AvailableLanguageTag[]],
   ),
   useSystemPreferences: v.boolean(),
 });

--- a/src/frontend/sharedTypes/locale.ts
+++ b/src/frontend/sharedTypes/locale.ts
@@ -1,17 +1,12 @@
 import * as v from 'valibot';
 
-import {isSupportedLanguageTag, SupportedLanguageTag} from '../lib/intl';
+import {TranslatedLanguageTag} from '../lib/intl';
 
 // Do not change! Bump version in LocaleStoreContext when modifying this schema.
 export const LocaleStateSchema = v.object({
   languageTag: v.pipe(
     v.string(),
-    v.transform((value): SupportedLanguageTag => {
-      if (!isSupportedLanguageTag(value)) {
-        throw new Error(`Value is not a supported language tag: ${value}`);
-      }
-      return value;
-    }),
+    v.transform(value => value as TranslatedLanguageTag),
   ),
   useSystemPreferences: v.boolean(),
 });

--- a/src/frontend/sharedTypes/locale.ts
+++ b/src/frontend/sharedTypes/locale.ts
@@ -5,9 +5,11 @@ import {AvailableLanguageTag} from '../lib/intl';
 import LANGUAGES from '../languages.json';
 import MESSAGES from '../../../translations/messages.json';
 
+// // from v0 schema definition
 type LegacySupportedLanguageTag = keyof typeof LANGUAGES;
 
-function isSupportedLanguageTag(
+// from v0 schema definition
+function legacyIsSupportedLanguageTag(
   value: string,
 ): value is LegacySupportedLanguageTag {
   return value in LANGUAGES;
@@ -22,7 +24,7 @@ export const LocaleStateSchemaV0 = v.variant('languageTag', [
     languageTag: v.pipe(
       v.string(),
       v.transform((value): LegacySupportedLanguageTag => {
-        if (!isSupportedLanguageTag(value)) {
+        if (!legacyIsSupportedLanguageTag(value)) {
           throw new Error(`Value is not a supported language tag: ${value}`);
         }
         return value;


### PR DESCRIPTION
This is towards #1881.

#1902 started to address this, but it just revealed the tangle of code that is intl.

First, the intl.ts was exporting the type `SupportedLanguageTag` which was ALL possible language tags, including the languages that we did not support. This was being used as the language tag type in the intlProvider. 

We then were also exporting type `TranslatedLanguageTag` which are the only the language tag which our app supports.

These names are a little misleading as the TranslatedLanguageTag at the tags the app supports, while the `SupportedLanguageTag` is just ALL language tags.

As well, since the intlProvider had the type of SupportedLanguageTag, we had to check that that the language tag returned by the intlProvider was a language tag supported by the app everytime we used it. 

In order to simplify this, i got rid of SupportedLanguageTag entirely. Now the intl provider is of type `TranslatedLanguageTag`. So now we dont need to check everytime we use it because typescript guarantees it is of the right type.

I also updated the store migration to use valibot validation when migrating.

Lastly i added a onRehydrateCheck in zustand. The reason for this i that `TranslatedLanguageTag` can change. If for some reason the app no longer supportes a language the user was using, we just set the app language to system preference.