### PR TITLE
fix: read storage when it is updated

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -19,10 +19,10 @@ Logger.setLogCallback(log => {
 // https://github.com/maplibre/maplibre-react-native/blob/6f99de530eec2e06de485ef86f4be61f941e0e09/docs/content/modules/mlrn-module.md#setconnectedconnected
 setConnected(true);
 
-import {QueryClient} from '@tanstack/react-query';
+import {QueryClient, focusManager} from '@tanstack/react-query';
 import {AppNavigator} from './AppNavigator';
 import {initializeNodejs} from './initializeNodejs';
-import {PermissionsAndroid} from 'react-native';
+import {AppState, PermissionsAndroid} from 'react-native';
 import {AppProviders} from './contexts/AppProviders';
 import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
 import * as SplashScreen from 'expo-splash-screen';
@@ -208,6 +208,10 @@ const appUsagePromptStore = createAppUsageStatsStore({
 });
 
 const queryClient = new QueryClient();
+
+AppState.addEventListener('change', status => {
+  focusManager.setFocused(status === 'active');
+});
 
 const App = () => {
   const [permissionsAsked, setPermissionsAsked] = React.useState(false);

--- a/src/frontend/hooks/useStorageReadingQuery.ts
+++ b/src/frontend/hooks/useStorageReadingQuery.ts
@@ -15,6 +15,5 @@ export function useStorageReadingQuery() {
   return useSuspenseQuery({
     queryKey: STORAGE_QUERY_KEY,
     queryFn: getReading,
-    refetchOnWindowFocus: true,
   });
 }

--- a/src/frontend/hooks/useStorageReadingQuery.ts
+++ b/src/frontend/hooks/useStorageReadingQuery.ts
@@ -15,5 +15,6 @@ export function useStorageReadingQuery() {
   return useSuspenseQuery({
     queryKey: STORAGE_QUERY_KEY,
     queryFn: getReading,
+    refetchOnWindowFocus: true,
   });
 }


### PR DESCRIPTION
closes #1706 
### Summary

With useQuery, refetchOnWindowFocus defaults to true [("If set to true, the query will refetch on window focus if the data is stale."](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery)
but it doesn't actually do anything because it only works without wiring on browsers. For react native, you need to make sure the focus manager is set in order for react query to know when the app is active.

> Instead of event listeners on window, React Native provides focus information through the [AppState module](https://reactnative.dev/docs/appstate#app-states). You can use the AppState "change" event to trigger an update when the app state changes to "active":

Based on the docs: https://tanstack.com/query/latest/docs/framework/react/react-native#refetch-on-app-focus

So adds a listener in App State so that react query knows when the app is active, and thus when to refetch queries.
That way, when someone clears up some of their storage and comes back to the app, the low storage warnings update accordingly.
