### PR TITLE
fix: do not specify coordinates when initializing a draft observation

### DIFF
--- a/src/frontend/contexts/DraftObservationContext.test.tsx
+++ b/src/frontend/contexts/DraftObservationContext.test.tsx
@@ -179,8 +179,6 @@ describe('useDraftObservationActions()', () => {
       expect(stateHook.result.current.unsavedAttachments).toStrictEqual([]);
       expect(stateHook.result.current.value).toStrictEqual({
         schemaName: 'observation',
-        lat: 0,
-        lon: 0,
         metadata: {manualLocation: false},
         tags: {notes: ''},
         attachments: [],

--- a/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
+++ b/src/frontend/contexts/PersistedStores/DraftObservationStore.ts
@@ -509,8 +509,6 @@ function createEmptyStoreState(): DraftStateEmpty {
 function createEmptyObservationValue(): ObservationValueWithPreset {
   return {
     schemaName: 'observation',
-    lat: 0,
-    lon: 0,
     metadata: {manualLocation: false},
     tags: {
       notes: '',


### PR DESCRIPTION
Fixes #2048 

Removes the (0,0) coordinate initialization for an "empty" observation. This prevents the issue of an observation defaulting to Null Island when a location isn't registered by the time it's created. Instead, no coordinates are specified for the saved observation, which I _think_ makes more sense in this case.

---

Example observation when doing the repro steps in original issue with this change applied:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a9018a4e-f5b8-4a6e-9f4c-d822d0460663" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0ea8a8a4-1820-4b21-b37e-72603f213e4e" />
