### PR TITLE
fix: track bottom sheet (android)

### DIFF
--- a/app.json
+++ b/app.json
@@ -116,7 +116,8 @@
         "android.permission.FOREGROUND_SERVICE_LOCATION",
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
-        "android.permission.CHANGE_WIFI_MULTICAST_STATE"
+        "android.permission.CHANGE_WIFI_MULTICAST_STATE",
+        "android.permission.RECEIVE_BOOT_COMPLETED"
       ],
       "package": "com.comapeo"
     },

--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,7 @@ module.exports = function (api) {
     presets: ['babel-preset-expo'],
     plugins: [
       ['transform-inline-environment-variables', {include: requiredEnvVars}],
-      // react-native-reanimated/plugin has to be last
+      // react-native-worklets/plugin has to be last
       'react-native-worklets/plugin',
     ],
   };

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,7 +22,7 @@ module.exports = function (api) {
     plugins: [
       ['transform-inline-environment-variables', {include: requiredEnvVars}],
       // react-native-reanimated/plugin has to be last
-      'react-native-reanimated/plugin',
+      'react-native-worklets/plugin',
     ],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "react-native-mmkv": "4.3.1",
         "react-native-nitro-modules": "0.35.9",
         "react-native-progress": "5.0.1",
-        "react-native-reanimated": "4.5.0",
+        "react-native-reanimated": "4.5.2",
         "react-native-restart": "0.0.28",
         "react-native-safe-area-context": "5.7.0",
         "react-native-scale-bar": "1.0.6",
@@ -27981,9 +27981,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.5.0.tgz",
-      "integrity": "sha512-+iPfvK34PKKYP/p/4TaBliFkbfvjGDIvXuiiaxvISP5ip7sWegvlacwU/uAV6zNDSSmX0tDyER7PurPMKGDipA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.5.2.tgz",
+      "integrity": "sha512-2XF4a2VyKTy3bxugm9teClxwQ9X4pIkFmoKxIwMQqJdhoFQvjN7In/faKWtjQ8bxTYG+uIJyl6F7oxEwkngjKA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27993,7 +27993,7 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "0.83 - 0.86",
-        "react-native-worklets": "0.10.x"
+        "react-native-worklets": "0.10.x - 0.11.x"
       }
     },
     "node_modules/react-native-restart": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-mmkv": "4.3.1",
     "react-native-nitro-modules": "0.35.9",
     "react-native-progress": "5.0.1",
-    "react-native-reanimated": "4.5.0",
+    "react-native-reanimated": "4.5.2",
     "react-native-restart": "0.0.28",
     "react-native-safe-area-context": "5.7.0",
     "react-native-scale-bar": "1.0.6",

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
@@ -1,27 +1,34 @@
 import React from 'react';
 import {GPSForegroundPermissionDisabled} from './GPSForegroundPermissionDisabled';
 import * as Location from 'expo-location';
-import {Linking, StyleSheet, View, AppState} from 'react-native';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {
+  Linking,
+  StyleSheet,
+  View,
+  AppState,
+  LayoutChangeEvent,
+  useWindowDimensions,
+} from 'react-native';
 import {GPSBackgroundPermissionDisabled} from './GPSBackgroundPermissionDisabled';
 import {Loading} from '../../../sharedComponents/Loading';
 import {StartStopTrack} from './StartStopTrack';
-import Animated, {SlideInDown, SlideOutDown} from 'react-native-reanimated';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 import {WHITE} from '../../../lib/styles';
 import {useFocusEffect} from '@react-navigation/native';
 import {useLocationPermissionModalMutation} from '../../../hooks/useLocationPermissionTracker';
-import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 
 const handleOpenSettings = () => {
   Linking.sendIntent('android.settings.LOCATION_SOURCE_SETTINGS');
 };
 
-export const TrackBottomSheet = React.memo(() => {
-  // The sheet anchors to the bottom of the (tab-bar-inset) scene; without the
-  // bottom inset its content sits flush against the tab bar and the action
-  // button reads as tucked under it on devices with a home indicator.
-  const insets = useSafeAreaInsets();
-  const bottomBarHeight = useBottomTabBarHeight();
+const ANIMATION_DURATION = 250;
+
+export const TrackBottomSheet = React.memo(({isOpen}: {isOpen: boolean}) => {
+  const {height} = useWindowDimensions();
   const [foregroundPermission, setForegroundPermission] =
     React.useState<Location.LocationPermissionResponse | null>(null);
   const [backgroundPermission, setBackgroundPermission] =
@@ -43,18 +50,23 @@ export const TrackBottomSheet = React.memo(() => {
     setBackgroundPermission(background);
   }, []);
 
-  // Re-check permissions on screen focus
+  // Re-check permissions on screen focus, but only while the sheet is open.
   // Handles re-checking when navigating back from in-app
   useFocusEffect(
     React.useCallback(() => {
-      checkPermissions();
-    }, [checkPermissions]),
+      if (isOpen) {
+        checkPermissions();
+      }
+    }, [isOpen, checkPermissions]),
   );
   // Re-check permissions when returning from system settings
   // App goes to background during system settings, then becomes active again when user returns
-  // Only needed if permissions haven't been granted yet
+  // Only needed if the sheet is open and permissions haven't been granted yet
   React.useEffect(() => {
-    if (foregroundPermission?.granted && backgroundPermission?.granted) {
+    if (
+      !isOpen ||
+      (foregroundPermission?.granted && backgroundPermission?.granted)
+    ) {
       return;
     }
 
@@ -66,6 +78,7 @@ export const TrackBottomSheet = React.memo(() => {
 
     return () => sub.remove();
   }, [
+    isOpen,
     foregroundPermission?.granted,
     backgroundPermission?.granted,
     checkPermissions,
@@ -112,30 +125,44 @@ export const TrackBottomSheet = React.memo(() => {
     return <StartStopTrack />;
   };
 
-  const sheetStyle = [
-    styles.animatedBackground,
-    {paddingBottom: insets.bottom + bottomBarHeight},
-  ];
-
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';
+
+  const measuredHeight = React.useRef(height);
+  const translateY = useSharedValue(height);
+
+  React.useEffect(() => {
+    translateY.value = withTiming(isOpen ? 0 : measuredHeight.current, {
+      duration: ANIMATION_DURATION,
+    });
+  }, [isOpen, translateY]);
+
+  const onLayoutSheet = (event: LayoutChangeEvent) => {
+    measuredHeight.current = event.nativeEvent.layout.height;
+  };
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{translateY: translateY.value}],
+  }));
+
   if (isE2E) {
+    if (!isOpen) {
+      return null;
+    }
     return (
       <View style={styles.container}>
-        <View style={sheetStyle}>{renderContent()}</View>
+        <View style={styles.animatedBackground}>{renderContent()}</View>
       </View>
     );
-  } else
-    return (
-      // Semi hacky, but without this <View> the animated view bounces too far initially and then bounces back down to adjust.
-      <View style={styles.container}>
-        <Animated.View
-          style={sheetStyle}
-          entering={SlideInDown.duration(250)}
-          exiting={SlideOutDown.duration(250)}>
-          {renderContent()}
-        </Animated.View>
-      </View>
-    );
+  }
+
+  return (
+    <Animated.View
+      style={[styles.animatedBackground, animatedStyle]}
+      onLayout={onLayoutSheet}
+      pointerEvents={isOpen ? 'auto' : 'none'}>
+      {renderContent()}
+    </Animated.View>
+  );
 });
 
 const styles = StyleSheet.create({
@@ -153,5 +180,7 @@ const styles = StyleSheet.create({
     minHeight: 140,
     borderTopRightRadius: 10,
     borderTopLeftRadius: 10,
+    position: 'absolute',
+    bottom: 0,
   },
 });

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
@@ -10,6 +10,7 @@ import Animated, {SlideInDown, SlideOutDown} from 'react-native-reanimated';
 import {WHITE} from '../../../lib/styles';
 import {useFocusEffect} from '@react-navigation/native';
 import {useLocationPermissionModalMutation} from '../../../hooks/useLocationPermissionTracker';
+import {useBottomTabBarHeight} from '@react-navigation/bottom-tabs';
 
 const handleOpenSettings = () => {
   Linking.sendIntent('android.settings.LOCATION_SOURCE_SETTINGS');
@@ -20,6 +21,7 @@ export const TrackBottomSheet = React.memo(() => {
   // bottom inset its content sits flush against the tab bar and the action
   // button reads as tucked under it on devices with a home indicator.
   const insets = useSafeAreaInsets();
+  const bottomBarHeight = useBottomTabBarHeight();
   const [foregroundPermission, setForegroundPermission] =
     React.useState<Location.LocationPermissionResponse | null>(null);
   const [backgroundPermission, setBackgroundPermission] =
@@ -112,7 +114,7 @@ export const TrackBottomSheet = React.memo(() => {
 
   const sheetStyle = [
     styles.animatedBackground,
-    {paddingBottom: 30 + insets.bottom},
+    {paddingBottom: insets.bottom + bottomBarHeight},
   ];
 
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';

--- a/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
+++ b/src/frontend/screens/MapScreen/TrackBottomSheet/index.tsx
@@ -128,6 +128,9 @@ export const TrackBottomSheet = React.memo(({isOpen}: {isOpen: boolean}) => {
   const isE2E = process.env.EXPO_PUBLIC_E2E_TEST === 'true';
 
   const measuredHeight = React.useRef(height);
+  // translateY moves the object down and the sheet is pinned to the bottom of the screen
+  // By setting the initial value to the height of the screen, it will be moved completely off the screen
+  // This means that it is NOT shown at first, which is desired
   const translateY = useSharedValue(height);
 
   React.useEffect(() => {

--- a/src/frontend/screens/MapScreen/index.tsx
+++ b/src/frontend/screens/MapScreen/index.tsx
@@ -222,7 +222,7 @@ export const MapScreen = ({
         bottom={20}
       />
 
-      {trackBottomSheetOpen && <TrackBottomSheet />}
+      <TrackBottomSheet isOpen={!!trackBottomSheetOpen} />
     </View>
   );
 };


### PR DESCRIPTION
closes #2019 

After spending a long time playing around with the app, the entering [layout animation](https://docs.swmansion.com/react-native-reanimated/docs/layout-animations/layout-transitions) was causing problems. It seems like it was causing the bottom sheet to 1. not render properly and 2. the buttons inside the bottoms sheet were un-clickable. In order to fix this, I changed the animation to use [`useSharedValue`](https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue) instead.

Unfortunately the animation logic is slightly more complicated now, but it is working consistently.

I also [updated the babel config plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#react-native-community-cli), as our was outdated with the v2 plugin.