### PR TITLE
fix: export observations to a non-evictable dir; clear error on missing source

### DIFF
--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -94,6 +94,32 @@ export function useFindRemoteArchive({url}: {url?: string}) {
 // 'background' key prefix prevents passcode prompt during permission dialog (see AuthContext.tsx)
 const EXPORT_MUTATION_KEY = ['background', 'export', 'observations'] as const;
 
+export class ExportFileMissingError extends Error {
+  name = 'ExportFileMissingError';
+}
+
+/**
+ * Copy the exported file to the user-chosen destination via the SAF dialog. If
+ * the source file is gone by the time the copy runs (the SAF dialog can stay
+ * open for a while), the native layer throws an ENOENT FileNotFoundException —
+ * surface a clear domain error rather than the opaque native one. (We check the
+ * error from the operation rather than pre-checking existence, which would be a
+ * TOCTOU race.)
+ */
+async function saveExportDocument(
+  args: Parameters<typeof saveDocuments>[0],
+  filepath: string,
+) {
+  try {
+    return await saveDocuments(args);
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('ENOENT')) {
+      throw new ExportFileMissingError(`Export file is missing: ${filepath}`);
+    }
+    throw err;
+  }
+}
+
 export function useExportObservations({projectId}: {projectId: string}) {
   const exportNoMedia = useExportGeoJSON({projectId});
   const exportWithMedia = useExportZipFile({projectId});
@@ -105,7 +131,10 @@ export function useExportObservations({projectId}: {projectId: string}) {
     retry: false,
     networkMode: 'always',
     mutationFn: async ({exportType}: {exportType: Exports}) => {
-      const exportDir = FileSystem.cacheDirectory + 'exports/';
+      // Use the persistent document directory, not the volatile cache: the
+      // export file must survive while the SAF "Save As" dialog is open, or
+      // Android cache eviction can delete it before the copy runs.
+      const exportDir = FileSystem.documentDirectory + 'exports/';
       const exportDirectory = await FileSystem.getInfoAsync(exportDir);
 
       if (!exportDirectory.exists) {
@@ -128,18 +157,21 @@ export function useExportObservations({projectId}: {projectId: string}) {
           })
           .then(async path => {
             const filepath = `file://${path}`;
-            const results = await saveDocuments({
-              sourceUris: [filepath],
-              mimeType: 'application/geo+json',
-              fileName: `${fileName}.geojson`,
-            });
-
-            FileSystem.deleteAsync(filepath, {idempotent: true}).catch(() => {
-              //do nothing as it is a temp file system that will eventually delete itself
-              noop();
-            });
-
-            return results;
+            try {
+              return await saveExportDocument(
+                {
+                  sourceUris: [filepath],
+                  mimeType: 'application/geo+json',
+                  fileName: `${fileName}.geojson`,
+                },
+                filepath,
+              );
+            } finally {
+              // documentDirectory is not auto-reclaimed by the OS, so always
+              // remove the export source — even if the SAF copy was cancelled
+              // or failed — so exports don't accumulate on the device.
+              FileSystem.deleteAsync(filepath, {idempotent: true}).catch(noop);
+            }
           });
       }
 
@@ -155,18 +187,21 @@ export function useExportObservations({projectId}: {projectId: string}) {
         })
         .then(async path => {
           const filepath = `file://${path}`;
-          const results = await saveDocuments({
-            sourceUris: [filepath],
-            mimeType: 'application/zip',
-            fileName: `${fileName}.zip`,
-          });
-
-          FileSystem.deleteAsync(filepath, {idempotent: true}).catch(() => {
-            //do nothing as it is a temp file system that will eventually delete itself
-            noop();
-          });
-
-          return results;
+          try {
+            return await saveExportDocument(
+              {
+                sourceUris: [filepath],
+                mimeType: 'application/zip',
+                fileName: `${fileName}.zip`,
+              },
+              filepath,
+            );
+          } finally {
+            // documentDirectory is not auto-reclaimed by the OS, so always
+            // remove the export source — even if the SAF copy was cancelled or
+            // failed — so exports don't accumulate on the device.
+            FileSystem.deleteAsync(filepath, {idempotent: true}).catch(noop);
+          }
         });
     },
   });


### PR DESCRIPTION
## Sentry issue fixed

| Short ID | Title | Events | Link |
|---|---|---|---|
| COMAPEO-233 | java.io.FileNotFoundException: …/cache/exports/CoMapeo_undefined_Obsvns_….zip: ENOENT | 1 | https://awana-digital.sentry.io/issues/7455055251/ |

## Root cause — confirmed: cache eviction under storage pressure

`useExportObservations` wrote the export `.zip`/`.geojson` into `FileSystem.cacheDirectory + 'exports/'` (= Android `context.cacheDir`, OS-purgeable), then passed it to `@react-native-documents/picker` `saveDocuments()`, which opens the SAF "Save As" dialog and only then copies the bytes (`writeDocuments` → `FileOperations.kt` `contentResolver.openInputStream(sourceUri)`). The source lived in the **evictable cache** directory, so it could be deleted between writing and copying → native `FileNotFoundException: …: open failed: ENOENT`.

The cache-eviction diagnosis is **confirmed** by the events (it isn't speculation — and Android *does* purge cache that fast under pressure):
- Both events of COMAPEO-233 had critically low **free disk**: ~135 MB and ~513 MB free (≈0.05% / 0.45%), with `low_memory = False` (so disk, not RAM).
- Both carried Android **`DEVICE_STORAGE_LOW`** breadcrumbs. Under `ACTION_DEVICE_STORAGE_LOW`, Android's PackageManager purges app `cacheDir` **immediately**, not slowly.
- The missing path is provably the *backend-written source* in `cache/exports/` (filename built by `@comapeo/core` `mapeo-project.js` `#exportPrefix` from the project name — hence the `undefined`/long-name variants), read by the native SAF copy after the user picked a destination.

## Fix

- Write the export into the **persistent** `FileSystem.documentDirectory + 'exports/'` (= `context.filesDir`, **not** OS-purgeable), so the source survives while the SAF dialog is open. This defeats the reproduced root cause.
- Wrap `saveDocuments` in `saveExportDocument(...)`, which catches the operation's ENOENT and rethrows a clear `ExportFileMissingError` (check the error from the operation, not a TOCTOU pre-check).
- **Always clean up the source with `try/finally`.** Because `documentDirectory` is no longer auto-reclaimed by the OS, cleanup matters more — and it previously only ran on success. Now the (potentially multi-hundred-MB media) export is deleted even when the SAF copy is **cancelled or fails**, so it can't accumulate in persistent storage on already-full devices.

## Residual risk / follow-ups

Low. One remaining gap: an export orphaned by the process being killed mid-copy would persist in `documentDirectory/exports/` (no longer auto-reclaimed). A startup sweep of that dir would cover it — noted as a small follow-up, not done here.

Closes #1957
