### PR TITLE
fix: background map share cancels

### DIFF
--- a/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {StyleSheet, View, Pressable} from 'react-native';
+import {StyleSheet, View, Pressable, AppState} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
 import * as Sentry from '@sentry/react-native';
@@ -84,6 +84,15 @@ export function ReceivingBackgroundMap({
       },
     );
   }, [abortDownload, shareId, navigation]);
+
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextState => {
+      if (nextState === 'background') {
+        handleCancel();
+      }
+    });
+    return () => subscription.remove();
+  }, [handleCancel]);
 
   const handleDone = () => {
     navigation.goBack();

--- a/src/frontend/screens/BackgroundMaps/SendingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/SendingBackgroundMap.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {StyleSheet, View, Pressable} from 'react-native';
+import {AppState, StyleSheet, View, Pressable} from 'react-native';
 import {defineMessages, useIntl} from 'react-intl';
 import * as Sentry from '@sentry/react-native';
 import MaterialIcon from '@react-native-vector-icons/material-icons';
@@ -119,6 +119,15 @@ export function SendingBackgroundMap({
       },
     );
   }, [navigation, cancelMapShare, shareId]);
+
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextState => {
+      if (nextState === 'background') {
+        cancelShare();
+      }
+    });
+    return () => subscription.remove();
+  }, [cancelShare]);
 
   const handleClose = () => {
     navigation.goBack();


### PR DESCRIPTION
closes #1913 
Adds use effect to cancel the map share in the case of either a sender or receiver backgrounding the app, as was specified in the notion document as the requested behavior.
https://app.notion.com/p/digidem/Map-Sharing-Sender-in-BG-mode-error-36e1b08162d580a6bb82e42ca5873c46

In order to see if it worked properly, I had to build a release-candidate apk and install it on my devices. Running dev builds on two devices simultaneously USB connected didn't work for me. But in the case of the rc on devices, it worked perfectly.