### PR TITLE
fix: fix offline fallback map not showing when app is offline

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Logger} from '@maplibre/maplibre-react-native';
+import {Logger, setConnected} from '@maplibre/maplibre-react-native';
 import {getLocales} from 'expo-localization';
 
 // Maplibre logs when tile requests are cancelled, which is often.
@@ -13,6 +13,12 @@ Logger.setLogCallback(log => {
   }
   return false;
 });
+
+// All styles are served via localhost and we need to bypass the internal connectivity manager in MapLibre React Native
+// in order for things to work while the app is offline.
+// https://github.com/maplibre/maplibre-react-native/blob/6f99de530eec2e06de485ef86f4be61f941e0e09/docs/content/modules/mlrn-module.md#setconnectedconnected
+setConnected(true);
+
 import {QueryClient} from '@tanstack/react-query';
 import {AppNavigator} from './AppNavigator';
 import {initializeNodejs} from './initializeNodejs';


### PR DESCRIPTION
Fixes #1922 

Subtle piece in the [MapLibre React Native docs](https://github.com/maplibre/maplibre-react-native/blob/6f99de530eec2e06de485ef86f4be61f941e0e09/docs/content/modules/mlrn-module.md#setconnectedconnected) that's particularly relevant:

> If hosting styles/sources on `localhost`, it's necessary to bypass `ConnectivityManager` when the device is
offline ([maplibre/maplibre-react-native#21](https://github.com/maplibre/maplibre-react-native/issues/21#issuecomment-2558602006), [mapbox/mapbox-gl-native#12819](https://github.com/mapbox/mapbox-gl-native/issues/12819)):
> 
> ```ts
> setConnected(true);
> ```

Since the style endpoint is always served via localhost, we call the above on app init so that MapLibre always attempts to fetch from the specified map style endpoint, even when the app is offline. This fixes the map on the main map screen as well as the embedded one in the observation details screen.

---

- Offline

    https://github.com/user-attachments/assets/79c26499-234b-4de3-8a56-0337188b4724

- Online

    https://github.com/user-attachments/assets/d3308bdc-1e71-490c-988a-50a142010ced