### PR TITLE
fix: guard audio recorder against use after teardown (COMAPEO-1Z7)

### DIFF
--- a/src/frontend/screens/Audio/AudioRecording/useAudioRecording.test.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/useAudioRecording.test.tsx
@@ -1,0 +1,94 @@
+import {renderHook, act} from '@testing-library/react-native';
+import {useAudioRecorder, useAudioRecorderState} from 'expo-audio';
+
+import {useAudioRecording} from './useAudioRecording';
+
+const mockedUseAudioRecorder = jest.mocked(useAudioRecorder);
+const mockedUseAudioRecorderState = jest.mocked(useAudioRecorderState);
+
+type DeferredRecorder = {
+  recorder: {
+    prepareToRecordAsync: jest.Mock;
+    record: jest.Mock;
+    stop: jest.Mock;
+    uri: string | null;
+  };
+  resolvePrepare: () => void;
+};
+
+function mockRecorderWithPendingPrepare(): DeferredRecorder {
+  let resolvePrepare!: () => void;
+  const prepareToRecordAsync = jest.fn(
+    () =>
+      new Promise<void>(resolve => {
+        resolvePrepare = resolve;
+      }),
+  );
+  const recorder = {
+    prepareToRecordAsync,
+    record: jest.fn(),
+    stop: jest.fn(() => Promise.resolve()),
+    uri: null,
+  };
+  // @ts-expect-error Partial mock is enough for these tests
+  mockedUseAudioRecorder.mockReturnValue(recorder);
+  // @ts-expect-error Partial mock is enough for these tests
+  mockedUseAudioRecorderState.mockReturnValue({
+    isRecording: false,
+    durationMillis: 0,
+  });
+  return {recorder, resolvePrepare: () => resolvePrepare()};
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useAudioRecording', () => {
+  // Regression test for Sentry COMAPEO-1Z7. Leaving the recording screen before
+  // prepareToRecordAsync resolves (e.g. starting then stopping/leaving in quick
+  // succession) unmounts the hook, which releases the recorder's native shared
+  // object. record() then ran against the released object and crashed with
+  // "Cannot use shared object that was already released".
+  test('does not call record() when unmounted before prepareToRecordAsync resolves', async () => {
+    const {recorder, resolvePrepare} = mockRecorderWithPendingPrepare();
+
+    const {result, unmount} = renderHook(() => useAudioRecording());
+
+    let startRecordingPromise!: Promise<void>;
+    act(() => {
+      startRecordingPromise = result.current.startRecording();
+    });
+
+    expect(recorder.prepareToRecordAsync).toHaveBeenCalledTimes(1);
+    expect(recorder.record).not.toHaveBeenCalled();
+
+    // Simulate navigating away from the screen while prepare is still pending.
+    unmount();
+
+    await act(async () => {
+      resolvePrepare();
+      await startRecordingPromise;
+    });
+
+    expect(recorder.record).not.toHaveBeenCalled();
+  });
+
+  test('calls record() when still mounted after prepareToRecordAsync resolves', async () => {
+    const {recorder, resolvePrepare} = mockRecorderWithPendingPrepare();
+
+    const {result} = renderHook(() => useAudioRecording());
+
+    let startRecordingPromise!: Promise<void>;
+    act(() => {
+      startRecordingPromise = result.current.startRecording();
+    });
+
+    await act(async () => {
+      resolvePrepare();
+      await startRecordingPromise;
+    });
+
+    expect(recorder.record).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
+++ b/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {
   useAudioRecorder,
   useAudioRecorderState,
@@ -10,9 +10,21 @@ const RECORDING_OPTIONS = RecordingPresets.HIGH_QUALITY!;
 export function useAudioRecording() {
   const recorder = useAudioRecorder(RECORDING_OPTIONS);
   const status = useAudioRecorderState(recorder, 100);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const startRecording = useCallback(async () => {
     await recorder.prepareToRecordAsync();
+    // expo-audio releases the recorder's native object when this hook unmounts.
+    // If the screen unmounts while prepareToRecordAsync is still awaiting,
+    // record() would run against a released object and crash (Sentry COMAPEO-1Z7).
+    if (!isMountedRef.current) return;
     recorder.record();
   }, [recorder]);
 


### PR DESCRIPTION
## Problem

Sentry [COMAPEO-1Z7](https://awana-digital.sentry.io/issues/7341419707/) — `Call to function 'AudioRecorder.record' has been rejected. → Caused by: Cannot use shared object that was already released` (127 events / 127 users).

The crash is at `recorder.record()` in `useAudioRecording.startRecording`:

```ts
const startRecording = useCallback(async () => {
  await recorder.prepareToRecordAsync();
  recorder.record();          // <-- crash
}, [recorder]);
```

`AudioRecorder` is a `SharedObject` created via expo-audio's `useReleasingSharedObject`, which calls `.release()` on the native object when the hook unmounts. `prepareToRecordAsync()` takes a moment on a real device, so if the recording screen is left during that await — i.e. **starting then leaving in quick succession** — the recorder is released before the awaited promise settles, and the subsequent `record()` runs against a released shared object and crashes.

This window is reachable in normal use: `usePreventBackButtonWhileRecording` only blocks back-navigation once recording has started (`shouldPrevent: !isLoading`), so the user can leave the screen during the prepare/loading phase.

## Fix

Track whether the hook is still mounted and skip `record()` if it was torn down during the `prepareToRecordAsync` await.

## Test

`useAudioRecording.test.tsx` reproduces the timing window at the hook level (an e2e test would be flaky for a race this tight): a deferred `prepareToRecordAsync` is started, the hook is unmounted, then the promise resolves — and we assert `record()` is **not** called on the released recorder. A second test asserts the happy path still records. Verified the regression test fails without the guard and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)