### PR TITLE
enhancement: adds sentry replay

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -81,7 +81,6 @@ Sentry.init({
   debug: false, // this added alot of unneccesary noise to the console.
   initialScope: {user: {id: sentryUserId}},
   enableMetrics: false,
-  replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: sentryEnvironment === 'qa' ? 1.0 : 0,
   integrations:
     sentryEnvironment === 'qa'

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -73,8 +73,8 @@ const sentryEnvironment: SentryEnvironment =
 
 const appMetricsOptIn = sentryEnvironment !== 'production';
 let navigationIntegration:
-  | ReturnType<(typeof Sentry)['reactNavigationIntegration']>
-  | undefined = undefined;
+  ReturnType<(typeof Sentry)['reactNavigationIntegration']> | undefined =
+  undefined;
 const sentryUserId = getSentryUserId({now: new Date(), storage});
 
 Sentry.init({
@@ -85,6 +85,7 @@ Sentry.init({
   debug: false, // this added alot of unneccesary noise to the console.
   initialScope: {user: {id: sentryUserId}},
   enableMetrics: false,
+  replaysSessionSampleRate: sentryEnvironment === 'qa' ? 1.0 : 0,
   replaysOnErrorSampleRate: sentryEnvironment === 'qa' ? 1.0 : 0,
   integrations:
     sentryEnvironment === 'qa'

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -73,8 +73,8 @@ const sentryEnvironment: SentryEnvironment =
 
 const appMetricsOptIn = sentryEnvironment !== 'production';
 let navigationIntegration:
-  ReturnType<(typeof Sentry)['reactNavigationIntegration']> | undefined =
-  undefined;
+  | ReturnType<(typeof Sentry)['reactNavigationIntegration']>
+  | undefined = undefined;
 const sentryUserId = getSentryUserId({now: new Date(), storage});
 
 Sentry.init({

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -81,6 +81,18 @@ Sentry.init({
   debug: false, // this added alot of unneccesary noise to the console.
   initialScope: {user: {id: sentryUserId}},
   enableMetrics: false,
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: sentryEnvironment === 'qa' ? 1.0 : 0,
+  integrations:
+    sentryEnvironment === 'qa'
+      ? [
+          Sentry.mobileReplayIntegration({
+            maskAllText: false,
+            maskAllImages: false,
+            maskAllVectors: false,
+          }),
+        ]
+      : [],
 });
 
 if (appMetricsOptIn) {


### PR DESCRIPTION
closes #1970 

- Enables Sentry replay on QA builds on error only. This is for release-candidates not pre-release as currently configured.
- I am passing the option to not mask anything since it is just for QA.
- The Map will probably capture as black screen until we can implement captureSurfaceViews as an option, but that is not available until [version 8.12](https://github.com/getsentry/sentry-react-native/releases/tag/8.12.0) and we are on version 8.0

