### PR TITLE
fix: use updated settings language

### DIFF
--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -61,15 +61,30 @@ export function createLocaleStore({persist} = {persist: false}) {
         storage: createJSONStorage(() => MMKVStoreInitializer),
         version: 1,
         migrate,
-        // usable language tags can change between app boot ups
-        // this just makes sure the language tag is still usable
-        // if not, then use system preferences
-        onRehydrateStorage: () => state => {
-          if (!state) return;
-          const usable = getUsableLanguageTag(state.languageTag);
-          if (!usable) {
-            store.setState(createInitialState());
+        // Runs on every hydration (unlike `migrate`, which only runs on a
+        // version bump). Its return value becomes the applied state
+        // directly, so there's no need to reach for the store instance,
+        // which doesn't exist in the onRehydrateStorage.
+        merge: (persistedState, currentState) => {
+          const state = persistedState as LocaleState;
+
+          if (state.useSystemPreferences) {
+            // usable language tags can change between app boot ups;
+            // re-resolve from system preferences in case they changed
+            const systemLanguageTags = getLocales().map(l => l.languageTag);
+            return {
+              ...currentState,
+              languageTag:
+                getUsableLanguageTagFromSystemPreferences(systemLanguageTags),
+            };
           }
+
+          // checks that the language tag is still an available language
+          if (!getUsableLanguageTag(state.languageTag)) {
+            return {...currentState, ...createInitialState()};
+          }
+
+          return {...currentState, ...state};
         },
       }),
     );

--- a/src/frontend/contexts/LocaleStoreContext.tsx
+++ b/src/frontend/contexts/LocaleStoreContext.tsx
@@ -66,25 +66,32 @@ export function createLocaleStore({persist} = {persist: false}) {
         // directly, so there's no need to reach for the store instance,
         // which doesn't exist in the onRehydrateStorage.
         merge: (persistedState, currentState) => {
-          const state = persistedState as LocaleState;
+          const parseResults = v.safeParse(LocaleStateSchema, persistedState);
 
-          if (state.useSystemPreferences) {
+          if (!parseResults.success) {
+            return currentState;
+          }
+
+          const validatedPersistedState = parseResults.output;
+
+          if (validatedPersistedState.useSystemPreferences) {
             // usable language tags can change between app boot ups;
             // re-resolve from system preferences in case they changed
             const systemLanguageTags = getLocales().map(l => l.languageTag);
             return {
               ...currentState,
+              ...validatedPersistedState,
               languageTag:
                 getUsableLanguageTagFromSystemPreferences(systemLanguageTags),
             };
           }
 
           // checks that the language tag is still an available language
-          if (!getUsableLanguageTag(state.languageTag)) {
+          if (!getUsableLanguageTag(validatedPersistedState.languageTag)) {
             return {...currentState, ...createInitialState()};
           }
 
-          return {...currentState, ...state};
+          return {...currentState, ...validatedPersistedState};
         },
       }),
     );


### PR DESCRIPTION
closes #1989 

When we simplified the intl provider in #1902, we updated the architecture to persist the language code, and only update the language in the app when the language is changed by user. This means that when the language is changed in the android settings, the provider doesn't get updated, causing the problem in 1902.

Initially i tried to change this in [onRehydrateStorage](https://zustand.docs.pmnd.rs/reference/integrations/persisting-store-data#onrehydratestorage). I tried to hydrate the store with the new language code provided by the android settings. But this was not actually updating the store properly. It seems like it is not properly documented, but due to the synchronous nature of the store, onRehydrateStorage tries to update the store BEFORE the store is initialized (As found by Claude). If we catch the error in the `onRehydrateStorage` you see that it is trying to update a store that is undefined and throwing an error. In the documentation it looks like `onRehydrateStorage` should be used to only update states outside the store.

I then used the [merge](https://zustand.docs.pmnd.rs/reference/integrations/persisting-store-data#merge) function which directly updates the store as seen in the docs. I also moved all the functions originally in the onRehydrateStorage into the `merge` function

Essentially we are checking for the language code in the android settings, and merging that language code into the store state. This means that if the android setting language has changed, that will be reflected in the provider.

One caveat is that this will only update if the app is completely closed and restarted. Trying to update the app language when the app has not restarted would require us to listen for when the app has been backgrounded, and then update the provider in a `useEffect`. While this is something that we could do, I think the complication of that code is not worth doing for a very unlikely edge case.



