### PR TITLE
fix: duplicate option label bleeds into other selectOne fields

### DIFF
--- a/src/frontend/screens/ObservationFields/SelectMultiple.tsx
+++ b/src/frontend/screens/ObservationFields/SelectMultiple.tsx
@@ -60,7 +60,7 @@ export const SelectMultiple = React.memo<Props>(({field}) => {
       <QuestionLabel field={field} />
       {field.options.map((item, index) => (
         <CheckItem
-          key={item.label}
+          key={`${item.value}-${index}`}
           onPress={() => handleChange(item.value)}
           checked={valueAsArray.includes(item.value)}
           label={item.label}

--- a/src/frontend/screens/ObservationFields/SelectOne.tsx
+++ b/src/frontend/screens/ObservationFields/SelectOne.tsx
@@ -49,7 +49,7 @@ export const SelectOne = React.memo<Props>(({field}) => {
       <QuestionLabel field={field} />
       {field.options.map((item, index) => (
         <RadioItem
-          key={item.label}
+          key={`${item.value}-${index}`}
           onPress={() => updateTag(field.tagKey, item.value)}
           checked={tags && item.value === tags[field.tagKey] ? true : false}
           label={item.label}


### PR DESCRIPTION
## Problem

A `selectOne`/`selectMultiple` field with two options sharing the same `label` (different `value`) causes the duplicated option to bleed into *other* `selectOne` fields opened after it while paging through an observation's questions.

Reported against the config tooling in digidem/comapeocat#49, but the root cause is in this app.

## Root cause

`ObservationFields/index.tsx` pages between questions with `navigation.popTo('ObservationFields', {question: n})` — the same route, so one screen instance is reused and `<Question>` re-renders with a different `field`. Each field's options list was keyed by `item.label`, so two options with the same label produced **duplicate React keys**. React then can't reconcile the previous field's list against the next field's, leaking a stale option element into a later field.

The config is valid (distinct `value`s); the bug is purely client-side rendering.

## Fix

Key options by `` `${item.value}-${index}` `` instead of `item.label` in `SelectOne.tsx` and `SelectMultiple.tsx`. Unique even if a config duplicates both label and value, and `index` is stable here since `field.options` never reorders.

Fixes #1946
Refs digidem/comapeocat#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)