### PR TITLE
fix: treat already-deleted doc as success on delete; fix stale-error capture

### DIFF
--- a/src/frontend/screens/Observation/ConfirmDeleteObservationBottomSheet.tsx
+++ b/src/frontend/screens/Observation/ConfirmDeleteObservationBottomSheet.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../sharedComponents/Buttons';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeleteDocument} from '@comapeo/core-react';
+import {DocAlreadyDeletedError, getErrorCode} from '@comapeo/core/errors.js';
 import * as Sentry from '@sentry/react-native';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
@@ -42,11 +43,10 @@ export const ConfirmDeleteObservationBottomSheet = ({
   const navigation = useNavigationFromRoot();
   const {projectId} = useActiveProject();
   const {observationId} = route.params;
-  const {mutate: deleteObservationMutation, error: deleteObservationError} =
-    useDeleteDocument({
-      docType: 'observation',
-      projectId,
-    });
+  const {mutate: deleteObservationMutation} = useDeleteDocument({
+    docType: 'observation',
+    projectId,
+  });
 
   function handleDelete() {
     deleteObservationMutation(
@@ -56,7 +56,13 @@ export const ConfirmDeleteObservationBottomSheet = ({
           navigation.pop(2);
         },
         onError: err => {
-          Sentry.captureException(deleteObservationError);
+          // Already deleted (double-tap, or deleted on another device and
+          // synced) — the user's intent is satisfied, so finish quietly.
+          if (getErrorCode(err) === DocAlreadyDeletedError.code) {
+            navigation.pop(2);
+            return;
+          }
+          Sentry.captureException(err);
           navigation.navigate('ErrorBottomSheet', {error: err});
         },
       },

--- a/src/frontend/screens/Track/ConfirmDeleteTrackBottomSheet.tsx
+++ b/src/frontend/screens/Track/ConfirmDeleteTrackBottomSheet.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../sharedComponents/Buttons';
 import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes';
 import {useDeleteTrackMutation} from '../../hooks/server/track';
+import {DocAlreadyDeletedError, getErrorCode} from '@comapeo/core/errors.js';
 import * as Sentry from '@sentry/react-native';
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
 
@@ -50,6 +51,12 @@ export const ConfirmDeleteTrackBottomSheet = ({
           navigation.pop(2);
         },
         onError: err => {
+          // Already deleted (double-tap, or deleted on another device and
+          // synced) — the user's intent is satisfied, so finish quietly.
+          if (getErrorCode(err) === DocAlreadyDeletedError.code) {
+            navigation.pop(2);
+            return;
+          }
           Sentry.captureException(err);
           navigation.navigate('ErrorBottomSheet', {error: err});
         },


### PR DESCRIPTION
## Sentry issues fixed

| Short ID | Title | Events | Link |
|---|---|---|---|
| COMAPEO-1YT | Error: Doc already deleted | 1 | https://awana-digital.sentry.io/issues/7315369908/ |

## Root cause

Deleting an observation/track that is already gone (a double-tap, or it was deleted on another device and synced) makes `@comapeo/core` `DataType.delete` throw `DocAlreadyDeletedError`. The throw is correct — the doc is already gone, which is the success case from the user's point of view — but both confirm-delete sheets reported it to Sentry. The observation sheet also had a **stale-variable bug**: `onError` captured the hook's previous-render `deleteObservationError` instead of the fresh `err` argument.

## Fix

`ConfirmDeleteObservationBottomSheet.tsx` and `ConfirmDeleteTrackBottomSheet.tsx`: in `onError`, when `err.code === DocAlreadyDeletedError.code` (imported from `@comapeo/core/errors.js`), finish quietly (`navigation.pop(2)`) without Sentry or the error sheet. The observation sheet now captures the fresh `err` (and drops the unused stale `error` from the hook destructure).

## Follow-up

The double-tap that produces this is tracked in digidem/CoMapeo-mobile#1944 (disable the Delete button while the deletion is pending).

Closes #1959
