### PR TITLE
fix: ensure a default project is activated after leaving a project

### DIFF
--- a/src/frontend/hooks/server/useEnsureDefaultProject.test.tsx
+++ b/src/frontend/hooks/server/useEnsureDefaultProject.test.tsx
@@ -1,0 +1,136 @@
+import {renderHook} from '@testing-library/react-native';
+import type {MapeoManager} from '@comapeo/core';
+import type {MapeoClientApi} from '@comapeo/ipc';
+import React, {type ReactNode} from 'react';
+
+import {useEnsureDefaultProject} from './useEnsureDefaultProject';
+import {
+  createManager,
+  setUpIPC,
+} from '../../../../tests/integration/helpers/core';
+import {MapeoApiWrapper} from '../../../../tests/integration/helpers/MapeoApiWrapper';
+
+function createWrapper(client: MapeoClientApi) {
+  return ({children}: {children: ReactNode}) => {
+    return <MapeoApiWrapper mapeoApi={client}>{children}</MapeoApiWrapper>;
+  };
+}
+
+function renderEnsureDefaultProject(client: MapeoClientApi) {
+  const {result} = renderHook(() => useEnsureDefaultProject(), {
+    wrapper: createWrapper(client),
+  });
+  return result.current;
+}
+
+function createFailingCreateClient(client: MapeoClientApi): MapeoClientApi {
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop === 'createProject') {
+        return () => Promise.reject(new Error('create failed'));
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+describe('useEnsureDefaultProject', () => {
+  let manager: MapeoManager;
+  let client: MapeoClientApi;
+  let onTeardown: Array<() => unknown> = [];
+
+  beforeEach(async () => {
+    onTeardown = [];
+
+    const managerSetup = await createManager({
+      name: 'test',
+      deviceType: 'mobile',
+    });
+    ({manager} = managerSetup);
+    const {fastifyController} = managerSetup;
+
+    const ipcSetup = setUpIPC({manager});
+    ({client} = ipcSetup);
+    const {stop} = ipcSetup;
+    onTeardown.push(stop);
+
+    await fastifyController.start();
+    onTeardown.push(() => fastifyController.stop());
+  });
+
+  afterEach(async () => {
+    for (const fn of onTeardown) await fn();
+  });
+
+  test('returns the existing default (unnamed) project without creating one', async () => {
+    const namedProjectId = await client.createProject({name: 'named project'});
+    const defaultProjectId = await client.createProject();
+    expect(namedProjectId).not.toEqual(defaultProjectId);
+
+    const ensureDefaultProject = renderEnsureDefaultProject(client);
+
+    await expect(ensureDefaultProject()).resolves.toEqual(defaultProjectId);
+
+    const projects = await client.listProjects();
+    expect(projects).toHaveLength(2);
+  });
+
+  test('creates a default project when none exists', async () => {
+    await client.createProject({name: 'named project'});
+
+    const ensureDefaultProject = renderEnsureDefaultProject(client);
+
+    const result = await ensureDefaultProject();
+
+    const projects = await client.listProjects();
+    expect(projects).toHaveLength(2);
+    const unnamed = projects.filter(project => !project.name);
+    expect(unnamed).toHaveLength(1);
+    expect(result).toEqual(unnamed[0]!.projectId);
+  });
+
+  test('ignores the excluded project when looking for the default', async () => {
+    const excludedId = await client.createProject();
+
+    const ensureDefaultProject = renderEnsureDefaultProject(client);
+
+    const result = await ensureDefaultProject({excludeProjectId: excludedId});
+
+    expect(result).not.toEqual(excludedId);
+    const projects = await client.listProjects();
+    expect(projects).toHaveLength(2);
+  });
+
+  test('concurrent calls create exactly one project', async () => {
+    const ensureDefaultProject = renderEnsureDefaultProject(client);
+
+    const [first, second, third] = await Promise.all([
+      ensureDefaultProject(),
+      ensureDefaultProject(),
+      ensureDefaultProject(),
+    ]);
+
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    const projects = await client.listProjects();
+    expect(projects).toHaveLength(1);
+  });
+
+  test('falls back to another joined project if creation fails', async () => {
+    const namedProjectId = await client.createProject({name: 'named project'});
+
+    const ensureDefaultProject = renderEnsureDefaultProject(
+      createFailingCreateClient(client),
+    );
+
+    await expect(ensureDefaultProject()).resolves.toEqual(namedProjectId);
+  });
+
+  test('rejects if creation fails and no other project exists', async () => {
+    const ensureDefaultProject = renderEnsureDefaultProject(
+      createFailingCreateClient(client),
+    );
+
+    await expect(ensureDefaultProject()).rejects.toThrow('create failed');
+  });
+});

--- a/src/frontend/hooks/server/useEnsureDefaultProject.ts
+++ b/src/frontend/hooks/server/useEnsureDefaultProject.ts
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import {useClientApi} from '@comapeo/core-react';
+import type {MapeoClientApi} from '@comapeo/ipc';
+import {QueryClient, useQueryClient} from '@tanstack/react-query';
+
+// Matches @comapeo/core-react's getProjectsQueryKey(), which is not exported
+const PROJECTS_QUERY_KEY = ['@comapeo/core-react', 'projects'];
+
+// Shared across all callers so that concurrent "no default project exists"
+// checks result in exactly one project being created (see issue #1940)
+const inFlightCreates = new WeakMap<MapeoClientApi, Promise<string>>();
+
+export type EnsureDefaultProjectOptions = {
+  /**
+   * Project to ignore when looking for a project to switch to, e.g. the
+   * project currently being left.
+   */
+  excludeProjectId?: string;
+};
+
+/**
+ * Returns the ID of the project that should become (or stay) the active
+ * project when the current one is left or removed: the default (unnamed)
+ * project if one exists, otherwise a newly created one, falling back to any
+ * other joined project if creation fails. Reads a fresh project list rather
+ * than the query cache, so it is safe to call from mutation callbacks.
+ */
+export function useEnsureDefaultProject(): (
+  opts?: EnsureDefaultProjectOptions,
+) => Promise<string> {
+  const clientApi = useClientApi();
+  const queryClient = useQueryClient();
+
+  return React.useCallback(
+    (opts: EnsureDefaultProjectOptions = {}) =>
+      ensureDefaultProject({clientApi, queryClient, ...opts}),
+    [clientApi, queryClient],
+  );
+}
+
+async function ensureDefaultProject({
+  clientApi,
+  queryClient,
+  excludeProjectId,
+}: {
+  clientApi: MapeoClientApi;
+  queryClient: QueryClient;
+} & EnsureDefaultProjectOptions): Promise<string> {
+  const projects = await clientApi.listProjects();
+  const candidates = projects.filter(
+    project =>
+      project.status === 'joined' && project.projectId !== excludeProjectId,
+  );
+
+  const existingDefault = candidates.find(project => !project.name);
+  if (existingDefault) return existingDefault.projectId;
+
+  let createPromise = inFlightCreates.get(clientApi);
+  if (!createPromise) {
+    createPromise = clientApi.createProject().finally(() => {
+      inFlightCreates.delete(clientApi);
+    });
+    inFlightCreates.set(clientApi, createPromise);
+  }
+
+  try {
+    return await createPromise;
+  } catch (err) {
+    const fallback = candidates[0];
+    if (fallback) return fallback.projectId;
+    throw err;
+  } finally {
+    queryClient.invalidateQueries({queryKey: PROJECTS_QUERY_KEY});
+  }
+}

--- a/src/frontend/screens/YourTeam/LeaveProject.test.tsx
+++ b/src/frontend/screens/YourTeam/LeaveProject.test.tsx
@@ -1,0 +1,177 @@
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '@testing-library/react-native';
+import type {MapeoManager} from '@comapeo/core';
+import type {MapeoClientApi} from '@comapeo/ipc';
+import {NavigationContainer} from '@react-navigation/native';
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import React from 'react';
+import {Text} from 'react-native';
+
+import {
+  createManager,
+  setUpIPC,
+} from '../../../../tests/integration/helpers/core';
+import {createAppProvidersWrapper} from '../../../../tests/integration/helpers/react';
+import {sleep} from '../../lib/sleep';
+import {ActiveProjectProvider} from '../../contexts/ActiveProjectContext';
+import {useActiveProjectId} from '../../contexts/ActiveProjectIdStoreContext';
+import type {AppStackParamsList} from '../../sharedTypes/navigation';
+import {LeaveProject} from './LeaveProject';
+
+const Stack =
+  createNativeStackNavigator<
+    Pick<
+      AppStackParamsList,
+      'LeaveProject' | 'Home' | 'LeftProjectConfirmation' | 'ErrorBottomSheet'
+    >
+  >();
+
+function ActiveProjectIdProbe() {
+  const activeProjectId = useActiveProjectId();
+  return <Text>{`active:${activeProjectId}`}</Text>;
+}
+
+function LeftProjectConfirmationScreen() {
+  return (
+    <>
+      <Text>Left project confirmation</Text>
+      <ActiveProjectIdProbe />
+    </>
+  );
+}
+
+function HomeScreen() {
+  return <Text>Home</Text>;
+}
+
+function ErrorBottomSheetScreen() {
+  return <Text>Error bottom sheet</Text>;
+}
+
+describe('LeaveProject', () => {
+  let manager: MapeoManager;
+  let client: MapeoClientApi;
+  let onTeardown: Array<() => unknown> = [];
+
+  beforeEach(async () => {
+    onTeardown = [];
+
+    const managerSetup = await createManager({
+      name: 'test',
+      deviceType: 'mobile',
+    });
+    ({manager} = managerSetup);
+    const {fastifyController} = managerSetup;
+
+    const ipcSetup = setUpIPC({manager});
+    ({client} = ipcSetup);
+    const {stop} = ipcSetup;
+    onTeardown.push(stop);
+
+    await fastifyController.start();
+    onTeardown.push(() => fastifyController.stop());
+  });
+
+  afterEach(async () => {
+    for (const fn of onTeardown) await fn();
+  });
+
+  function renderLeaveProjectScreen({
+    activeProjectId,
+  }: Readonly<{activeProjectId: string}>) {
+    const appProviders = createAppProvidersWrapper({
+      mapeoApi: client,
+      activeProjectId,
+    });
+    onTeardown.push(appProviders.teardown);
+
+    const {unmount} = render(
+      <React.Suspense fallback={null}>
+        <ActiveProjectProvider activeProjectId={activeProjectId}>
+          <NavigationContainer>
+            <Stack.Navigator>
+              <Stack.Screen
+                name="LeaveProject"
+                component={LeaveProject}
+                initialParams={{memberType: 'participant'}}
+              />
+              <Stack.Screen name="Home" component={HomeScreen} />
+              <Stack.Screen
+                name="LeftProjectConfirmation"
+                component={LeftProjectConfirmationScreen}
+              />
+              <Stack.Screen
+                name="ErrorBottomSheet"
+                component={ErrorBottomSheetScreen}
+              />
+            </Stack.Navigator>
+          </NavigationContainer>
+        </ActiveProjectProvider>
+      </React.Suspense>,
+      {
+        wrapper: appProviders.wrapper,
+      },
+    );
+
+    // Unmount before tearing down the RPC server, so that in-flight RPC
+    // requests from mounted components don't hold the test process open
+    // (same workaround as in the Exchange screen tests)
+    onTeardown.unshift(async () => {
+      unmount();
+      await sleep(0);
+    });
+  }
+
+  test('leaving switches the active project to the existing default project', async () => {
+    const projectToLeaveId = await client.createProject({
+      name: 'shared project',
+    });
+    const defaultProjectId = await client.createProject();
+
+    renderLeaveProjectScreen({activeProjectId: projectToLeaveId});
+
+    const user = userEvent.setup();
+    await user.press(await screen.findByText('Yes, Leave'));
+
+    await expect(
+      screen.findByText('Left project confirmation'),
+    ).resolves.toBeVisible();
+    await expect(
+      screen.findByText(`active:${defaultProjectId}`),
+    ).resolves.toBeVisible();
+
+    await waitFor(async () => {
+      const projects = await client.listProjects();
+      expect(projects.map(p => p.projectId)).not.toContain(projectToLeaveId);
+    });
+  });
+
+  test('leaving creates a default project when none exists, instead of staying on the left project', async () => {
+    const projectToLeaveId = await client.createProject({
+      name: 'shared project',
+    });
+
+    renderLeaveProjectScreen({activeProjectId: projectToLeaveId});
+
+    const user = userEvent.setup();
+    await user.press(await screen.findByText('Yes, Leave'));
+
+    await expect(
+      screen.findByText('Left project confirmation'),
+    ).resolves.toBeVisible();
+
+    const projects = await client.listProjects();
+    expect(projects).toHaveLength(1);
+    const newDefault = projects[0]!;
+    expect(newDefault.name).toBeUndefined();
+    expect(newDefault.projectId).not.toEqual(projectToLeaveId);
+
+    await expect(
+      screen.findByText(`active:${newDefault.projectId}`),
+    ).resolves.toBeVisible();
+  });
+});

--- a/src/frontend/screens/YourTeam/LeaveProject.tsx
+++ b/src/frontend/screens/YourTeam/LeaveProject.tsx
@@ -11,9 +11,10 @@ import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {BLUE_GREY} from '../../lib/styles';
 import MaterialDesignIcons from '@react-native-vector-icons/material-design-icons';
-import {useLeaveProject, useManyProjects} from '@comapeo/core-react';
+import {useClientApi, useLeaveProject} from '@comapeo/core-react';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useProjectSettings} from '../../hooks/server/projects';
+import {useEnsureDefaultProject} from '../../hooks/server/useEnsureDefaultProject';
 import {useActiveProjectIdActions} from '../../contexts/ActiveProjectIdStoreContext';
 import * as Sentry from '@sentry/react-native';
 import {UIActivityIndicator} from 'react-native-indicators';
@@ -53,45 +54,64 @@ export const LeaveProject = ({
   const {data: projectSettings} = useProjectSettings();
   const leaveProject = useLeaveProject();
   const {setActiveProjectId} = useActiveProjectIdActions();
-  const {data: projects} = useManyProjects();
+  const ensureDefaultProject = useEnsureDefaultProject();
+  const clientApi = useClientApi();
+  const [isFinalizing, setIsFinalizing] = React.useState(false);
 
   const isCoordinator = route.params.memberType === 'coordinator';
+
+  async function finalizeLeave() {
+    try {
+      const defaultProjectId = await ensureDefaultProject({
+        excludeProjectId: projectId,
+      });
+      setActiveProjectId(defaultProjectId);
+      // Reset (rather than replace) so that no screen with queries
+      // scoped to the left project stays mounted — refetching them
+      // errors because leaving closes the project's data stores.
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 1,
+          routes: [
+            {name: 'Home'},
+            {
+              name: 'LeftProjectConfirmation',
+              params: {projectName: projectSettings.name ?? ''},
+            },
+          ],
+        }),
+      );
+    } catch (err) {
+      setIsFinalizing(false);
+      Sentry.captureException(err);
+      navigation.replace('ErrorBottomSheet', {
+        error: toError(err, 'Error updating active project'),
+      });
+    }
+  }
 
   function handleLeaveProject() {
     leaveProject.mutate(
       {projectId},
       {
         onSuccess: () => {
-          try {
-            const defaultProject = projects?.find(
-              project => project.name === undefined,
-            );
-            if (defaultProject?.projectId) {
-              setActiveProjectId(defaultProject.projectId);
-            }
-            // Reset (rather than replace) so that no screen with queries
-            // scoped to the left project stays mounted — refetching them
-            // errors because leaving closes the project's data stores.
-            navigation.dispatch(
-              CommonActions.reset({
-                index: 1,
-                routes: [
-                  {name: 'Home'},
-                  {
-                    name: 'LeftProjectConfirmation',
-                    params: {projectName: projectSettings.name ?? ''},
-                  },
-                ],
-              }),
-            );
-          } catch (err) {
-            Sentry.captureException(err);
-            navigation.replace('ErrorBottomSheet', {
-              error: toError(err, 'Error updating active project'),
-            });
-          }
+          setIsFinalizing(true);
+          finalizeLeave();
         },
-        onError: err => {
+        onError: async err => {
+          // Core marks the project left locally before waiting for sync, so a
+          // sync timeout can reject after the project has actually been left.
+          setIsFinalizing(true);
+          const wasActuallyLeft = await clientApi.listProjects().then(
+            projects =>
+              !projects.some(project => project.projectId === projectId),
+            () => false,
+          );
+          if (wasActuallyLeft) {
+            finalizeLeave();
+            return;
+          }
+          setIsFinalizing(false);
           Sentry.captureException(err);
           navigation.replace('ErrorBottomSheet', {error: err});
         },
@@ -119,7 +139,7 @@ export const LeaveProject = ({
       </View>
 
       <View style={styles.buttons}>
-        {leaveProject.status === 'pending' ? (
+        {leaveProject.status === 'pending' || isFinalizing ? (
           <UIActivityIndicator style={{marginVertical: 20}} />
         ) : (
           <>


### PR DESCRIPTION
## Description

Fixes #1939.

Leaving a project looked up the default (unnamed) project in a render-time snapshot of `useManyProjects` and silently skipped `setActiveProjectId` when none was found, leaving the app wedged on the left project — whose data stores are closed and which no longer appears in `listProjects()`. Relaunching didn't recover, because the active-project store's fallback only runs when no project ID is persisted.

### Changes

- New `useEnsureDefaultProject` hook: resolves the project that should become active from a **fresh** `listProjects()` call at decision time — existing unnamed project → create one → fall back to any other joined project if creation fails. Concurrent callers share a single in-flight create (one project max), which the follow-up PR for #1940 relies on.
- `LeaveProject` now uses it, so there is always a valid project to switch to (or a visible error), never a silent no-op.
- `LeaveProject` also recovers when core's `leaveProject` rejects with a sync timeout *after* the project has already been marked left locally (core persists `hasLeftProject` and deletes settings before waiting up to 45s for sync): on mutation error it re-checks `listProjects()` and runs the normal success path if the project is actually gone.

### Tests

- `useEnsureDefaultProject` hook tests (real `MapeoManager` over IPC): finds existing default, creates when missing, respects `excludeProjectId`, dedupes concurrent calls, falls back on creation failure, rejects when nothing is left to fall back to.
- `LeaveProject` component tests: leaving switches to the existing default; regression test that leaving with **no** default creates one and navigates instead of staying wedged on the left project.

> Stacked on #1938 (base branch `fix/leave-project-stale-queries`). Follow-up: duplicate-default-projects fix for #1940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
