### PR TITLE
fix: prevent duplicate default projects from unguarded creation races

### DIFF
--- a/src/frontend/hooks/server/useEnsureDefaultProject.test.tsx
+++ b/src/frontend/hooks/server/useEnsureDefaultProject.test.tsx
@@ -116,6 +116,22 @@ describe('useEnsureDefaultProject', () => {
     expect(projects).toHaveLength(1);
   });
 
+  // Regression test for #1940: e.g. the invite-accept flow and the
+  // removed-from-project flow each deciding to create a default project
+  test('concurrent calls from separately mounted components create exactly one project', async () => {
+    const ensureFromComponentA = renderEnsureDefaultProject(client);
+    const ensureFromComponentB = renderEnsureDefaultProject(client);
+
+    const [first, second] = await Promise.all([
+      ensureFromComponentA(),
+      ensureFromComponentB(),
+    ]);
+
+    expect(second).toEqual(first);
+    const projects = await client.listProjects();
+    expect(projects).toHaveLength(1);
+  });
+
   test('falls back to another joined project if creation fails', async () => {
     const namedProjectId = await client.createProject({name: 'named project'});
 

--- a/src/frontend/screens/Invites/InviteReceived.tsx
+++ b/src/frontend/screens/Invites/InviteReceived.tsx
@@ -7,9 +7,8 @@ import {
   useAcceptInvite,
   useRejectInvite,
   useSingleInvite,
-  useCreateProject,
-  useManyProjects,
 } from '@comapeo/core-react';
+import {useEnsureDefaultProject} from '../../hooks/server/useEnsureDefaultProject';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
 import {UIActivityIndicator} from 'react-native-indicators';
@@ -64,11 +63,8 @@ export const InviteReceived = ({
 
   const acceptInvite = useAcceptInvite();
   const rejectInvite = useRejectInvite();
-  const createProject = useCreateProject();
+  const ensureDefaultProject = useEnsureDefaultProject();
   const {isTracking} = useTracking();
-  const {data: allProjects} = useManyProjects();
-
-  const hasDefaultProject = allProjects.some(proj => !proj.name);
 
   const projectColor = invite.projectColor;
   const statsShared = invite.sendStats;
@@ -85,13 +81,11 @@ export const InviteReceived = ({
       {inviteId: inviteId},
       {
         onSuccess: projectId => {
-          if (!hasDefaultProject) {
-            createProject.mutate(undefined, {
-              onError: err => {
-                Sentry.captureException(err);
-              },
-            });
-          }
+          // The user should ALWAYS have a default (solo) project. This was
+          // not implemented until after v6, so create one if it is missing
+          ensureDefaultProject({excludeProjectId: projectId}).catch(err => {
+            Sentry.captureException(err);
+          });
           navigation.reset({
             index: 1,
             routes: [

--- a/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/index.tsx
+++ b/src/frontend/screens/ProjectCreation/CreateOrNameSoloProject/index.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {useCreateProject, useUpdateProjectSettings} from '@comapeo/core-react';
+import {useEnsureDefaultProject} from '../../../hooks/server/useEnsureDefaultProject';
 import {HookFormTextInput} from '../../../sharedComponents/HookFormTextInput';
 import {NativeRootNavigationProps} from '../../../sharedTypes/navigation';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
@@ -82,6 +83,7 @@ export const CreateOrNameSoloProject = ({
 
   const {setActiveProjectId} = useActiveProjectIdActions();
   const createProjectMutation = useCreateProject();
+  const ensureDefaultProject = useEnsureDefaultProject();
   const {projectId} = useActiveProject();
   const updateSettingsMutation = useUpdateProjectSettings({
     projectId: projectId,
@@ -130,10 +132,12 @@ export const CreateOrNameSoloProject = ({
         {name: projectName},
         {
           onSuccess: () => {
-            createProjectMutation.mutate(undefined, {
-              onError: err => {
-                Sentry.captureException(err);
-              },
+            // Naming the solo project means there is no longer an unnamed
+            // (default) project, so create a new one to take its place.
+            // Exclude the renamed project in case the rename is not yet
+            // reflected in listProjects()
+            ensureDefaultProject({excludeProjectId: projectId}).catch(err => {
+              Sentry.captureException(err);
             });
 
             navigation.replace('ShareProjectStats', {

--- a/src/frontend/screens/RemovedFromProjectBottomSheet.test.tsx
+++ b/src/frontend/screens/RemovedFromProjectBottomSheet.test.tsx
@@ -1,0 +1,173 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import type {MapeoManager} from '@comapeo/core';
+import type {MapeoClientApi} from '@comapeo/ipc';
+import {NavigationContainer} from '@react-navigation/native';
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import React from 'react';
+import {Text} from 'react-native';
+
+import {createManager, setUpIPC} from '../../../tests/integration/helpers/core';
+import {createAppProvidersWrapper} from '../../../tests/integration/helpers/react';
+import {sleep} from '../lib/sleep';
+import {ActiveProjectProvider} from '../contexts/ActiveProjectContext';
+import {useActiveProjectId} from '../contexts/ActiveProjectIdStoreContext';
+import type {AppStackParamsList} from '../sharedTypes/navigation';
+import {RemovedFromProjectBottomSheet} from './RemovedFromProjectBottomSheet';
+
+const Stack =
+  createNativeStackNavigator<
+    Pick<
+      AppStackParamsList,
+      'Home' | 'RemovedFromProjectBottomSheet' | 'ErrorBottomSheet'
+    >
+  >();
+
+function ActiveProjectIdProbe() {
+  const activeProjectId = useActiveProjectId();
+  return <Text>{`active:${activeProjectId}`}</Text>;
+}
+
+function HomeScreen() {
+  return (
+    <>
+      <Text>Home</Text>
+      <ActiveProjectIdProbe />
+    </>
+  );
+}
+
+function ErrorBottomSheetScreen() {
+  return <Text>Error bottom sheet</Text>;
+}
+
+describe('RemovedFromProjectBottomSheet', () => {
+  let manager: MapeoManager;
+  let client: MapeoClientApi;
+  let onTeardown: Array<() => unknown> = [];
+
+  beforeEach(async () => {
+    onTeardown = [];
+
+    const managerSetup = await createManager({
+      name: 'test',
+      deviceType: 'mobile',
+    });
+    ({manager} = managerSetup);
+    const {fastifyController} = managerSetup;
+
+    const ipcSetup = setUpIPC({manager});
+    ({client} = ipcSetup);
+    const {stop} = ipcSetup;
+    onTeardown.push(stop);
+
+    await fastifyController.start();
+    onTeardown.push(() => fastifyController.stop());
+  });
+
+  afterEach(async () => {
+    for (const fn of onTeardown) await fn();
+  });
+
+  function renderRemovedBottomSheet({
+    activeProjectId,
+  }: Readonly<{activeProjectId: string}>) {
+    const appProviders = createAppProvidersWrapper({
+      mapeoApi: client,
+      activeProjectId,
+    });
+    onTeardown.push(appProviders.teardown);
+
+    const {unmount} = render(
+      <React.Suspense fallback={null}>
+        <ActiveProjectProvider activeProjectId={activeProjectId}>
+          {/* Same stack shape as ProjectRemovalListener's reset dispatch */}
+          <NavigationContainer
+            initialState={{
+              routes: [{name: 'Home'}, {name: 'RemovedFromProjectBottomSheet'}],
+              index: 1,
+            }}>
+            <Stack.Navigator>
+              <Stack.Screen name="Home" component={HomeScreen} />
+              <Stack.Screen
+                name="RemovedFromProjectBottomSheet"
+                component={RemovedFromProjectBottomSheet}
+              />
+              <Stack.Screen
+                name="ErrorBottomSheet"
+                component={ErrorBottomSheetScreen}
+              />
+            </Stack.Navigator>
+          </NavigationContainer>
+        </ActiveProjectProvider>
+      </React.Suspense>,
+      {
+        wrapper: appProviders.wrapper,
+      },
+    );
+
+    // Unmount before tearing down the RPC server, so that in-flight RPC
+    // requests from mounted components don't hold the test process open
+    // (same workaround as in the Exchange screen tests)
+    onTeardown.unshift(async () => {
+      unmount();
+      await sleep(0);
+    });
+  }
+
+  test('closing switches the active project to the existing default project', async () => {
+    const removedProjectId = await client.createProject({
+      name: 'removed project',
+    });
+    const defaultProjectId = await client.createProject();
+
+    renderRemovedBottomSheet({activeProjectId: removedProjectId});
+
+    const closeButton = await screen.findByText('Close');
+    fireEvent.press(closeButton);
+
+    await expect(
+      screen.findByText(`active:${defaultProjectId}`),
+    ).resolves.toBeVisible();
+
+    await waitFor(async () => {
+      const projects = await client.listProjects();
+      expect(projects.map(p => p.projectId)).not.toContain(removedProjectId);
+    });
+  });
+
+  test('double-tapping Close creates at most one default project', async () => {
+    const removedProjectId = await client.createProject({
+      name: 'removed project',
+    });
+
+    renderRemovedBottomSheet({activeProjectId: removedProjectId});
+
+    const closeButton = await screen.findByText('Close');
+    // Two presses can land before the re-render that hides the button (#1940).
+    // Both presses go in one act() block so no re-render happens between
+    // them, like a real double-tap on a busy JS thread
+    act(() => {
+      fireEvent.press(closeButton);
+      fireEvent.press(closeButton);
+    });
+
+    await waitFor(
+      async () => {
+        const projects = await client.listProjects();
+        expect(projects.map(p => p.projectId)).not.toContain(removedProjectId);
+        const unnamed = projects.filter(project => !project.name);
+        expect(unnamed).toHaveLength(1);
+        expect(projects).toHaveLength(1);
+      },
+      {timeout: 10_000},
+    );
+
+    await expect(screen.findByText(/^active:/)).resolves.toBeVisible();
+  });
+});

--- a/src/frontend/screens/RemovedFromProjectBottomSheet.tsx
+++ b/src/frontend/screens/RemovedFromProjectBottomSheet.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {BottomSheetWrapper} from '../sharedComponents/BottomSheetWrapper';
 import {StyleSheet, View} from 'react-native';
 import {SecondaryButton} from '../sharedComponents/Buttons';
@@ -6,14 +7,14 @@ import {NativeRootNavigationProps} from '../sharedTypes/navigation';
 import {HeaderText} from '../sharedComponents/Text/HeaderText';
 import {BLACK} from '../lib/styles';
 import {
-  useCreateProject,
   useLeaveProject,
-  useManyProjects,
   useOwnRoleInProject,
   useProjectSettings,
 } from '@comapeo/core-react';
+import * as Sentry from '@sentry/react-native';
 import {useActiveProject} from '../contexts/ActiveProjectContext';
 import {useActiveProjectIdActions} from '../contexts/ActiveProjectIdStoreContext';
+import {useEnsureDefaultProject} from '../hooks/server/useEnsureDefaultProject';
 import {UIActivityIndicator} from 'react-native-indicators';
 import {ColorCard} from '../sharedComponents/ColorCard';
 import {DEFAULT_PROJECT_COLOR} from '../constants';
@@ -45,11 +46,45 @@ export const RemovedFromProjectBottomSheet = ({
   const {
     data: {name, projectColor},
   } = useProjectSettings({projectId});
-  const {data: projects} = useManyProjects();
-  const defaultProject = projects.find(proj => !proj.name);
   const {setActiveProjectId} = useActiveProjectIdActions();
-  const createProject = useCreateProject();
+  const ensureDefaultProject = useEnsureDefaultProject();
   const leaveProject = useLeaveProject();
+  const [isFinalizing, setIsFinalizing] = React.useState(false);
+  // Guards against a second tap landing before the re-render that hides the
+  // button — each tap would otherwise leave and create a project (#1940)
+  const hasPressedRef = React.useRef(false);
+
+  function handleClose() {
+    if (hasPressedRef.current) return;
+    hasPressedRef.current = true;
+    leaveProject.mutate(
+      {projectId},
+      {
+        onSuccess: async () => {
+          setIsFinalizing(true);
+          try {
+            const defaultProjectId = await ensureDefaultProject({
+              excludeProjectId: projectId,
+            });
+            setActiveProjectId(defaultProjectId);
+            navigation.popToTop();
+          } catch (err) {
+            hasPressedRef.current = false;
+            setIsFinalizing(false);
+            Sentry.captureException(err);
+            navigation.navigate('ErrorBottomSheet', {
+              error: toError(err, 'Error creating default project'),
+            });
+          }
+        },
+        onError: err => {
+          hasPressedRef.current = false;
+          Sentry.captureException(err);
+          navigation.navigate('ErrorBottomSheet', {error: err});
+        },
+      },
+    );
+  }
 
   return (
     <BottomSheetWrapper>
@@ -72,47 +107,12 @@ export const RemovedFromProjectBottomSheet = ({
         </ColorCard>
 
         <View style={styles.buttonContainer}>
-          {leaveProject.status === 'pending' ||
-          createProject.status === 'pending' ? (
+          {leaveProject.status === 'pending' || isFinalizing ? (
             <UIActivityIndicator style={{margin: 20}} />
           ) : (
             <SecondaryButton
               fullSize
-              onPress={() => {
-                leaveProject.mutate(
-                  {projectId},
-                  {
-                    onSuccess: () => {
-                      if (!defaultProject) {
-                        // The user should ALWAYS have a default (solo) project. This was not implemented until after v6. So this creates one if it does not exist
-                        createProject.mutate(undefined, {
-                          onError: err => {
-                            const firstProject = projects[0];
-                            if (firstProject) {
-                              setActiveProjectId(firstProject.projectId);
-                              navigation.popToTop();
-                              return;
-                            }
-                            navigation.navigate('ErrorBottomSheet', {
-                              error: toError(
-                                err,
-                                'Error creating default project',
-                              ),
-                            });
-                          },
-                          onSuccess: newDefaultProjectId => {
-                            setActiveProjectId(newDefaultProjectId);
-                            navigation.popToTop();
-                          },
-                        });
-                        return;
-                      }
-                      setActiveProjectId(defaultProject.projectId);
-                      navigation.popToTop();
-                    },
-                  },
-                );
-              }}
+              onPress={handleClose}
               text={formatMessage(m.close)}
             />
           )}

--- a/src/frontend/sharedComponents/ProjectRemovalListener.tsx
+++ b/src/frontend/sharedComponents/ProjectRemovalListener.tsx
@@ -53,7 +53,12 @@ export const ProjectRemovalListener = () => {
 
   React.useEffect(() => {
     function handleRoleChange(event: RoleChangeEvent) {
-      if (event.role.roleId === BLOCKED_ROLE_ID) {
+      // Re-dispatching while the bottom sheet is open would remount it,
+      // discarding any in-progress leave and re-enabling its button (#1940)
+      if (
+        event.role.roleId === BLOCKED_ROLE_ID &&
+        currentRouteName !== 'RemovedFromProjectBottomSheet'
+      ) {
         dispatchToRemovedProjectBottomSheet();
       }
     }
@@ -63,7 +68,7 @@ export const ProjectRemovalListener = () => {
     return () => {
       projectApi.removeListener('own-role-change', handleRoleChange);
     };
-  }, [projectApi, dispatchToRemovedProjectBottomSheet]);
+  }, [projectApi, dispatchToRemovedProjectBottomSheet, currentRouteName]);
 
   return null;
 };


### PR DESCRIPTION
## Description

Fixes #1940.

We have seen duplicate default (unnamed) projects in production testing. Every place that lazily created the default project checked a render-time snapshot of the project list and fired `createProject` without awaiting it, so concurrent flows could each decide "no default exists" and create one — e.g. the invite-accept flow's unawaited create racing the removed-from-project flow, or sequential invite sheets reading a stale cache while the first create was still in flight. Project creation is slow (keypair + project instance + default config import), so these windows are seconds wide on low-end devices.

### Changes

All lazy default-project creation now goes through `useEnsureDefaultProject` (from #1941), which checks a fresh `listProjects()` at call time and shares one in-flight create across all callers:

- `RemovedFromProjectBottomSheet`: replaces the inline find/create logic. Also adds the missing `onError` for the leave mutation (failures were silent), and the creation-failure fallback can no longer re-activate the project the user was just removed from (the helper excludes it; previously it fell back to a stale `projects[0]`).
- `InviteReceived`: replaces the render-time `hasDefaultProject` check + fire-and-forget create.
- `CreateOrNameSoloProject` (name-solo flow): replaces the fire-and-forget create after renaming the solo project.
- `ProjectRemovalListener`: the `own-role-change` event path now guards on the current route like the initial-check effect, so a repeat role-change event can't remount the bottom sheet and discard an in-progress leave (which left the user stuck with a re-enabled button).
- The sheet's Close button is guarded against double-taps landing before the disabling re-render.

### Tests

- Hook-level regression test: concurrent `ensureDefaultProject` calls from separately mounted components create exactly one project (the cross-flow race that produced the production duplicates).
- `RemovedFromProjectBottomSheet` component tests (real `MapeoManager` over IPC): closing switches to the existing default project and leaves the removed project; double-tapping Close creates at most one default project.

One investigation note: a same-component double-tap alone did *not* duplicate in the old code — React Query only fires mutate-level callbacks for the latest `mutate()` call on an observer — so the cross-component race above is the production-relevant path; the double-tap guard is belt-and-braces.

> Stacked on #1941 (base branch `fix/ensure-default-project-on-leave`), which is itself stacked on #1938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
