### PR TITLE
fix: select duplicate label

### DIFF
--- a/src/frontend/screens/ObservationFields/SelectMultiple.test.tsx
+++ b/src/frontend/screens/ObservationFields/SelectMultiple.test.tsx
@@ -86,6 +86,38 @@ test('works when tagValue is a scalar string', () => {
   expect(updateTag).toHaveBeenCalledWith(['a', 'b']);
 });
 
+test('re-renders correctly when swapped to a field with duplicate labels', () => {
+  const DUPLICATE_LABEL_OPTIONS = [
+    {label: 'Same', value: 'x'},
+    {label: 'Same', value: 'y'},
+  ];
+  const NEXT_OPTIONS = [
+    {label: 'Red', value: 'red'},
+    {label: 'Blue', value: 'blue'},
+  ];
+  const updateTag = jest.fn();
+
+  const {rerender} = render(
+    <SelectMultiple
+      options={DUPLICATE_LABEL_OPTIONS}
+      updateTag={updateTag}
+      tagValue={[]}
+    />,
+  );
+
+  rerender(
+    <SelectMultiple
+      options={NEXT_OPTIONS}
+      updateTag={updateTag}
+      tagValue={[]}
+    />,
+  );
+
+  expect(screen.getByText('Red')).toBeOnTheScreen();
+  expect(screen.getByText('Blue')).toBeOnTheScreen();
+  expect(screen.queryByText('Same')).toBeNull();
+});
+
 test('multiple options can be selected', () => {
   const updateTag = jest.fn();
   const {rerender} = render(

--- a/src/frontend/screens/ObservationFields/SelectMultiple.tsx
+++ b/src/frontend/screens/ObservationFields/SelectMultiple.tsx
@@ -32,7 +32,7 @@ export const SelectMultiple = ({
     <View testID="OBS.select-multiple-inp">
       {options.map((item, index) => (
         <TouchableOpacity
-          key={item.label}
+          key={String(item.value)}
           accessibilityRole="checkbox"
           testID={`OBS.select-multiple-inp-${item.label}`}
           accessibilityState={{selected: valueAsArray.includes(item.value)}}

--- a/src/frontend/screens/ObservationFields/SelectMultiple.tsx
+++ b/src/frontend/screens/ObservationFields/SelectMultiple.tsx
@@ -32,7 +32,8 @@ export const SelectMultiple = ({
     <View testID="OBS.select-multiple-inp">
       {options.map((item, index) => (
         <TouchableOpacity
-          key={String(item.value)}
+          // eslint-disable-next-line @eslint-react/no-array-index-key
+          key={`${index}-${String(item.value)}`}
           accessibilityRole="checkbox"
           testID={`OBS.select-multiple-inp-${item.label}`}
           accessibilityState={{selected: valueAsArray.includes(item.value)}}

--- a/src/frontend/screens/ObservationFields/SelectOne.test.tsx
+++ b/src/frontend/screens/ObservationFields/SelectOne.test.tsx
@@ -62,3 +62,64 @@ test('works when tagValue is undefined', () => {
 
   expect(updateTag).toHaveBeenCalledWith('a');
 });
+
+test('options with duplicate labels each save their own distinct value when pressed', () => {
+  const updateTag = jest.fn();
+
+  render(
+    <SelectOne
+      options={[
+        {label: '00PM', value: 'Cap Start - 12'},
+        {label: '00PM', value: 'Cap End - 12'},
+      ]}
+      updateTag={updateTag}
+      tagValue={undefined}
+    />,
+  );
+
+  const matches = screen.getAllByText('00PM');
+  fireEvent.press(matches[0]!);
+  expect(updateTag).toHaveBeenLastCalledWith('Cap Start - 12');
+
+  fireEvent.press(matches[1]!);
+  expect(updateTag).toHaveBeenLastCalledWith('Cap End - 12');
+});
+
+// Duplicate labels (but distinct values) caused stale options to bleed into the
+// next field when navigating between questions. Real-world example: a
+// camera-settings field with two "00PM" options ("Cap Start - 12" / "Cap End - 12").
+test('re-renders correctly when swapped to a field with duplicate labels', () => {
+  const CAMERA_SETTINGS_OPTIONS = [
+    {label: 'MultiShot - RPF2Shot', value: 'multishot-rpf2shot'},
+    {label: '00PM', value: 'Cap Start - 12'},
+    {label: '00PM', value: 'Cap End - 12'},
+    {label: 'Smart IR - On', value: 'smart-ir-on'},
+  ];
+  const NEXT_OPTIONS = [
+    {label: 'Option A', value: 'a'},
+    {label: 'Option B', value: 'b'},
+  ];
+  const updateTag = jest.fn();
+
+  const {rerender} = render(
+    <SelectOne
+      options={CAMERA_SETTINGS_OPTIONS}
+      updateTag={updateTag}
+      tagValue={undefined}
+    />,
+  );
+
+  rerender(
+    <SelectOne
+      options={NEXT_OPTIONS}
+      updateTag={updateTag}
+      tagValue={undefined}
+    />,
+  );
+
+  expect(screen.getByText('Option A')).toBeOnTheScreen();
+  expect(screen.getByText('Option B')).toBeOnTheScreen();
+  expect(screen.queryByText('00PM')).toBeNull();
+  expect(screen.queryByText('MultiShot - RPF2Shot')).toBeNull();
+  expect(screen.queryByText('Smart IR - On')).toBeNull();
+});

--- a/src/frontend/screens/ObservationFields/SelectOne.tsx
+++ b/src/frontend/screens/ObservationFields/SelectOne.tsx
@@ -17,7 +17,8 @@ export const SelectOne = ({options, updateTag, tagValue}: SelectOneProps) => {
         const isSelected = item.value === tagValue;
         return (
           <TouchableOpacity
-            key={String(item.value)}
+            // eslint-disable-next-line @eslint-react/no-array-index-key
+            key={`${index}-${String(item.value)}`}
             accessibilityRole="radio"
             testID={`OBS.select-one-inp-${item.label}`}
             accessibilityState={{checked: isSelected, selected: isSelected}}

--- a/src/frontend/screens/ObservationFields/SelectOne.tsx
+++ b/src/frontend/screens/ObservationFields/SelectOne.tsx
@@ -17,7 +17,7 @@ export const SelectOne = ({options, updateTag, tagValue}: SelectOneProps) => {
         const isSelected = item.value === tagValue;
         return (
           <TouchableOpacity
-            key={item.label}
+            key={String(item.value)}
             accessibilityRole="radio"
             testID={`OBS.select-one-inp-${item.label}`}
             accessibilityState={{checked: isSelected, selected: isSelected}}


### PR DESCRIPTION
Uses option value as key for select one and select multiple. 
Adds tests for making sure duplicate labels don't cause the wrong options to appear (which is why the key change was necessary)

This is a redo of https://github.com/digidem/comapeo-mobile/issues/1946 which was addressing this issue: https://github.com/digidem/comapeocat/issues/49


Summary
A selectOne (or selectMultiple) field whose options include two entries with the same label (but different value) causes a rendering glitch: the duplicated option bleeds into other selectOne fields that are opened after it while paging through an observation's questions.

Originally reported against the config tooling in https://github.com/digidem/comapeocat/issues/49, but the root cause is in this app.

It was redone for two reasons
1. The code for these files was totally refactored, so a merge with the develop branch would cause conflicts
 and 2. I am trying a slightly different approach.

This was Gregor's fix: 
Use a unique key (`${item.value}-${index}`) instead of item.label in both components. This is robust even if a malformed config duplicates both label and value, and index is a stable key here since field.options never reorders.

My take...
However, using the index is against the ESLint rule `no-array-index-key`. So instead, if we just convert the value to a string, that prevents the issue with duplicate labels. If the value is duplicated, there is a bigger problem with the options in the categories so it should probably show as wonky to the user as it is wonky!

However, if you think the array index should also be there in the key, I will add that.