### PR TITLE
chore: automates play store submission and upload to github releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,10 +29,6 @@ on:
         description: 'EAS build ID (UUID from expo.dev build URL)'
         required: true
         type: string
-      version:
-        description: 'Release version short form (e.g. 10.5)'
-        required: true
-        type: string
 
 jobs:
   build:
@@ -106,8 +102,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     needs: build
-    outputs:
-      release_version_short: ${{ steps.version.outputs.release_version_short }}
 
     steps:
       - name: Create GitHub App Token
@@ -149,7 +143,6 @@ jobs:
         id: inputs
         run: |
           echo "build_id=${{ inputs.build_id || needs.build.outputs.build_id }}" >> $GITHUB_OUTPUT
-          echo "version=${{ inputs.version || needs.tag.outputs.release_version_short }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1
@@ -196,9 +189,17 @@ jobs:
             sleep 60
           done
 
+      - name: Extract version from EAS build
+        id: eas_version
+        env:
+          BUILD_ID: ${{ steps.inputs.outputs.build_id }}
+        run: |
+          version=$(eas build:view "$BUILD_ID" --json | jq -r '.appVersion')
+          echo "version=$version" >> $GITHUB_OUTPUT
+
       - name: Download APK from R2
         env:
-          VERSION: ${{ steps.inputs.outputs.version }}
+          VERSION: ${{ steps.eas_version.outputs.version }}
         run: |
           APK_URL="https://downloads.comapeo.app/android/release/comapeo-v${VERSION}.apk"
           echo "Downloading APK from $APK_URL"
@@ -207,7 +208,7 @@ jobs:
       - name: Read release notes
         id: release_notes
         env:
-          VERSION: ${{ steps.inputs.outputs.version }}
+          VERSION: ${{ steps.eas_version.outputs.version }}
         run: |
           MINOR_VERSION=$(echo "$VERSION" | cut -d. -f1)
           NOTES_FILE="release-notes/closed-prs-v${MINOR_VERSION}.md"
@@ -224,7 +225,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          VERSION: ${{ steps.inputs.outputs.version }}
+          VERSION: ${{ steps.eas_version.outputs.version }}
           RELEASE_BODY: ${{ steps.release_notes.outputs.body }}
           # On workflow_dispatch the tag job doesn't run, so we create the tag here
           CREATE_TAG: ${{ github.event_name == 'workflow_dispatch' && '--create-tag' || '' }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -80,6 +80,7 @@ jobs:
   comment:
     name: Comment
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     needs: build
 
     steps:
@@ -185,10 +186,10 @@ jobs:
           while true; do
             status=$(eas build:view "$BUILD_ID" --json | jq -r '.status')
             echo "Build status: $status"
-            if [ "$status" = "FINISHED" ]; then
+            if [ "$status" = "finished" ]; then
               echo "Build finished successfully"
               break
-            elif [ "$status" = "ERRORED" ] || [ "$status" = "CANCELLED" ]; then
+            elif [ "$status" = "errored" ] || [ "$status" = "canceled" ]; then
               echo "Build failed with status: $status"
               exit 1
             fi
@@ -225,10 +226,13 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.inputs.outputs.version }}
           RELEASE_BODY: ${{ steps.release_notes.outputs.body }}
+          # On workflow_dispatch the tag job doesn't run, so we create the tag here
+          CREATE_TAG: ${{ github.event_name == 'workflow_dispatch' && '--create-tag' || '' }}
         run: |
           gh release create "v${VERSION}" \
             --title "CoMapeo v${VERSION}" \
             --notes "$RELEASE_BODY" \
+            $CREATE_TAG \
             "comapeo-v${VERSION}.apk#CoMapeo Android APK"
 
   submit:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,7 +1,6 @@
 # Summary:
 #
-# Creates a production build of the app that is eventually submitted for distribution.
-# This workflow DOES NOT automatically perform the submission - that must still be handled manually.
+# Creates a production build of the app and submits it for distribution.
 #
 # Triggers:
 #
@@ -13,6 +12,9 @@
 # - Creates a comment on the (merged) Release Candidate PR with a link to the EAS build process.
 # - Creates a release tag named `v${version}` on the merge commit in the targeted `release/**` branch.
 #   `version` is `<minor>.<patch>` e.g. `1.2.0` is truncated to `2.0`.
+# - Waits for EAS build to complete, then:
+#   - Creates a GitHub Release with the APK downloaded from R2 and release notes attached
+#   - Submits the AAB to the Google Play Store production track via `eas submit`
 name: Build Release
 
 on:
@@ -21,14 +23,25 @@ on:
       - closed
     branches:
       - 'release/**'
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: 'EAS build ID (UUID from expo.dev build URL)'
+        required: true
+        type: string
+      version:
+        description: 'Release version short form (e.g. 10.5)'
+        required: true
+        type: string
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     outputs:
       eas_build_url: ${{ steps.build.outputs.eas_build_url }}
+      build_id: ${{ steps.build.outputs.build_id }}
 
     steps:
       - name: Checkout repository
@@ -60,6 +73,7 @@ jobs:
             exit 1
           fi
           echo "Build ID: $build_id"
+          echo "build_id=$build_id" >> $GITHUB_OUTPUT
           eas_build_url="$EAS_PROJECT_URL/builds/$build_id"
           echo "eas_build_url=$eas_build_url" >> $GITHUB_OUTPUT
 
@@ -89,7 +103,10 @@ jobs:
   tag:
     name: Create release tag
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     needs: build
+    outputs:
+      release_version_short: ${{ steps.version.outputs.release_version_short }}
 
     steps:
       - name: Create GitHub App Token
@@ -119,3 +136,128 @@ jobs:
           git config --global user.email '${{ vars.RELEASE_BOT_USER_ID }}+awana-release-bot[bot]@users.noreply.github.com'
           git tag v${{ steps.version.outputs.release_version_short }}
           git push origin v${{ steps.version.outputs.release_version_short }}
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build, tag]
+    if: always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.tag.result == 'success'))
+
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          echo "build_id=${{ inputs.build_id || needs.build.outputs.build_id }}" >> $GITHUB_OUTPUT
+          echo "version=${{ inputs.version || needs.tag.outputs.release_version_short }}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Wait for EAS build to finish
+        env:
+          BUILD_ID: ${{ steps.inputs.outputs.build_id }}
+        run: |
+          echo "Waiting for EAS build $BUILD_ID to complete..."
+          while true; do
+            status=$(eas build:view "$BUILD_ID" --json | jq -r '.status')
+            echo "Build status: $status"
+            if [ "$status" = "FINISHED" ]; then
+              echo "Build finished successfully"
+              break
+            elif [ "$status" = "ERRORED" ] || [ "$status" = "CANCELLED" ]; then
+              echo "Build failed with status: $status"
+              exit 1
+            fi
+            sleep 60
+          done
+
+      - name: Download APK from R2
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+        run: |
+          APK_URL="https://downloads.comapeo.app/android/release/comapeo-v${VERSION}.apk"
+          echo "Downloading APK from $APK_URL"
+          curl -fL "$APK_URL" -o "comapeo-v${VERSION}.apk"
+
+      - name: Read release notes
+        id: release_notes
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+        run: |
+          MINOR_VERSION=$(echo "$VERSION" | cut -d. -f1)
+          NOTES_FILE="release-notes/closed-prs-v${MINOR_VERSION}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            {
+              echo "body<<RELEASE_NOTES_EOF"
+              cat "$NOTES_FILE"
+              echo "RELEASE_NOTES_EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "body=No release notes found." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+          RELEASE_BODY: ${{ steps.release_notes.outputs.body }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "CoMapeo v${VERSION}" \
+            --notes "$RELEASE_BODY" \
+            "comapeo-v${VERSION}.apk#CoMapeo Android APK"
+
+  submit:
+    name: Submit to Play Store
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    needs: build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Set up Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Submit to Google Play Store
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          eas submit --platform android --profile production --id ${{ needs.build.outputs.build_id }} --non-interactive

--- a/eas.json
+++ b/eas.json
@@ -56,6 +56,11 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "production",
+        "releaseStatus": "completed"
+      }
+    }
   }
 }


### PR DESCRIPTION
closes #1177
### Summary

- Updates eas.json with submit config for Google Play
- Adds two new jobs to the Build Release workflow:
   1. GitHub Release — automatically creates a GitHub Release with the APK (downloaded from R2) and release notes attached if they exist, every time a release PR is merged
   2. Play Store submission — automatically submits the production AAB to the Play Store via eas submit after every release build

### Testing
I need to merge this to develop to test it. The workflow has a manual trigger (workflow_dispatch) that lets me run just the GitHub Release job with a specific build ID and version — without triggering a real release or touching the Play Store. That is a much more complicated piece of code and doesn't hurt much if we have to test it out a few times, unlike the play store submission. 

**My plan once merged**: run it manually with the v10.5 hotfix build. This gives us two things at once:

1. Confirms the workflow actually works
2. Gets v10.5 onto our GitHub releases page

@ErikSin  — Can you review this untested so I can merge this so I can run the test? The workflow_dispatch trigger only appears in the Actions tab once the workflow is on develop, unfortunately. 
