### PR TITLE
fix: ui for early access

### DIFF
--- a/messages/en-US/primary.json
+++ b/messages/en-US/primary.json
@@ -23,8 +23,11 @@
   "$1Navigation.Menu.currentProject": {
     "message": "Current Project"
   },
-  "$1Navigation.Menu.earlyAccessLabel": {
-    "message": "You are in Early Access Mode."
+  "$1Navigation.Menu.earlyAccessOn": {
+    "message": "Early Access ON"
+  },
+  "$1Navigation.Menu.earlyAccessTurnOff": {
+    "message": "Turn Off"
   },
   "$1Navigation.Menu.exchange": {
     "message": "Exchange"

--- a/messages/en-US/secondary.json
+++ b/messages/en-US/secondary.json
@@ -438,11 +438,8 @@
   "screens.DataAndPrivacy.respectsPrivacy": {
     "message": "CoMapeo Respects Your Privacy & Autonomy"
   },
-  "screens.EarlyAccess.feedbackLink": {
-    "message": "Share it here"
-  },
   "screens.EarlyAccess.feedbackPrefix": {
-    "message": "Have feedback?"
+    "message": "Have feedback? Share it at"
   },
   "screens.EarlyAccess.infoBox": {
     "message": "Data from Early Access won't be visible to collaborators who haven't opted in."

--- a/src/frontend/screens/ComapeoSettings/EarlyAccess.tsx
+++ b/src/frontend/screens/ComapeoSettings/EarlyAccess.tsx
@@ -38,11 +38,7 @@ const m = defineMessages({
   },
   feedbackPrefix: {
     id: 'screens.EarlyAccess.feedbackPrefix',
-    defaultMessage: 'Have feedback? ',
-  },
-  feedbackLink: {
-    id: 'screens.EarlyAccess.feedbackLink',
-    defaultMessage: 'Share it here',
+    defaultMessage: 'Have feedback? Share it at ',
   },
 });
 
@@ -103,14 +99,10 @@ export const EarlyAccess = ({
         <View style={styles.feedbackRow}>
           <BodyText>{formatMessage(m.feedbackPrefix)}</BodyText>
           <Pressable
-            onPress={() =>
-              Linking.openURL(
-                'https://docs.google.com/forms/d/10r8wJ7WuZ5PMR7Gbx9aKcWTq-IFXz2ZcPKvk7bP0K4Q/edit',
-              )
-            }
+            onPress={() => Linking.openURL('mailto:feedback@comapeo.app')}
             accessibilityRole="link">
             <HeaderText variant="header5" style={styles.feedbackLinkText}>
-              {formatMessage(m.feedbackLink)}
+              {'feedback@comapeo.app'}
             </HeaderText>
           </Pressable>
         </View>

--- a/src/frontend/sharedComponents/DrawerMenu.tsx
+++ b/src/frontend/sharedComponents/DrawerMenu.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {View, StyleSheet, ScrollView, TouchableOpacity} from 'react-native';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Pressable,
+} from 'react-native';
 import {useIntl, defineMessages} from 'react-intl';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import IonIcon from '@react-native-vector-icons/ionicons';
@@ -119,20 +125,25 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
             />
           )}
           {isEarly ? (
-            <View style={styles.earlyAccessAlert}>
-              <View style={styles.earlyAccessRow}>
-                <MaterialIcon name="flag" size={20} color={NEW_DARK_GREY} />
-                <HeaderText variant="header6" style={styles.earlyAccessLabel}>
-                  {formatMessage(m.earlyAccessOn)}
-                </HeaderText>
-                <BodyText
-                  variant="tinyMeta"
-                  style={styles.earlyAccessTurnOff}
-                  onPress={() => navigation.navigate('EarlyAccess')}>
-                  {formatMessage(m.earlyAccessTurnOff)}
-                </BodyText>
+            <ColorCard backgroundColor={LIGHT_ORANGE}>
+              <View style={styles.earlyAccessAlert}>
+                <View style={styles.earlyAccessRow}>
+                  <MaterialIcon name="flag" size={20} color={NEW_DARK_GREY} />
+                  <HeaderText variant="header6" style={styles.earlyAccessLabel}>
+                    {formatMessage(m.earlyAccessOn)}
+                  </HeaderText>
+                  <Pressable
+                    onPress={() => navigation.navigate('EarlyAccess')}
+                    hitSlop={{top: 12, bottom: 12, left: 12, right: 12}}>
+                    <BodyText
+                      variant="tinyMeta"
+                      style={styles.earlyAccessTurnOff}>
+                      {formatMessage(m.earlyAccessTurnOff)}
+                    </BodyText>
+                  </Pressable>
+                </View>
               </View>
-            </View>
+            </ColorCard>
           ) : null}
           <ColorCard backgroundColor={projectColor}>
             <View style={{padding: 20, gap: 12}}>
@@ -314,10 +325,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   earlyAccessAlert: {
-    backgroundColor: LIGHT_ORANGE,
-    borderWidth: 0.5,
-    borderColor: BLUE_GREY,
-    borderRadius: 6,
     padding: 15,
   },
   earlyAccessRow: {

--- a/src/frontend/sharedComponents/DrawerMenu.tsx
+++ b/src/frontend/sharedComponents/DrawerMenu.tsx
@@ -11,7 +11,13 @@ import Exchange from '../images/Exchange.svg';
 import CollaborateIcon from '../images/ProjectParticipant.svg';
 import {BodyText} from '../sharedComponents/Text/BodyText.tsx';
 import {useProjectRoleAndDetails} from '../hooks/useProjectRoleAndDetails.ts';
-import {BLUE_GREY, COMAPEO_BLUE, NEW_DARK_GREY, WHITE} from '../lib/styles.ts';
+import {
+  BLUE_GREY,
+  COMAPEO_BLUE,
+  LIGHT_ORANGE,
+  NEW_DARK_GREY,
+  WHITE,
+} from '../lib/styles.ts';
 import {useActiveProject} from '../contexts/ActiveProjectContext.tsx';
 import {MenuLowStorageAlert} from '../sharedComponents/Storage/MenuLowStorageAlert.tsx';
 import {useStorageReadingQuery} from '../hooks/useStorageReadingQuery.ts';
@@ -64,9 +70,13 @@ const m = defineMessages({
     id: '$1Navigation.Menu.switchProject',
     defaultMessage: 'Switch Project',
   },
-  earlyAccessLabel: {
-    id: '$1Navigation.Menu.earlyAccessLabel',
-    defaultMessage: 'You are in Early Access Mode.',
+  earlyAccessOn: {
+    id: '$1Navigation.Menu.earlyAccessOn',
+    defaultMessage: 'Early Access ON',
+  },
+  earlyAccessTurnOff: {
+    id: '$1Navigation.Menu.earlyAccessTurnOff',
+    defaultMessage: 'Turn Off',
   },
   team: {
     id: '$1Navigation.Menu.team',
@@ -101,13 +111,29 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
   return (
     <View style={[styles.container, {paddingTop: insets.top}]}>
       <ScrollView contentContainerStyle={styles.scrollContainer}>
-        {isLow && (
-          <MenuLowStorageAlert
-            freeBytes={freeBytes}
-            percentUsed={percentUsed}
-          />
-        )}
-        <View>
+        <View style={styles.topCardsContainer}>
+          {isLow && (
+            <MenuLowStorageAlert
+              freeBytes={freeBytes}
+              percentUsed={percentUsed}
+            />
+          )}
+          {isEarly ? (
+            <View style={styles.earlyAccessAlert}>
+              <View style={styles.earlyAccessRow}>
+                <MaterialIcon name="flag" size={20} color={NEW_DARK_GREY} />
+                <HeaderText variant="header6" style={styles.earlyAccessLabel}>
+                  {formatMessage(m.earlyAccessOn)}
+                </HeaderText>
+                <BodyText
+                  variant="tinyMeta"
+                  style={styles.earlyAccessTurnOff}
+                  onPress={() => navigation.navigate('EarlyAccess')}>
+                  {formatMessage(m.earlyAccessTurnOff)}
+                </BodyText>
+              </View>
+            </View>
+          ) : null}
           <ColorCard backgroundColor={projectColor}>
             <View style={{padding: 20, gap: 12}}>
               <HeaderText variant="header2">{projectHeader}</HeaderText>
@@ -170,13 +196,6 @@ export function DrawerMenu({closeMenu}: {closeMenu: () => void}) {
             </View>
           </ColorCard>
         </View>
-
-        {isEarly ? (
-          <View style={styles.label}>
-            <MaterialIcon name="flag" size={20} />
-            <BodyText>{formatMessage(m.earlyAccessLabel)}</BodyText>
-          </View>
-        ) : null}
 
         <View style={styles.bottomItemsContainer}>
           {role !== 'solo' && (
@@ -280,6 +299,9 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     justifyContent: 'space-between',
   },
+  topCardsContainer: {
+    gap: 12,
+  },
   bottomItemsContainer: {
     gap: 20,
     paddingBottom: 20,
@@ -291,10 +313,22 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  label: {
-    gap: 10,
-    alignSelf: 'center',
-    alignItems: 'center',
+  earlyAccessAlert: {
+    backgroundColor: LIGHT_ORANGE,
+    borderWidth: 0.5,
+    borderColor: BLUE_GREY,
+    borderRadius: 6,
+    padding: 15,
+  },
+  earlyAccessRow: {
     flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  earlyAccessLabel: {
+    flex: 1,
+  },
+  earlyAccessTurnOff: {
+    color: COMAPEO_BLUE,
   },
 });

--- a/src/frontend/sharedComponents/Storage/MenuLowStorageAlert.tsx
+++ b/src/frontend/sharedComponents/Storage/MenuLowStorageAlert.tsx
@@ -104,7 +104,6 @@ const styles = StyleSheet.create({
     padding: 12,
     flex: 1,
     gap: 12,
-    marginBottom: 20,
   },
   headerRow: {
     flexDirection: 'row',

--- a/tests/e2e/specs/settings/early-access.test.ts
+++ b/tests/e2e/specs/settings/early-access.test.ts
@@ -28,7 +28,7 @@ describe('Settings - Early Access Mode', () => {
       ),
     ).toBeDisplayed();
     await expect($(byTextMatches('Have feedback?'))).toBeDisplayed();
-    await expect($(byTextMatches('Share it here'))).toBeDisplayed();
+    await expect($(byTextMatches('Share it at'))).toBeDisplayed();
   });
 
   it('should show ON in the App Settings list item text', async () => {
@@ -45,9 +45,7 @@ describe('Settings - Early Access Mode', () => {
     await backBtn.click();
     const backBtnAgain = await $(byResourceId('MAIN.header-back-btn'));
     await backBtnAgain.click();
-    await expect(
-      $(byTextMatches('You are in Early Access Mode')),
-    ).toBeDisplayed();
+    await expect($(byTextMatches('Early Access ON'))).toBeDisplayed();
     const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
     const aboutComapeoOption = await $(byResourceId('aboutSettingsButton'));


### PR DESCRIPTION
closes #1914 

Updates UI for early access notification in the drawer menu. Updates the link for feedback.

**(with larger size font and low storage)**
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b9fc3afb-3c39-4eec-928f-dbadb362784f" />

**(more regular-ish size font)**
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/7ea82338-bbd9-4f9a-a963-c8c6ca6acb70" />

The new language around the feedback as requested. I don't think it will often fit on one line so will usually look like this
---
<img width="250" alt="image" src="https://github.com/user-attachments/assets/688e187a-ff32-474f-9dfe-38b4137cd927" />


