### PR TITLE
fix: use markerview which always renders on top

### DIFF
--- a/src/frontend/screens/MapScreen/CurrentTrack/UserTooltipMarker.tsx
+++ b/src/frontend/screens/MapScreen/CurrentTrack/UserTooltipMarker.tsx
@@ -1,4 +1,4 @@
-import {PointAnnotation} from '@maplibre/maplibre-react-native';
+import {MarkerView} from '@maplibre/maplibre-react-native';
 import {StyleSheet, Text, View} from 'react-native';
 
 import {useTrackState} from '../../../contexts/TrackStoreContext';
@@ -21,7 +21,7 @@ export const UserTooltipMarker = () => {
   return (
     // We dont want to put this check in the parent because it will cause the parent (the map) to render too often
     location?.coords && (
-      <PointAnnotation
+      <MarkerView
         key={`locationView-${timer}`}
         id="locationView"
         coordinate={[location.coords.longitude, location.coords.latitude]}
@@ -39,7 +39,7 @@ export const UserTooltipMarker = () => {
           </View>
           <View style={styles.arrow} />
         </View>
-      </PointAnnotation>
+      </MarkerView>
     )
   );
 };


### PR DESCRIPTION
fixes #1917 

Replaces Point Annotation with a markerview, as markerview renders ontop of the other layers.

<img width="216" height="472" alt="image" src="https://github.com/user-attachments/assets/2f2d03d7-9e9a-4241-be1c-d838b4e05014" />
