### PR TITLE
fix: clearer error title and message for a download error on map shares

### DIFF
--- a/messages/en-US/secondary.json
+++ b/messages/en-US/secondary.json
@@ -1150,6 +1150,15 @@
   "screens.Settings.MapManagement.MapShareCanceled.title": {
     "message": "Sharing Canceled"
   },
+  "screens.Settings.MapManagement.ReceivingBackgroundMap.downloadErrorDescription": {
+    "message": "Map sharing was interrupted. Make sure both devices are connected to the same network and try again."
+  },
+  "screens.Settings.MapManagement.ReceivingBackgroundMap.downloadErrorTitle": {
+    "message": "Connection Lost"
+  },
+  "screens.Settings.MapManagement.ReceivingBackgroundMap.downloadFailedTitle": {
+    "message": "Map Download Failed"
+  },
   "screens.Settings.MapManagement.ReplaceBackgroundMap.cancel": {
     "message": "Cancel"
   },

--- a/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
+++ b/src/frontend/screens/BackgroundMaps/ReceivingBackgroundMap.tsx
@@ -42,6 +42,19 @@ const m = defineMessages({
     id: 'screens.Settings.MapManagement.BackgroundMapUpdated.done',
     defaultMessage: 'Done',
   },
+  downloadErrorTitle: {
+    id: 'screens.Settings.MapManagement.ReceivingBackgroundMap.downloadErrorTitle',
+    defaultMessage: 'Connection Lost',
+  },
+  downloadErrorDescription: {
+    id: 'screens.Settings.MapManagement.ReceivingBackgroundMap.downloadErrorDescription',
+    defaultMessage:
+      'Map sharing was interrupted. Make sure both devices are connected to the same network and try again.',
+  },
+  downloadFailedTitle: {
+    id: 'screens.Settings.MapManagement.ReceivingBackgroundMap.downloadFailedTitle',
+    defaultMessage: 'Map Download Failed',
+  },
 });
 
 export function ReceivingBackgroundMap({
@@ -107,12 +120,23 @@ export function ReceivingBackgroundMap({
   }
 
   if (mapShare.status === 'error') {
-    const message = mapShare.error.message ?? 'Map download failed';
-    Sentry.captureException(new Error(message));
+    const isDownloadError =
+      mapShare.error.code === MapShareErrorCode.DOWNLOAD_ERROR;
+    const title = isDownloadError
+      ? t(m.downloadErrorTitle)
+      : t(m.downloadFailedTitle);
+    const description = isDownloadError
+      ? t(m.downloadErrorDescription)
+      : mapShare.error.message;
+    Sentry.captureException(
+      new Error(
+        `Map download error [${mapShare.error.code}]: ${mapShare.error.message}`,
+      ),
+    );
     return (
       <MapShareError
-        title={message}
-        description={message}
+        title={title}
+        description={description}
         onClose={handleDone}
       />
     );


### PR DESCRIPTION
towards #1972 
### Summary
- During a QA session, map sharing was dropped/ stopped and [one can see the reason in Sentry](https://awana-digital.sentry.io/issues/7512267993/events/bfe39279e1fc42eb8768d87ec21bbb77/), NETWORK_LOST
- But the user just saw terminated
- This PR checks the mapShare.error.code and shows a Connection Lost specific title and message if it is a DOWNLOAD_ERROR
- For other codes, shows a now translatable title and the raw error.message as the description (it might be helpful for non network failures)
- Improves Sentry reporting to include the error code and message 

### Context and follow up
Sentry breadcrumbs on the failing session showed NETWORK_LOST one second before the "terminated" error on a ZTE Blade A3 Lite (Android 9). The backend maps all download failures — network, disk, server — to the single DOWNLOAD_ERROR code.

### Follow-up for Core? (Whom should I tag here?)
As far as I can find by looking at JSDocs in @comapeo/core-react, DOWNLOAD_ERROR covers network loss, disk errors, and server errors all together. Is there anything more specific that core or @comapeo/core-react could inspect to expose more granular error codes in that situation? Might it be useful to allow the frontend to show more targeted guidance? Not sure.

On slow, old, and/ or full devices, is there anything that can be done to support resuming a download if the network is momentarily dropped?

