### PR TITLE
fix: resilient startup permissions request (and don't get stuck on the splash)

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -216,7 +216,16 @@ const App = () => {
       'android.permission.CAMERA',
       'android.permission.ACCESS_FINE_LOCATION',
       'android.permission.ACCESS_COARSE_LOCATION',
-    ]).then(() => setPermissionsAsked(true));
+    ])
+      .catch(err => {
+        // Rejects when no Activity is attached (e.g. launched in the
+        // background)
+        Sentry.captureException(err);
+      })
+      // Always dismiss the splash, regardless of outcome — this startup ask
+      // is only an eager prompt; each feature re-requests its own permission
+      // on demand. Never gate splash dismissal on the request succeeding.
+      .finally(() => setPermissionsAsked(true));
   }, []);
 
   return (


### PR DESCRIPTION
## Sentry issue fixed

| Short ID | Title | Events | Link |
|---|---|---|---|
| COMAPEO-1AH | java.lang.IllegalStateException: Tried to use permissions API while not attached to an Activity | 8 | https://awana-digital.sentry.io/issues/6427694671/ |

## Root cause

`App`'s mount effect called `PermissionsAndroid.requestMultiple([...]).then(() => setPermissionsAsked(true))` with **no `.catch`**. When the effect runs with no Activity attached (app launched/resumed in the background, or the Activity is being recreated), RN rejects with `IllegalStateException: Tried to use permissions API while not attached to an Activity`. With no rejection handler this was an unhandled rejection — and, worse, `setPermissionsAsked(true)` never ran, so `AppNavigator` never called `SplashScreen.hide()` and the user was **stuck on the splash screen** until restart.

## Fix

Add `.catch(Sentry.captureException)` so the rejection is no longer unhandled, and `.finally(() => setPermissionsAsked(true))` so the splash always dismisses regardless of outcome.

### Why `setPermissionsAsked(true)` belongs in `finally()`, not `then()` only

`permissionsAsked` is **not** a record that "the OS permission dialog was shown" — it's a *"startup is done, the splash may hide"* latch. Its only consumer is `AppNavigator` (`if (permissionAsked) SplashScreen.hide()`); nothing reads it as "permissions were granted/asked." And in the failure case (no Activity), **no dialog is or can be shown anyway**. Crucially, every feature re-requests its own permission on demand — camera (`react-native-vision-camera` `useCameraPermission`), location (`expo-location` on each `AppState 'active'`), audio (`requestRecordingPermissionsAsync`) — so this startup ask is only an eager convenience, not load-bearing. Gating the latch on `then()` only would reintroduce the exact stuck-splash symptom of COMAPEO-1AH for the no-Activity population while gaining nothing.

## Residual risk

Low — the permission set is unchanged, and splash dismissal stays unconditional. Because each feature re-requests its own permission on demand, a startup ask that can't run (no Activity attached) is harmless: the relevant prompt appears when the user next reaches that feature.

---

_Note: the map view-tag `IllegalViewOperationException` (COMAPEO-1PD) that was previously bundled with this fix is handled separately (a `@maplibre/maplibre-react-native` patch), so it is not addressed here._


Closes #1952
