### PR TITLE
Sets the environment variable when building a release to production.

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -262,5 +262,6 @@ jobs:
       - name: Submit to Google Play Store
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          APP_VARIANT: production
         run: |
           eas submit --platform android --profile production --id ${{ needs.build.outputs.build_id }} --non-interactive


### PR DESCRIPTION
closes #1177 
This auto [upload to the play store failed](https://github.com/digidem/comapeo-mobile/actions/runs/27293678002/job/80621158351), I believe, because we did not set which environment to use, and there were no credentials for com.comapeo.dev. With the setting of the environment to production, the credentials in expo should now be available.
If we have any hotfixes, this will run, and we can see what happens. 