### PR TITLE
fix: don't show the location "improve accuracy" dialog; handle its rejection

### DIFF
--- a/src/frontend/contexts/LocationContext.tsx
+++ b/src/frontend/contexts/LocationContext.tsx
@@ -115,14 +115,16 @@ function LocationProviderInitialized({
     const handleCheckAndStartWatchPosition = () => {
       if (!isMounted || locationSubscription) return;
 
-      startWatchPosition(store).then(sub => {
-        if (isMounted) {
-          locationSubscription = sub;
-        } else {
-          // If unmounted before promise resolves, clean up immediately
-          sub.remove();
-        }
-      });
+      startWatchPosition(store)
+        .then(sub => {
+          if (isMounted) {
+            locationSubscription = sub;
+          } else {
+            // If unmounted before promise resolves, clean up immediately
+            sub.remove();
+          }
+        })
+        .catch(Sentry.captureException);
     };
 
     const initialPermissionGranted =
@@ -178,6 +180,11 @@ function startWatchPosition(store: StoreApi<LocationState>) {
   return watchPositionAsync(
     {
       accuracy: Accuracy.BestForNavigation,
+      // Don't show Google Play Services' "improve location accuracy" dialog
+      // (only triggered when the network provider is off): it pushes a
+      // network/Wi-Fi-based accuracy mode that's useless offline, and if the
+      // user dismisses it, watching never starts. Use available providers (GPS).
+      mayShowUserSettingsDialog: false,
     },
     location => {
       store.setState(prev => ({...prev, location}));


### PR DESCRIPTION
## Sentry issue fixed

| Short ID | Title | Events | Link |
|---|---|---|---|
| COMAPEO-17N | Error: Location request failed due to unsatisfied device settings | 78 | https://awana-digital.sentry.io/issues/6292596512/ |

## What the "user settings dialog" is (and why this matters for offline users)

When you call `watchPositionAsync`, expo-location can show Google Play Services' **"improve location accuracy"** dialog. From the native code (`LocationModule.kt`):

```kotlin
if (hasNetworkProviderEnabled(ctx) || !showUserSettingsDialog) {
  requestContinuousUpdates(...)   // start watching with available providers (incl. GPS-only)
} else {
  // network provider OFF + dialog enabled → show the Play Services dialog;
  // on dismiss → reject AND never start location updates
}
```

So the dialog appears **only when the network (Wi-Fi/fused) location provider is off**, and it asks the user to turn on Google's *network-based* accuracy mode. For CoMapeo's offline, GPS-only users that mode is irrelevant — and, critically, **if they dismiss the dialog today, location watching never starts** and the call rejects with `LocationSettingsUnsatisfiedException` (the Sentry error).

## Root cause

`startWatchPosition` (`src/frontend/contexts/LocationContext.tsx`) called `watchPositionAsync` with only `accuracy` set (so `mayShowUserSettingsDialog` defaulted to `true`), and the effect started it with `…then(sub => …)` and **no `.catch`** — so a GPS-only user dismissing the dialog produced an unhandled rejection reported to Sentry.

## Fix

1. Pass **`mayShowUserSettingsDialog: false`**. expo then skips the dialog and starts location updates with whatever providers are available (GPS) — exactly what an offline GPS-only user wants. This also removes the rejection path entirely (that branch requires the dialog).
2. Add a `.catch(Sentry.captureException)` to the effect's promise chain as a safety net, so any future `watchPositionAsync` rejection can never again surface as an unhandled rejection.

This does **not** weaken GPS for offline users — the dialog was about Google's network accuracy mode, not GPS, and dismissing it was actively preventing location from starting.

## Residual risk

Low. GPS-on users are unaffected; offline GPS-only users now start location without a useless prompt.

Closes #1948
