### PR TITLE
fix: jest-test-fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const NODE_MODULE_PATTERNS_TO_TRANSFORM = [
   '@react-native',
   '@?expo',
   '@?react-navigation',
-  '@sentry/react-native',
+  '@sentry/',
   'native-base',
   // Awana modules distributed as ESM
   '@comapeo/',
@@ -61,6 +61,7 @@ const NODE_MODULE_PATTERNS_TO_TRANSFORM = [
 const config = {
   preset: 'jest-expo',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  resolver: './node_modules/react-native-worklets/jest/resolver.js',
   // https://react-native-documents.github.io/docs/sponsor-only/jest-mocks
   setupFiles: [
     './node_modules/@react-native-documents/picker/jest/build/jest/setup.js',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,11 @@
 import {jest, afterAll} from '@jest/globals';
+import {performance as nodePerformance} from 'node:perf_hooks';
+
+// undici reads `performance.markResourceTiming` at import time (as early as
+// @comapeo/core's own imports), so it must be patched before any test file loads.
+
+globalThis.performance.markResourceTiming =
+  nodePerformance.markResourceTiming.bind(nodePerformance);
 
 jest.mock('./translations/index', () => {
   const actual = jest.requireActual('./translations/index');

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "expo-linking": "56.0.14",
         "expo-localization": "56.0.6",
         "expo-location": "56.0.18",
+        "expo-modules-core": "56.0.21",
         "expo-secure-store": "56.0.4",
         "expo-sensors": "56.0.6",
         "expo-splash-screen": "56.0.10",
@@ -175,6 +176,7 @@
         "type-fest": "5.7.0",
         "typescript": "5.9.3",
         "typescript-eslint": "8.62.1",
+        "undici": "6.25.0",
         "webdriverio": "9.29.1",
         "zod-validation-error": "4.0.2"
       }
@@ -17309,6 +17311,27 @@
         "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
       }
     },
+    "node_modules/expo-modules-core": {
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.21.tgz",
+      "integrity": "sha512-lT413DZFuX/cSsOqGtZnqtyCGlY3F3FFDiVhwzB8wX4Ei9HZYPXhV59Mm8SNJquo8+JfLRi3arv3z5U4MqJRcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/expo-modules-macros-plugin": "0.2.2",
+        "expo-modules-jsi": "~56.0.12",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": "^0.7.4 || ^0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-worklets": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-modules-jsi": {
       "version": "56.0.12",
       "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.12.tgz",
@@ -17626,27 +17649,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/expo/node_modules/expo-modules-core": {
-      "version": "56.0.21",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.21.tgz",
-      "integrity": "sha512-lT413DZFuX/cSsOqGtZnqtyCGlY3F3FFDiVhwzB8wX4Ei9HZYPXhV59Mm8SNJquo8+JfLRi3arv3z5U4MqJRcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/expo-modules-macros-plugin": "0.2.2",
-        "expo-modules-jsi": "~56.0.12",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*",
-        "react-native-worklets": "^0.7.4 || ^0.8.0"
-      },
-      "peerDependenciesMeta": {
-        "react-native-worklets": {
-          "optional": true
-        }
       }
     },
     "node_modules/expo/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "expo-linking": "56.0.14",
     "expo-localization": "56.0.6",
     "expo-location": "56.0.18",
+    "expo-modules-core": "56.0.21",
     "expo-secure-store": "56.0.4",
     "expo-sensors": "56.0.6",
     "expo-splash-screen": "56.0.10",
@@ -196,13 +197,17 @@
     "type-fest": "5.7.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.62.1",
+    "undici": "6.25.0",
     "webdriverio": "9.29.1",
     "zod-validation-error": "4.0.2"
   },
   "overrides": {
     "axios": "1.15.0",
     "basic-ftp": "5.2.0",
-    "require-addon": "1.1.0"
+    "require-addon": "1.1.0",
+    "expo-modules-core": {
+      "react-native-worklets": "$react-native-worklets"
+    }
   },
   "expo": {
     "install": {

--- a/src/frontend/metrics/sendMetricsData.test.ts
+++ b/src/frontend/metrics/sendMetricsData.test.ts
@@ -1,10 +1,18 @@
 import * as http from 'node:http';
 import {buffer} from 'node:stream/consumers';
 import {promisify} from 'node:util';
+import {useRealFetch} from '../../../tests/integration/helpers/core';
 import {sendMetricsData} from './sendMetricsData';
 
 describe('sendMetricsReport', () => {
   let teardowns: Array<() => unknown>;
+  let callFetch: () => void;
+
+  beforeAll(() => {
+    callFetch = useRealFetch();
+  });
+
+  afterAll(() => callFetch());
 
   beforeEach(() => {
     teardowns = [];

--- a/src/frontend/packageJson.test.ts
+++ b/src/frontend/packageJson.test.ts
@@ -3,38 +3,14 @@ import * as path from 'node:path';
 import * as semver from 'semver';
 
 describe('frontend package.json', () => {
-  let frontendMapeoDependencies: Record<string, string>;
-  let backendMapeoDependencies: Record<string, string>;
   let allFrontendDependencies: Record<string, string>;
 
   beforeAll(async () => {
     const rootPath = path.resolve(__dirname, '..', '..');
     const frontendPackageJsonPath = path.join(rootPath, 'package.json');
-    const backendPackageJsonPath = path.join(
-      rootPath,
-      'src',
-      'backend',
-      'package.json',
+    allFrontendDependencies = await readAllDependencies(
+      frontendPackageJsonPath,
     );
-    [
-      frontendMapeoDependencies,
-      backendMapeoDependencies,
-      allFrontendDependencies,
-    ] = await Promise.all([
-      readMapeoDependencies(frontendPackageJsonPath),
-      readMapeoDependencies(backendPackageJsonPath),
-      readAllDependencies(frontendPackageJsonPath),
-    ]);
-  });
-
-  it('uses versions of @mapeo dependencies that match their backend counterparts', () => {
-    for (const [dependency, frontendVersion] of Object.entries(
-      frontendMapeoDependencies,
-    )) {
-      const backendVersion = backendMapeoDependencies[dependency];
-      if (!backendVersion) continue;
-      expect(semver.satisfies(frontendVersion, backendVersion)).toBe(true);
-    }
   });
 
   it('all front end dependencies use exact version', () => {
@@ -44,22 +20,6 @@ describe('frontend package.json', () => {
     }
   });
 });
-
-async function readMapeoDependencies(
-  packageJsonPath: string,
-): Promise<Record<string, string>> {
-  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
-  const {dependencies = {}, devDependencies = {}} = packageJson;
-  const allDependencies: Record<string, string> = {
-    ...dependencies,
-    ...devDependencies,
-  };
-  const mapeoEntries = Object.entries(allDependencies).filter(
-    ([dependency]) =>
-      dependency.startsWith('@mapeo/') || dependency.startsWith('@comapeo/'),
-  );
-  return Object.fromEntries(mapeoEntries);
-}
 
 async function readAllDependencies(
   packageJsonPath: string,

--- a/tests/integration/helpers/core.ts
+++ b/tests/integration/helpers/core.ts
@@ -217,7 +217,7 @@ export const createTestServer = (): Promise<{
     });
   });
 
-// jest-expo stubs `fetch` with a non-working stub; this swaps in undici's real implementation.
+// jest-expo subs `fetch` with a non-working stub; this swaps in undici's real implementation.
 export function useRealFetch(): () => void {
   const originalFetch = global.fetch;
   const originalHeaders = global.Headers;

--- a/tests/integration/helpers/core.ts
+++ b/tests/integration/helpers/core.ts
@@ -182,6 +182,10 @@ export const createTestServer = (): Promise<{
 
     childProcess.unref();
 
+    // @comapeo/core needs to reach the server spawned above (e.g. to add it
+    // as a peer).
+    const callFetch = useRealFetch();
+
     childProcess.stdout.on('data', data => {
       const url = data.toString().trim();
 
@@ -190,10 +194,12 @@ export const createTestServer = (): Promise<{
           serverBaseUrl: url,
           close: () => {
             childProcess.kill('SIGTERM');
+            callFetch();
           },
         });
       } else {
         childProcess.kill();
+        callFetch();
         reject(new Error('Test is not set up correctly: invalid URL'));
       }
     });
@@ -210,6 +216,24 @@ export const createTestServer = (): Promise<{
       }
     });
   });
+
+// jest-expo stubs `fetch` with a non-working stub; this swaps in undici's real implementation.
+export function useRealFetch(): () => void {
+  const originalFetch = global.fetch;
+  const originalHeaders = global.Headers;
+  const originalResponse = global.Response;
+
+  const {fetch, Headers, Response} = require('undici');
+  global.fetch = fetch;
+  global.Headers = Headers;
+  global.Response = Response;
+
+  return () => {
+    global.fetch = originalFetch;
+    global.Headers = originalHeaders;
+    global.Response = originalResponse;
+  };
+}
 
 function urlIsValid(url: string): boolean {
   try {


### PR DESCRIPTION
closes #2017 
At first, every test file failed with "Cannot find module 'expo-modules-core'." 
This PR fixes that and all the issues that surfaced after that was resolved; now all tests (68 suites / 760 tests) pass again.

1. `expo-modules-core` was only a transitive dependency of expo and wasn't hoisted to the top level of node modules, so jest-expo's setup couldn't require() it. I pinned it as a direct dependency, with an overrides entry so its optional peer on react-native-worklets resolves to the version this app already pins (because otherwise the npm install failed).
2. `react-native-worklets` 0.10 crashes under Jest. So, I wired up the jest resolver react-native-worklets ships for this problem exactly, so tests load its JS mock instead.
3. @sentry/core and other @sentry/* sub-packages ship ESM-only and weren't in the Babel transform allowlist.
4. jest-expo now substitutes the global fetch with a stub that does nothing — this broke two tests that need to spin up a real local HTTP server and expect fetch to reach it (`sendMetricsData.test.ts` and `Exchange/index.test.tsx`, the latter via @comapeo/core's member-api adding a server peer). So I added a shared helper that swaps in [undici](https://github.com/nodejs/undici)'s real implementation for those cases. Because of using undici, jest.setup.js now needs a patch for performance.markResourceTiming, which undici reads at import time, so it has to happen before any test file's own imports run.
5. `packageJson.test.ts` compared frontend and backend package.json dependency versions; that comparison is irrelevant now that src/backend/ is gone, so I removed that test/ check.
