### PR TITLE
fix: observation list faster rendering

### DIFF
--- a/src/frontend/screens/ComapeoSettings/CreateTestData.tsx
+++ b/src/frontend/screens/ComapeoSettings/CreateTestData.tsx
@@ -1,5 +1,5 @@
 import {useOwnDeviceInfo, useCreateDocument} from '@comapeo/core-react';
-import {useMutation} from '@tanstack/react-query';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {lengthToDegrees} from '@turf/helpers';
 import {randomPosition} from '@turf/random';
 import {LocationObject} from 'expo-location';
@@ -10,7 +10,7 @@ import {StyleSheet, TextInput, ToastAndroid, View} from 'react-native';
 import {UIActivityIndicator} from 'react-native-indicators';
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
-import {LIGHT_GREY, RED, WHITE} from '../../lib/styles';
+import {BLACK, LIGHT_GREY, RED, WHITE} from '../../lib/styles';
 import {PrimaryButton} from '../../sharedComponents/Buttons';
 import {LocationView} from '../../sharedComponents/LocationView';
 import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
@@ -216,6 +216,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     padding: 10,
     fontSize: 20,
+    color: BLACK,
   },
   errorText: {
     color: RED,
@@ -239,6 +240,7 @@ function useCreateFakeObservationsMutation() {
 
   const {data: deviceInfo} = useOwnDeviceInfo();
   const {data: presets} = usePresetsQuery();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({
@@ -306,7 +308,11 @@ function useCreateFakeObservationsMutation() {
         tasks.push(createObservationAsync({value}));
       }
 
-      return Promise.all(tasks);
+      await Promise.all(tasks);
+      // so that the new observations show up in the list without needing to refresh
+      await queryClient.invalidateQueries({
+        queryKey: ['@comapeo/core-react', 'projects', projectId],
+      });
     },
   });
 }

--- a/src/frontend/screens/Observation/TrackAccordian.tsx
+++ b/src/frontend/screens/Observation/TrackAccordian.tsx
@@ -9,6 +9,8 @@ import {useTracks} from '../../hooks/server/track.ts';
 import {View} from 'react-native';
 import {LIGHT_GREY} from '../../lib/styles.ts';
 import {findAssociatedTrack} from './findAssociatedTrack.ts';
+import {usePresetsQuery} from '../../hooks/server/presets.ts';
+import {useIsMyDocument} from '../../hooks/server/useIsMyDocument.ts';
 
 const m = defineMessages({
   track: {
@@ -20,10 +22,12 @@ const m = defineMessages({
 export function TrackAccordian({observationId}: {observationId: string}) {
   const navigation = useNavigationFromRoot();
   const {data: allTracks} = useTracks();
+  const {data: allPresets} = usePresetsQuery();
   const track =
     allTracks === undefined
       ? undefined
       : findAssociatedTrack({tracks: allTracks, observationId});
+  const isMine = useIsMyDocument(track?.originalVersionId ?? '');
   const {formatMessage} = useIntl();
 
   if (!track) return null;
@@ -48,6 +52,8 @@ export function TrackAccordian({observationId}: {observationId: string}) {
         innerAccordianDetails={
           <TrackListItem
             track={track}
+            allPresets={allPresets}
+            isMine={isMine}
             onPress={() => {
               navigation.push('Track', {trackId: track.docId});
             }}

--- a/src/frontend/screens/ObservationsList/ObservationListItem.tsx
+++ b/src/frontend/screens/ObservationsList/ObservationListItem.tsx
@@ -3,24 +3,23 @@ import {StyleSheet, TouchableOpacity, View} from 'react-native';
 
 import {PresetCircleIcon} from '../../sharedComponents/icons/PresetIcon';
 import {Attachment, ViewStyleProp} from '../../sharedTypes';
-import {Observation} from '@comapeo/schema';
+import {Observation, Preset} from '@comapeo/schema';
 import {
   FormattedObservationDate,
   FormattedPresetName,
 } from '../../sharedComponents/FormattedData';
 import {PhotoAttachmentView} from '../../sharedComponents/PhotoAttachmentView.tsx';
 import {isSavedPhoto} from '../../lib/attachmentTypeChecks.ts';
-import {matchPreset} from '../../lib/utils';
 import {sharedStyles} from './SharedStyle.ts';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText.tsx';
 import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
-import {useIsMyDocument} from '../../hooks/server/useIsMyDocument.ts';
 import {UIActivityIndicator} from 'react-native-indicators';
-import {usePresetsQuery} from '../../hooks/server/presets.ts';
 
 interface ObservationListItemProps {
   style?: ViewStyleProp;
   observation: Observation;
+  preset: Preset | undefined;
+  isMine: boolean;
   testID: string;
   onPress: (id: string) => void;
 }
@@ -36,9 +35,13 @@ export const ObservationListItem = React.memo<ObservationListItemProps>(
 function ObservationListItemNotMemoized({
   style,
   observation,
+  preset,
+  isMine,
   testID,
   onPress,
 }: ObservationListItemProps) {
+  const photos = observation.attachments.filter(isSavedPhoto);
+
   return (
     <TouchableOpacity
       onPress={() => onPress(observation.docId)}
@@ -50,58 +53,41 @@ function ObservationListItemNotMemoized({
             <UIActivityIndicator />
           </View>
         }>
-        <ObservationListItemInner observation={observation} style={style} />
-      </React.Suspense>
-    </TouchableOpacity>
-  );
-}
-
-function ObservationListItemInner({
-  style,
-  observation,
-}: {
-  style?: ViewStyleProp;
-  observation: Observation;
-}) {
-  const {data: allPresets} = usePresetsQuery();
-  const preset = matchPreset(observation.tags, allPresets);
-  const photos = observation.attachments.filter(isSavedPhoto);
-  const isMine = useIsMyDocument(observation.originalVersionId);
-
-  return (
-    <View style={[styles.container, style, !isMine && sharedStyles.synced]}>
-      <View style={styles.text}>
-        <HeaderText variant="header4">
-          <FormattedPresetName preset={preset} />
-        </HeaderText>
-        <BodyText>
-          <FormattedObservationDate
-            createdDate={observation.createdAt}
-            variant="relative"
-          />
-        </BodyText>
-      </View>
-      {photos.length ? (
-        <View style={styles.photoContainer}>
-          <PhotoStack photos={photos} />
-          <View style={styles.smallIconContainer}>
+        <View style={[styles.container, style, !isMine && sharedStyles.synced]}>
+          <View style={styles.text}>
+            <HeaderText variant="header4">
+              <FormattedPresetName preset={preset} />
+            </HeaderText>
+            <BodyText>
+              <FormattedObservationDate
+                createdDate={observation.createdAt}
+                variant="relative"
+              />
+            </BodyText>
+          </View>
+          {photos.length ? (
+            <View style={styles.photoContainer}>
+              <PhotoStack photos={photos} />
+              <View style={styles.smallIconContainer}>
+                <PresetCircleIcon
+                  iconId={preset?.iconRef?.docId}
+                  testID={`OBS.${preset?.name}-list-icon`}
+                  size="small"
+                  color={preset?.color}
+                />
+              </View>
+            </View>
+          ) : (
             <PresetCircleIcon
               iconId={preset?.iconRef?.docId}
+              size="medium"
               testID={`OBS.${preset?.name}-list-icon`}
-              size="small"
               color={preset?.color}
             />
-          </View>
+          )}
         </View>
-      ) : (
-        <PresetCircleIcon
-          iconId={preset?.iconRef?.docId}
-          size="medium"
-          testID={`OBS.${preset?.name}-list-icon`}
-          color={preset?.color}
-        />
-      )}
-    </View>
+      </React.Suspense>
+    </TouchableOpacity>
   );
 }
 

--- a/src/frontend/screens/ObservationsList/TrackListItem.tsx
+++ b/src/frontend/screens/ObservationsList/TrackListItem.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
 import {FormattedObservationDate} from '../../sharedComponents/FormattedData.tsx';
-import {Track} from '@comapeo/schema';
+import {Preset, Track} from '@comapeo/schema';
 import {ViewStyleProp} from '../../sharedTypes/index';
 import {defineMessages, useIntl} from 'react-intl';
 import TrackIcon from '../../images/Track.svg';
 import {sharedStyles} from './SharedStyle.ts';
 import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText.tsx';
-import {useIsMyDocument} from '../../hooks/server/useIsMyDocument.ts';
 import {PresetCircleIcon} from '../../sharedComponents/icons/PresetIcon';
-import {usePresetsQuery} from '../../hooks/server/presets.ts';
 
 const m = defineMessages({
   track: {
@@ -22,6 +20,8 @@ const m = defineMessages({
 interface ObservationListItemProps {
   style?: ViewStyleProp;
   track: Track;
+  allPresets: Preset[];
+  isMine: boolean;
   testID: string;
   onPress: () => void;
 }
@@ -29,12 +29,12 @@ interface ObservationListItemProps {
 const TrackObservationItemNotMemoized = ({
   style,
   track,
+  allPresets,
+  isMine,
   testID,
   onPress,
 }: ObservationListItemProps) => {
   const {formatMessage} = useIntl();
-  const isMine = useIsMyDocument(track.originalVersionId);
-  const {data: allPresets} = usePresetsQuery();
   const matchedPreset =
     track.presetRef && allPresets.find(p => p.docId === track.presetRef?.docId);
 

--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -14,6 +14,8 @@ import {useTracks} from '../../hooks/server/track';
 import {useAuthContext} from '../../contexts/AuthContext';
 import {useEarlyAccessState} from '../../contexts/EarlyAccessContext';
 import {ObservationFilterToggle} from './ObservationFilterToggle';
+import {usePresetsQuery} from '../../hooks/server/presets';
+import {matchPreset} from '../../lib/utils';
 
 const m = defineMessages({
   observationListTitle: {
@@ -37,6 +39,8 @@ export const ObservationsList: React.FC<
   const {authState} = useAuthContext();
   const isEarlyAccessEnabled = useEarlyAccessState(s => s.isEarlyAccessEnabled);
   const {data: deviceInfo} = useOwnDeviceInfo();
+  const {data: allPresets} = usePresetsQuery();
+  const myDeviceId = deviceInfo?.deviceId;
 
   const [filterMode, setFilterMode] = React.useState<'all' | 'mine'>('all');
   const lastInteractionRef = React.useRef<number | null>(null);
@@ -65,19 +69,12 @@ export const ObservationsList: React.FC<
       return allData.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
     }
 
-    const myDeviceId = deviceInfo?.deviceId;
     const filtered = allData.filter(
       item => 'createdBy' in item && item.createdBy === myDeviceId,
     );
 
     return filtered.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-  }, [
-    observations,
-    tracks,
-    isEarlyAccessEnabled,
-    filterMode,
-    deviceInfo?.deviceId,
-  ]);
+  }, [observations, tracks, isEarlyAccessEnabled, filterMode, myDeviceId]);
 
   if ((!observations.length && !tracks.length) || authState === 'obscured') {
     return (
@@ -99,9 +96,12 @@ export const ObservationsList: React.FC<
       <FlatList
         keyExtractor={keyExtractor}
         style={styles.container}
-        windowSize={3}
-        removeClippedSubviews
+        windowSize={7}
+        initialNumToRender={10}
+        maxToRenderPerBatch={10}
+        updateCellsBatchingPeriod={20}
         renderItem={({item, index}) => {
+          const isMine = 'createdBy' in item && item.createdBy === myDeviceId;
           switch (item.schemaName) {
             case 'observation':
               return (
@@ -109,6 +109,8 @@ export const ObservationsList: React.FC<
                   key={item.docId}
                   testID={`observationListItem:${index}`}
                   observation={item}
+                  preset={matchPreset(item.tags, allPresets)}
+                  isMine={isMine}
                   style={styles.listItem}
                   onPress={() =>
                     navigation.navigate('Observation', {
@@ -123,6 +125,8 @@ export const ObservationsList: React.FC<
                   key={item.docId}
                   testID={`trackListItem:${index}`}
                   track={item}
+                  allPresets={allPresets}
+                  isMine={isMine}
                   style={styles.listItem}
                   onPress={() => {
                     navigation.navigate('Track', {trackId: item.docId});

--- a/src/frontend/screens/ObservationsList/index.tsx
+++ b/src/frontend/screens/ObservationsList/index.tsx
@@ -97,8 +97,6 @@ export const ObservationsList: React.FC<
         keyExtractor={keyExtractor}
         style={styles.container}
         windowSize={7}
-        initialNumToRender={10}
-        maxToRenderPerBatch={10}
         updateCellsBatchingPeriod={20}
         renderItem={({item, index}) => {
           const isMine = 'createdBy' in item && item.createdBy === myDeviceId;

--- a/src/frontend/screens/Track/ObservationList.tsx
+++ b/src/frontend/screens/Track/ObservationList.tsx
@@ -7,6 +7,9 @@ import {useNavigationFromRoot} from '../../hooks/useNavigationWithTypes.ts';
 import {defineMessages, useIntl} from 'react-intl';
 import {Accordian} from '../../sharedComponents/Accordian.tsx';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText.tsx';
+import {usePresetsQuery} from '../../hooks/server/presets.ts';
+import {useIsMyDocument} from '../../hooks/server/useIsMyDocument.ts';
+import {matchPreset} from '../../lib/utils.ts';
 
 interface TrackObservation {
   observations: Observation[];
@@ -26,6 +29,7 @@ const m = defineMessages({
 export function ObservationList({observations}: TrackObservation) {
   const navigation = useNavigationFromRoot();
   const {formatMessage} = useIntl();
+  const {data: allPresets} = usePresetsQuery();
   const numberOfObservations = observations.length;
 
   return (
@@ -43,9 +47,10 @@ export function ObservationList({observations}: TrackObservation) {
         </>
       }
       innerAccordianDetails={observations.map((observation, index) => (
-        <ObservationListItem
+        <TrackObservationListItem
           key={observation.docId}
           observation={observation}
+          allPresets={allPresets}
           onPress={() => {
             navigation.push('Observation', {
               observationId: observation.docId,
@@ -54,6 +59,29 @@ export function ObservationList({observations}: TrackObservation) {
           testID={'id' + index}
         />
       ))}
+    />
+  );
+}
+
+function TrackObservationListItem({
+  observation,
+  allPresets,
+  onPress,
+  testID,
+}: {
+  observation: Observation;
+  allPresets: ReturnType<typeof usePresetsQuery>['data'];
+  onPress: () => void;
+  testID: string;
+}) {
+  const isMine = useIsMyDocument(observation.originalVersionId);
+  return (
+    <ObservationListItem
+      observation={observation}
+      preset={matchPreset(observation.tags, allPresets)}
+      isMine={isMine}
+      onPress={onPress}
+      testID={testID}
     />
   );
 }


### PR DESCRIPTION
closes #1967
### Summary
This PR is an attempt to make the loading and scrolling of the observation list faster and smoother, even if there are a lot of observations.

### Lifts fetching data up to the parent level 
Now the fetch only happens once (with two queries) instead of potentially 500+ times (with two queries each) on each list item. Especially as the useIsMyDocument is a backend IPC call, not just a cache lookup.
This also required fixing two other places that use these list item components — the observations inside a Track detail screen, and the tracks inside an Observation  screen. Since those are single items or small fixed lists (not 500+), they call the hooks locally rather than lifting them up.

### Adds and removes some FlatList props. 
Some have to do with the fact that I noticed some blank screen time as I was scrolling up only.

**windowSize={7}** -- We used to have 3, but as I said, I am seeing a blank screen on fast scroll. The default is 21. Having a greater number here keeps windows above and below in memory. So 7 is a compromise to save memory but to try to address the blank screen on fast upward scroll.

**updateCellsBatchingPeriod={20}** — How often (in milliseconds) FlatList checks whether it needs to render more items. Default is 50ms. Halving it to 20ms means blank cells get filled in faster after a fast scroll, at the cost of slightly more CPU work.

**Removed removeClippedSubviews** — The default for Android is true, so I just took it out for noise prevention

### Put the Suspense around the whole ObservationListItem
Because the hooks are in the parent, the boundary can be simplified to just wrap the item since they are effectively synchronous. This fallback now only appears briefly when the initial list loads rather then flickering per item when scrolling.

### Fixes for Creation of Test Data
While doing this work, I used the creation of test observations and noticed my input was invisible. So I fixed that in this PR. I also had to reload the app to get the observations to show up, so I tried to address that as well by refetching the observation list after all of the new observations are created.

### Before the changes were made rendering a large list is awkward and slow (sometimes)


https://github.com/user-attachments/assets/6b839cb7-f201-4538-9241-99756adaec93

### After the changes from this PR shows the loading of the Observation List is much quicker and smoother

https://github.com/user-attachments/assets/8ab64f6a-e452-4ecc-b0e8-1a1c7c80efaa





