### PR TITLE
chore: upgrade core-react-native to the @latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@comapeo/core-react": "11.0.7",
-        "@comapeo/core-react-native": "1.0.0-pre.7",
+        "@comapeo/core-react-native": "1.0.0-pre.9",
         "@comapeo/default-categories": "1.1.2",
         "@comapeo/ipc": "8.0.0",
         "@expo-google-fonts/rubik": "0.4.2",
@@ -2576,12 +2576,12 @@
       }
     },
     "node_modules/@comapeo/core-react-native": {
-      "version": "1.0.0-pre.7",
-      "resolved": "https://registry.npmjs.org/@comapeo/core-react-native/-/core-react-native-1.0.0-pre.7.tgz",
-      "integrity": "sha512-I0l/SHrtBYJGOFxWE+6QPFJZ047wcx+5cNIWtMKs+zFh10NCPZeHlIA9HC0i5WMPynGUWHZovVNhXOvZhpS2Dg==",
+      "version": "1.0.0-pre.9",
+      "resolved": "https://registry.npmjs.org/@comapeo/core-react-native/-/core-react-native-1.0.0-pre.9.tgz",
+      "integrity": "sha512-om+QTQ6NIBDQRO2EBJPDF9GxqvtfcFXhJwpdsJlNhZ2vBp2fcyuBfh6zOWnM0yZbvWPYjV0MK35sztoSRPbaWA==",
       "license": "MIT",
       "dependencies": {
-        "@comapeo/ipc": "^9.0.0-pre.2"
+        "@comapeo/ipc": "9.0.0"
       },
       "bin": {
         "comapeo-rn-upload-sourcemaps": "build/cli/upload-sourcemaps.js"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@comapeo/core-react": "11.0.7",
-    "@comapeo/core-react-native": "1.0.0-pre.7",
+    "@comapeo/core-react-native": "1.0.0-pre.9",
     "@comapeo/default-categories": "1.1.2",
     "@comapeo/ipc": "8.0.0",
     "@expo-google-fonts/rubik": "0.4.2",


### PR DESCRIPTION
closes #2041.
closes #2042.

This PR just upgrades core-react-native to v1.0.0-pre9.

Unfortunately this introduces new invite errors which i am logging. But since we are not merging this into develop, i think for posterity we should merge this into the core-react-native branch, which will close the 2 issues above. This will introduce the new errors, but that can be fixed with a later PR.