### PR TITLE
chore: always run expo start in dev client mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ios": "npm run build:backend && npm run ios-no-backend-rebuild",
     "ios-no-backend-rebuild": "expo run:ios",
     "prestart": "npm run build:translations && npm run build:intl-polyfills",
-    "start": "expo start",
+    "start": "expo start --dev-client",
     "lint:prettier": "prettier \"src/**/*.{js,ts,jsx,tsx}\" --check",
     "lint:eslint": "eslint --cache .",
     "lint:types": "tsc --noEmit",


### PR DESCRIPTION
`expo-dev-client` was removed in https://github.com/digidem/comapeo-mobile/pull/1820 under the assumption that it isn't directly used anywhere. however - from what I can tell - running `expo start` will have different default behavior based on whether this module is installed (even if it's not configured in the `app.json`). without the module installed, the development server runs in "Expo Go" mode:

```console
› Using Expo Go
› Press s │ switch to development build
```

This mode generally does not work for our application because of the use of native modules that aren't registered with Expo Go. It's also generally recommended by Expo to run the server in development client mode for non-trivial apps.

If using `expo-dev-client` is not desirable, you can force Expo to use the development build by passing `--dev-client` to `expo start`, which is what this PR introduces. The console output will show this instead:

```console
› Using development build
› Press s │ switch to Expo Go
```