### PR TITLE
fix: fix blank drawer menu (experimental)

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -80,3 +80,9 @@ See: [Reviewer context](https://github.com/digidem/comapeo-mobile/pull/1225).
 
 Modifies Expo's native fetch implementation to stream files directly to the fetch request rather than loading them into memory. This patch enables streaming uploads by modifying the native Android code to read and transmit files in chunks. This prevents out-of-memory (OOM) errors when uploading large files (e.g., over 200MB).
 Refer to this [issue](https://github.com/expo/expo/issues) and this [PR](https://github.com/expo/expo/pull) which have been created to address this limitation in Expo's fetch implementation.
+
+## `react-native-drawer-layout`
+
+### [Experimental fix for empty drawer on Android](./react-native-drawer-layout+4.2.4.patch)
+
+Hard-to-reproduce issue where the drawer is empty on Android. It's possible that this is caused by `removeClippedSubviews` being set to `true` on Android, which could result in the drawer not being re-attached in some circumstances. The cost of setting `removeClippedSubviews` to `false` is that the drawer will always be rendered, even when it's not visible, which should have minimal impact on performance given that the drawer is small and there is only one of them.

--- a/patches/react-native-drawer-layout+4.2.4.patch
+++ b/patches/react-native-drawer-layout+4.2.4.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js b/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
+index 5fb761c..4a7face 100644
+--- a/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
++++ b/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
+@@ -296,7 +296,7 @@ export function Drawer({
+                 accessibilityLabel: overlayAccessibilityLabel
+               }) : null]
+             }), /*#__PURE__*/_jsx(Animated.View, {
+-              removeClippedSubviews: Platform.OS !== 'ios',
++              removeClippedSubviews: false,
+               style: [styles.drawer, {
+                 width: drawerWidth,
+                 position: drawerType === 'permanent' ? 'relative' : 'absolute'
+diff --git a/node_modules/react-native-drawer-layout/src/views/Drawer.native.tsx b/node_modules/react-native-drawer-layout/src/views/Drawer.native.tsx
+index ff41791..e8de76a 100644
+--- a/node_modules/react-native-drawer-layout/src/views/Drawer.native.tsx
++++ b/node_modules/react-native-drawer-layout/src/views/Drawer.native.tsx
+@@ -484,7 +484,7 @@ export function Drawer({
+                 ) : null}
+               </Animated.View>
+               <Animated.View
+-                removeClippedSubviews={Platform.OS !== 'ios'}
++                removeClippedSubviews={false}
+                 style={[
+                   styles.drawer,
+                   {


### PR DESCRIPTION
Fixes #1613

Ran a Claude Fable pass on this, and nothing from our code was showing any suspects for causing this bug. The one issue identified was the `removeClippedSubviews` setting on Android, which could cause the drawer contents not to be re-attached in certain circumstances when there is a race on re-rendering, which could happen on a project switch, related to #2057 which causes the drawer to be removed and re-rendered during the suspense phase from when a project is switched. 