### PR TITLE
fix: exchange index test

### DIFF
--- a/src/frontend/screens/Exchange/index.test.tsx
+++ b/src/frontend/screens/Exchange/index.test.tsx
@@ -359,5 +359,6 @@ describe('Exchange screen', () => {
       await syncStateIterator.next();
     }
     expect(await hasObservationSyncedToOtherProject()).toBe(true);
-  });
+    // This test needs more than the default 5 second Jest timeout.
+  }, 30_000);
 });

--- a/tests/integration/helpers/core.ts
+++ b/tests/integration/helpers/core.ts
@@ -168,12 +168,11 @@ export async function inviteToProject(
 
 export const createTestServer = (): Promise<{
   serverBaseUrl: string;
-  close: () => void;
+  close: () => Promise<void>;
 }> =>
   new Promise((resolve, reject) => {
-    const startServerPath = require.resolve(
-      '../../../tests/integration/helpers/startTestCloudServer.mjs',
-    );
+    const startServerPath =
+      require.resolve('../../../tests/integration/helpers/startTestCloudServer.mjs');
     const childProcess = spawn('node', [startServerPath], {
       stdio: ['ignore', 'pipe', 'inherit'],
     });
@@ -186,9 +185,11 @@ export const createTestServer = (): Promise<{
       if (urlIsValid(url)) {
         resolve({
           serverBaseUrl: url,
-          close: () => {
-            childProcess.kill('SIGTERM');
-          },
+          close: () =>
+            new Promise<void>(resolveClose => {
+              childProcess.once('close', () => resolveClose());
+              childProcess.kill('SIGTERM');
+            }),
         });
       } else {
         childProcess.kill();


### PR DESCRIPTION
Adds a longer timeout for the sync with remote archive test. 
Attempt to close open network handles.
Trying to get that test to pass more reliably. Right now it is failing a LOT!
But, it passed on first attempt on this PR