### PR TITLE
fix: don't report expo-image disk-cache misses for photo storage size

### DIFF
--- a/src/frontend/lib/file-system.ts
+++ b/src/frontend/lib/file-system.ts
@@ -65,7 +65,7 @@ export async function selectFile({
  */
 export async function getExpoImageStorageSize(
   imageURL: string,
-): Promise<number> {
+): Promise<number | null> {
   let fileInfo: FileSystem.FileInfo;
 
   if (imageURL.startsWith('file://')) {
@@ -73,16 +73,14 @@ export async function getExpoImageStorageSize(
   } else {
     const cachePath = await ExpoImage.getCachePathAsync(imageURL);
 
-    if (!cachePath) {
-      throw new Error(`Could not get size for image at ${imageURL}`);
-    }
+    // null when the image isn't in expo-image's disk cache (served from memory,
+    // not yet written, or evicted) — a benign miss, not an error.
+    if (!cachePath) return null;
 
     fileInfo = await FileSystem.getInfoAsync(`file://${cachePath}`);
   }
 
-  if (!fileInfo.exists) {
-    throw new Error(`Could not get size for image at ${imageURL}`);
-  }
+  if (!fileInfo.exists) return null;
 
   return fileInfo.size;
 }

--- a/src/frontend/screens/PhotoPreviewModal/helpers.ts
+++ b/src/frontend/screens/PhotoPreviewModal/helpers.ts
@@ -194,7 +194,7 @@ export function useImageLoadInfo() {
       setImageLoadInfo({
         height: event.source.height,
         width: event.source.width,
-        storageSize,
+        storageSize: storageSize ?? undefined,
       });
     } catch (err) {
       captureException(err);


### PR DESCRIPTION
## Sentry issue fixed

| Short ID | Title | Events | Link |
|---|---|---|---|
| COMAPEO-20Z | Error: Could not get size for image at … | 1 | https://awana-digital.sentry.io/issues/7400012137/ |

## Root cause

`getExpoImageStorageSize` reads the photo size from expo-image's on-device **disk cache** (`getCachePathAsync`). For a blob-server URL that returns `null` on a disk-cache miss (image served from memory, not yet written, or evicted), so the function threw — and the only caller (`useImageLoadInfo`) caught it and reported to Sentry. The image rendered fine; only the optional storage-size label was affected.

## Fix

`getExpoImageStorageSize` returns `Promise<number | null>` — `null` on a cache miss / missing file instead of throwing. `useImageLoadInfo` treats `null` as "no storage size" (`storageSize ?? undefined`). The UI already guards on `storageSize` being a number, so it degrades cleanly.

## Follow-up: make the label always show

Returning `null` omits the label on a cache miss rather than showing a wrong value. Making it **always** show requires the blob server to send `Content-Length` (it currently sends only `Content-Type`), so the client can read the size directly. Tracked in:
- digidem/comapeo-core#1281 (blob server `Content-Length`)
- digidem/CoMapeo-mobile#1945 (read it so the label always shows)

Closes #1950
