### PR TITLE
fix: add permission so tracks does not crash

### DIFF
--- a/app.json
+++ b/app.json
@@ -116,7 +116,8 @@
         "android.permission.FOREGROUND_SERVICE_LOCATION",
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
-        "android.permission.CHANGE_WIFI_MULTICAST_STATE"
+        "android.permission.CHANGE_WIFI_MULTICAST_STATE",
+        "android.permission.RECEIVE_BOOT_COMPLETED"
       ],
       "package": "com.comapeo"
     },


### PR DESCRIPTION
closes #2036.

Starting a track caused the entire app to hard-crash (FATAL EXCEPTION in TaskBroadcastReceiver, SIG 9) as soon as the first background location update was delivered.

Expo-location's background location task consumer schedules a persisted JobScheduler job on each location report. Android requires the RECEIVE_BOOT_COMPLETED permission for any persisted job request, or it throws IllegalArgumentException — and since this happens inside a native BroadcastReceiver, it's unrecoverable from JS 

Adding `android.permission.RECEIVE_BOOT_COMPLETED` to the Android permissions list in app.json fixes the issue.

This is stacked ontop of #2035 because the tracks sheet is inacessible without it.
