### PR TITLE
fix: jest exchange index test

### DIFF
--- a/src/frontend/screens/Exchange/index.test.tsx
+++ b/src/frontend/screens/Exchange/index.test.tsx
@@ -333,11 +333,8 @@ describe('Exchange screen', () => {
     // Tear down the UI (and its project); it should not have synced to the other manager
 
     await unmount();
-    // Access the project directly on the manager (not via IPC) to avoid a race
-    // between the unmount's in-flight disconnectServers() RPC call and close().
-    const managerProject = await manager.getProject(projectId);
-    managerProject.$sync.stop();
-    await managerProject.close();
+    project.$sync.stop();
+    await project.close();
 
     expect(await hasObservationSyncedToOtherProject()).toBe(false);
 
@@ -362,6 +359,5 @@ describe('Exchange screen', () => {
       await syncStateIterator.next();
     }
     expect(await hasObservationSyncedToOtherProject()).toBe(true);
-    // This test needs more than the default 5 second Jest timeout.
-  }, 30_000);
+  });
 });

--- a/src/frontend/screens/Exchange/index.test.tsx
+++ b/src/frontend/screens/Exchange/index.test.tsx
@@ -333,8 +333,11 @@ describe('Exchange screen', () => {
     // Tear down the UI (and its project); it should not have synced to the other manager
 
     await unmount();
-    project.$sync.stop();
-    await project.close();
+    // Access the project directly on the manager (not via IPC) to avoid a race
+    // between the unmount's in-flight disconnectServers() RPC call and close().
+    const managerProject = await manager.getProject(projectId);
+    managerProject.$sync.stop();
+    await managerProject.close();
 
     expect(await hasObservationSyncedToOtherProject()).toBe(false);
 

--- a/tests/integration/helpers/core.ts
+++ b/tests/integration/helpers/core.ts
@@ -58,7 +58,7 @@ export function setUpIPC({manager}: {manager: MapeoManager}) {
   const {port1, port2} = new MessageChannel();
 
   const server = createMapeoServer(manager, port1);
-  const client = createMapeoClient(port2);
+  const client = createMapeoClient(port2, {timeout: 30_000});
 
   return {
     client,
@@ -168,7 +168,7 @@ export async function inviteToProject(
 
 export const createTestServer = (): Promise<{
   serverBaseUrl: string;
-  close: () => Promise<void>;
+  close: () => void;
 }> =>
   new Promise((resolve, reject) => {
     const startServerPath =
@@ -185,11 +185,9 @@ export const createTestServer = (): Promise<{
       if (urlIsValid(url)) {
         resolve({
           serverBaseUrl: url,
-          close: () =>
-            new Promise<void>(resolveClose => {
-              childProcess.once('close', () => resolveClose());
-              childProcess.kill('SIGTERM');
-            }),
+          close: () => {
+            childProcess.kill('SIGTERM');
+          },
         });
       } else {
         childProcess.kill();


### PR DESCRIPTION
Another fix to try: 
Reverts the other changes. They didn't work! Instead passes the increase in timeout time of 30 seconds (since 5 seconds wasn't enough) to the rpc-reflector for every RPC call made through that client for tests.