### PR TITLE
fix: photo orientation

### DIFF
--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -161,7 +161,8 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
    * Only processes steps that are not already complete.
    */
   async function processPhoto(attachment: UnsavedPhotoAttachment) {
-    const {id, raw, original, thumbnail, preview, accelerometer} = attachment;
+    const {id, raw, original, thumbnail, preview, accelerometer, photoExif} =
+      attachment;
 
     if (raw.processingState !== 'complete' || !raw.uri) {
       throw new Error('Cannot process photo without raw image');
@@ -187,8 +188,19 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
         width = result.width;
         height = result.height;
       } else {
-        // Reset EXIF orientation so Glide loads raw sensor pixels, then rotate
-        // using accelerometer. Fixes devices where vision camera writes wrong EXIF.
+        // Zero out EXIF so Glide loads raw sensor pixels without auto-rotating,
+        // then apply rotation derived from accelerometer.
+        Sentry.addBreadcrumb({
+          category: 'photo-orientation',
+          level: 'info',
+          data: {
+            exifOrientation: photoExif?.Orientation ?? null,
+            accelerometer: accelerometer
+              ? {x: accelerometer.x, y: accelerometer.y, z: accelerometer.z}
+              : null,
+            rotation: getPhotoRotation(accelerometer),
+          },
+        });
         await Exify.write(raw.uri, {Orientation: 1});
         const result = await _processPhotoAttachment({
           id,

--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -11,7 +11,7 @@ import {
 } from 'zustand/middleware';
 import type {LocationObject, LocationProviderStatus} from 'expo-location';
 import type {AccelerometerMeasurement} from 'expo-sensors';
-import {manipulateAsync} from 'expo-image-manipulator';
+import {ImageManipulator, type SaveOptions} from 'expo-image-manipulator';
 import {excludeKeys} from 'filter-obj';
 import type {Attachment, Position} from '../../sharedTypes/index.ts';
 import {throwIfAborted} from '../../lib/throwIfAborted.ts';
@@ -182,19 +182,19 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
       if (original.processingState === 'complete' && original.uri) {
         // Original already processed, use existing URI
         // We need dimensions for thumbnail/preview, so fetch from the image
-        const result = await manipulateAsync(original.uri, []);
+        const result = await manipulate(original.uri, {});
         originalUri = result.uri;
         width = result.width;
         height = result.height;
       } else {
-        // Note: Expo Camera with skipProcessing: false automatically rotates photos
-        // to the correct orientation; no further rotation needed.
         const result = await _processPhotoAttachment({
           id,
           outputKey: 'original',
-          processPromise: manipulateAsync(raw.uri, [{rotate: 0}], {
-            compress: ORIGINAL_COMPRESSION,
-          }),
+          processPromise: manipulate(
+            raw.uri,
+            {rotate: 0},
+            {compress: ORIGINAL_COMPRESSION},
+          ),
         });
         originalUri = result.uri;
         width = result.width;
@@ -208,9 +208,9 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
         await _processPhotoAttachment({
           id,
           outputKey: 'thumbnail',
-          processPromise: manipulateAsync(
+          processPromise: manipulate(
             originalUri,
-            [{resize: thumbnailDimensions}],
+            {resize: thumbnailDimensions},
             {compress: THUMBNAIL_COMPRESSION},
           ),
         });
@@ -223,9 +223,9 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
         await _processPhotoAttachment({
           id,
           outputKey: 'preview',
-          processPromise: manipulateAsync(
+          processPromise: manipulate(
             originalUri,
-            [{resize: previewDimensions}],
+            {resize: previewDimensions},
             {compress: PREVIEW_COMPRESSION},
           ),
         });
@@ -571,6 +571,21 @@ function valueOf<T extends MapeoDoc>(doc: T & {forks?: string[]}) {
     'updatedAt',
     'deleted',
   ]);
+}
+
+async function manipulate(
+  uri: string,
+  actions: {rotate?: number; resize?: {width?: number; height?: number}},
+  saveOptions?: SaveOptions,
+): Promise<{uri: string; width: number; height: number}> {
+  let imageManipulatorContext = ImageManipulator.manipulate(uri);
+  if (actions.rotate !== undefined)
+    imageManipulatorContext = imageManipulatorContext.rotate(actions.rotate);
+  if (actions.resize !== undefined)
+    imageManipulatorContext = imageManipulatorContext.resize(actions.resize);
+  const ref = await imageManipulatorContext.renderAsync();
+  const result = await ref.saveAsync(saveOptions);
+  return result;
 }
 
 function hasIncompleteProcessing(attachment: UnsavedPhotoAttachment): boolean {

--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -19,7 +19,7 @@ import {parse} from 'valibot';
 import {PhotoEXIFSchema} from '../../lib/exif.ts';
 import * as Sentry from '@sentry/react-native';
 import {MMKVStoreInitializer} from '../../hooks/persistedState/createPersistedState';
-import type {PhotoFile} from 'react-native-vision-camera';
+import type {TakenPhoto} from '../../sharedComponents/CameraView';
 import * as Exify from '@lodev09/react-native-exify';
 
 export type DraftObservationStore = ReturnType<
@@ -161,7 +161,7 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
    * Only processes steps that are not already complete.
    */
   async function processPhoto(attachment: UnsavedPhotoAttachment) {
-    const {id, raw, original, thumbnail, preview} = attachment;
+    const {id, raw, original, thumbnail, preview, accelerometer} = attachment;
 
     if (raw.processingState !== 'complete' || !raw.uri) {
       throw new Error('Cannot process photo without raw image');
@@ -187,12 +187,15 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
         width = result.width;
         height = result.height;
       } else {
+        // Reset EXIF orientation so Glide loads raw sensor pixels, then rotate
+        // using accelerometer. Fixes devices where vision camera writes wrong EXIF.
+        await Exify.write(raw.uri, {Orientation: 1});
         const result = await _processPhotoAttachment({
           id,
           outputKey: 'original',
           processPromise: manipulate(
             raw.uri,
-            {rotate: 0},
+            {rotate: getPhotoRotation(accelerometer)},
             {compress: ORIGINAL_COMPRESSION},
           ),
         });
@@ -238,11 +241,11 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
     }
   }
 
-  async function addPhoto(picture: PhotoFile, metadata: PhotoMetadata) {
+  async function addPhoto(photo: TakenPhoto, metadata: PhotoMetadata) {
     const newAttachment = await createNewPhotoAttachment({
       id: nextAttachmentId++,
       metadata,
-      picture,
+      photo,
     });
     _addAttachment(newAttachment);
     await processPhoto(newAttachment);
@@ -522,13 +525,13 @@ function createEmptyObservationValue(): ObservationValueWithPreset {
 async function createNewPhotoAttachment({
   id,
   metadata,
-  picture,
+  photo,
 }: {
   id: number;
   metadata: PhotoMetadata;
-  picture: PhotoFile;
+  photo: TakenPhoto;
 }): Promise<UnsavedPhotoAttachment> {
-  const uri = `file://${picture.path}`;
+  const uri = `file://${photo.filePath}`;
   const exif = await Exify.read(uri);
   return {
     id,
@@ -586,6 +589,20 @@ async function manipulate(
   const ref = await imageManipulatorContext.renderAsync();
   const result = await ref.saveAsync(saveOptions);
   return result;
+}
+
+const ACC_AT_45_DEG = Math.sin(Math.PI / 4);
+
+// Rotation needed to correctly orient raw sensor pixels (sensor is 90° CW from device).
+function getPhotoRotation(acc?: AccelerometerMeasurement): number {
+  if (!acc) return 90;
+  const {x, y, z} = acc;
+  if (z < -ACC_AT_45_DEG || z > ACC_AT_45_DEG) {
+    if (Math.abs(y) > Math.abs(x)) return y <= 0 ? -90 : 90;
+    return x >= 0 ? 0 : 180;
+  }
+  if (x > -ACC_AT_45_DEG && x < ACC_AT_45_DEG) return y <= 0 ? -90 : 90;
+  return x >= 0 ? 0 : 180;
 }
 
 function hasIncompleteProcessing(attachment: UnsavedPhotoAttachment): boolean {

--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -190,10 +190,9 @@ export function createDraftObservationStore({persist}: {persist: boolean}) {
       } else {
         // Zero out EXIF so Glide loads raw sensor pixels without auto-rotating,
         // then apply rotation derived from accelerometer.
-        Sentry.addBreadcrumb({
-          category: 'photo-orientation',
+        Sentry.captureMessage('photo-orientation', {
           level: 'info',
-          data: {
+          extra: {
             exifOrientation: photoExif?.Orientation ?? null,
             accelerometer: accelerometer
               ? {x: accelerometer.x, y: accelerometer.y, z: accelerometer.z}

--- a/src/frontend/lib/photos.ts
+++ b/src/frontend/lib/photos.ts
@@ -1,3 +1,4 @@
+import type {AccelerometerMeasurement} from 'expo-sensors';
 import {PhotoMetadata} from '../contexts/PersistedStores/DraftObservationStore';
 import type {Attachment, PhotoEXIF} from '../sharedTypes';
 import {getPhotoLayout, type PhotoLayout} from './exif';
@@ -51,8 +52,15 @@ export function getDraftPhotoInfo({
 }): DisplayablePhotoInfo {
   const exifBasedInfo = photoExif ? extractInfoFromEXIF(photoExif) : undefined;
 
+  // With orientationSource="custom", vision camera writes a neutral EXIF tag so
+  // exifBasedInfo.layout is unreliable. Derive layout from the accelerometer instead.
+  const layout =
+    getLayoutFromAccelerometer(photoMetadata.accelerometer) ??
+    exifBasedInfo?.layout;
+
   return {
     ...exifBasedInfo,
+    layout,
     coordinates:
       typeof photoMetadata.location?.coords.longitude === 'number' &&
       typeof photoMetadata.location?.coords.latitude === 'number'
@@ -64,6 +72,14 @@ export function getDraftPhotoInfo({
     createdAt: photoMetadata.timestamp,
     external: false,
   };
+}
+
+function getLayoutFromAccelerometer(
+  acc?: AccelerometerMeasurement,
+): PhotoLayout | undefined {
+  if (!acc) return undefined;
+  const {x, y} = acc;
+  return Math.abs(x) > Math.abs(y) ? 'horizontal' : 'vertical';
 }
 
 function extractInfoFromEXIF(

--- a/src/frontend/lib/photos.ts
+++ b/src/frontend/lib/photos.ts
@@ -52,15 +52,14 @@ export function getDraftPhotoInfo({
 }): DisplayablePhotoInfo {
   const exifBasedInfo = photoExif ? extractInfoFromEXIF(photoExif) : undefined;
 
-  // With orientationSource="custom", vision camera writes a neutral EXIF tag so
-  // exifBasedInfo.layout is unreliable. Derive layout from the accelerometer instead.
+  // Derive layout from accelerometer; EXIF orientation is zeroed out before processing.
   const layout =
     getLayoutFromAccelerometer(photoMetadata.accelerometer) ??
     exifBasedInfo?.layout;
 
   return {
     ...exifBasedInfo,
-    layout,
+    ...(layout !== undefined && {layout}),
     coordinates:
       typeof photoMetadata.location?.coords.longitude === 'number' &&
       typeof photoMetadata.location?.coords.latitude === 'number'

--- a/src/frontend/screens/AddPhoto.tsx
+++ b/src/frontend/screens/AddPhoto.tsx
@@ -21,11 +21,11 @@ export const AddPhotoScreen = ({
 }: NativeRootNavigationProps<'AddPhoto'>) => {
   const {addPhoto} = useDraftObservationActions();
 
-  const handleAddPress = (takenPhoto: {
+  const handleAddPress = (capture: {
     photo: TakenPhoto;
     metadata: PhotoMetadata;
   }) => {
-    addPhoto(takenPhoto.photo, takenPhoto.metadata);
+    addPhoto(capture.photo, capture.metadata);
     navigation.pop();
   };
 

--- a/src/frontend/screens/AddPhoto.tsx
+++ b/src/frontend/screens/AddPhoto.tsx
@@ -7,7 +7,7 @@ import {NativeRootNavigationProps} from '../sharedTypes/navigation';
 import {useDraftObservationActions} from '../contexts/DraftObservationContext';
 import {PhotoMetadata} from '../contexts/PersistedStores/DraftObservationStore';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
-import type {PhotoFile} from 'react-native-vision-camera';
+import type {TakenPhoto} from '../sharedComponents/CameraView';
 
 const m = defineMessages({
   cancel: {
@@ -21,11 +21,11 @@ export const AddPhotoScreen = ({
 }: NativeRootNavigationProps<'AddPhoto'>) => {
   const {addPhoto} = useDraftObservationActions();
 
-  const handleAddPress = (capture: {
-    photo: PhotoFile;
+  const handleAddPress = (takenPhoto: {
+    photo: TakenPhoto;
     metadata: PhotoMetadata;
   }) => {
-    addPhoto(capture.photo, capture.metadata);
+    addPhoto(takenPhoto.photo, takenPhoto.metadata);
     navigation.pop();
   };
 

--- a/src/frontend/screens/CameraScreen.tsx
+++ b/src/frontend/screens/CameraScreen.tsx
@@ -6,7 +6,7 @@ import {CameraView} from '../sharedComponents/CameraView';
 import {NativeHomeTabsNavigationProps} from '../sharedTypes/navigation';
 import {PhotoMetadata} from '../contexts/PersistedStores/DraftObservationStore';
 import {useDraftObservationActions} from '../contexts/DraftObservationContext';
-import {PhotoFile} from 'react-native-vision-camera';
+import type {TakenPhoto} from '../sharedComponents/CameraView';
 
 export const CameraScreen = ({
   navigation,
@@ -14,12 +14,9 @@ export const CameraScreen = ({
   const isFocused = useIsFocused();
   const {createDraft, addPhoto} = useDraftObservationActions();
 
-  function handleAddPress(capture: {
-    photo: PhotoFile;
-    metadata: PhotoMetadata;
-  }) {
+  function handleAddPress(taken: {photo: TakenPhoto; metadata: PhotoMetadata}) {
     createDraft();
-    addPhoto(capture.photo, capture.metadata);
+    addPhoto(taken.photo, taken.metadata);
     navigation.navigate('ObservationCategoryChooser');
   }
 

--- a/src/frontend/screens/CameraScreen.tsx
+++ b/src/frontend/screens/CameraScreen.tsx
@@ -14,9 +14,12 @@ export const CameraScreen = ({
   const isFocused = useIsFocused();
   const {createDraft, addPhoto} = useDraftObservationActions();
 
-  function handleAddPress(taken: {photo: TakenPhoto; metadata: PhotoMetadata}) {
+  function handleAddPress(capture: {
+    photo: TakenPhoto;
+    metadata: PhotoMetadata;
+  }) {
     createDraft();
-    addPhoto(taken.photo, taken.metadata);
+    addPhoto(capture.photo, capture.metadata);
     navigation.navigate('ObservationCategoryChooser');
   }
 

--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -35,9 +35,13 @@ const m = defineMessages({
   },
 });
 
+export type TakenPhoto = {
+  filePath: string;
+  accelerometer?: AccelerometerMeasurement;
+};
+
 type Props = {
-  // Called when the user takes a picture.
-  onAddPress: (photo: {photo: PhotoFile; metadata: PhotoMetadata}) => void;
+  onAddPress: (photo: {photo: TakenPhoto; metadata: PhotoMetadata}) => void;
 };
 
 export const CameraView = ({onAddPress}: Props) => {
@@ -90,9 +94,12 @@ export const CameraView = ({onAddPress}: Props) => {
 
     camera.current
       .takePhoto({enableShutterSound: false})
-      .then(async photo => {
+      .then((photoFile: PhotoFile) => {
         onAddPress({
-          photo,
+          photo: {
+            filePath: photoFile.path,
+            accelerometer: accelerometerMeasurement.current || undefined,
+          },
           metadata: {
             location,
             accelerometer: accelerometerMeasurement.current || undefined,


### PR DESCRIPTION
towards #1872 
Turns out we cannot update to `react-native-vision-camera` version 5 without the new architecture. This is not well documented and took me a while to figure out. 

So this fix is attempting to override whatever EXIF orientation vision camera wrote (correct or not) with this command: `await Exify.write(raw.uri, {Orientation: 1}`;

Then after that we apply our home grown rotation using the accelerometer.

The `manipulateAsync` API got deprecated so now I made a wrapper/ helper for the suggested replacement (`ImageManipulator.manipulate`) since we use that behavior 3 times.

Also, in order to display the photo in the correct orientation, we have to calculate the layout using the accelerometer data 

At this point, this fix works for my three devices (two Samsungs and a Pixel running Android 15 & 16) **but not for a Motorola (Moto G4) testing device running Android 14**.

 It would be helpful to know why, so an idea is to see what the Exif value is for four different scenarios (portrait upright, landscape right, portrait upside down, landscape left). Then we can ascertain if possibly vision camera is writing wrong EXIF on that device. If not, we are stuck and have to wait for upgrade to vision camera 5.

I have added _temporary_ Sentry logging in case we want to debug this further so that we can see what the Exif Orientation is for a tester since different devices could possibly be using different values.

We could do an apk build and check Sentry for the Motorola to see what might be going on..