### PR TITLE
feat(metrics): include appId in device diagnostics payload

### DIFF
--- a/src/frontend/metrics/DeviceDiagnosticMetrics.ts
+++ b/src/frontend/metrics/DeviceDiagnosticMetrics.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-native';
 import {AppState, Dimensions, PixelRatio, Platform} from 'react-native';
 import * as NetInfo from '@react-native-community/netinfo';
+import * as Application from 'expo-application';
 import * as Device from 'expo-device';
 import {getMonthlyHash} from './getMonthlyHash';
 import {sendMetricsData} from './sendMetricsData';
@@ -15,6 +16,7 @@ const STORAGE_KEY = 'DeviceDiagnosticMetricsLastSentAt';
 type DeviceDiagnosticMetricsData = {
   type: 'device diagnostics v1';
   monthlyDeviceHash: string;
+  appId?: string;
   brand?: string;
   deviceType?: string;
   isEmulator?: true;
@@ -62,6 +64,7 @@ async function generateDeviceDiagnosticMetricsData(): Promise<DeviceDiagnosticMe
     ),
   };
 
+  setIfNotNull(result, 'appId', Application.applicationId);
   setIfNotNull(result, 'brand', Device.brand);
   setIfNotNull(result, 'manufacturer', Device.manufacturer);
   setIfNotNull(result, 'model', Device.modelId || Device.modelName);


### PR DESCRIPTION
## What

Adds `appId` to the `device diagnostics v1` telemetry payload in `DeviceDiagnosticMetrics.ts`, sourced from `expo-application`'s `Application.applicationId` — the same source the app-diagnostics payload already uses.

## Why

The device-diagnostics report (hardware: brand, model, screen, memory, CPU arch, deviceType) is the only telemetry stream that carries **no application identifier**. The app-diagnostics report already sends `appId`/`appName`.

Because of this, device-hardware metrics cannot be scoped to a release channel. Every hardware figure silently mixes production installs with RC, dev, `.test`, and QA builds — and QA testers who reinstall frequently get a fresh random device id each time (the `monthlyDeviceHash` rotates monthly and per-install), inflating device counts.

For scale: on the analytics side roughly **half** of all app-diagnostics rows are non-production (RC alone rivals production volume). Device diagnostics has *no* equivalent filter today, so none of that can be excluded.

## Change

- Import `expo-application`.
- Add optional `appId?: string` to `DeviceDiagnosticMetricsData`.
- `setIfNotNull(result, 'appId', Application.applicationId)`, mirroring the app-diagnostics implementation.

The field is optional; older clients omit it, and the ingestion pipeline stores the payload verbatim, so the new field flows through to `events.data` and can be exposed as a column downstream.

## Notes

Emulators are already distinguishable via the existing `isEmulator` field; this adds the missing build/channel dimension. No behavioural change beyond the extra field; no tests reference this payload.