### PR TITLE
fix: camera permissions screen unexpected appearance

### DIFF
--- a/messages/en-US/primary.json
+++ b/messages/en-US/primary.json
@@ -337,6 +337,9 @@
   "$1screens.AudioRecording.nowRecording": {
     "message": "Now Recording..."
   },
+  "$1screens.CameraScreen.cameraUnavailable": {
+    "message": "Camera unavailable. Please close and reopen CoMapeo to try again."
+  },
   "$1screens.CameraScreen.noCameraAccess": {
     "message": "No access to camera. Please allow access in settings."
   },

--- a/patches/README.md
+++ b/patches/README.md
@@ -74,6 +74,20 @@ Fixes a bug in the `MaskSymbol` component where the mask (`*`) briefly un-hides 
 
 See: [Reviewer context](https://github.com/digidem/comapeo-mobile/pull/1225).
 
+## react-native-vision-camera
+
+### [Fix camera device list startup race](./react-native-vision-camera+4.7.3+001+fix-camera-devices-startup-race.patch)
+
+`CameraDevicesManager` sends its device list to JS only at startup, but builds that list from `cameraProvider` and
+`extensionsManager`, which initialise asynchronously and yield an empty list until both are set. When initialisation
+loses that race, JS caches the empty list and nothing ever re-emits, so `useCameraDevice()` returns `undefined` — and the
+camera screen stays unavailable — until the app is restarted. This patch emits `CameraDevicesChanged` once
+initialisation completes, and re-sends the current list when JS subscribes, since events emitted before then are
+dropped.
+
+Fixed upstream in v5, which requires the New Architecture. 4.7.3 is the final 4.x release, so there is nothing to
+upgrade to.
+
 ## expo
 
 ### [Enable streaming file uploads in fetch API](./expo+54.0.33.patch)

--- a/patches/react-native-vision-camera+4.7.3+001+fix-camera-devices-startup-race.patch
+++ b/patches/react-native-vision-camera+4.7.3+001+fix-camera-devices-startup-race.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt b/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+index 0386478..723dcba 100644
+--- a/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
++++ b/node_modules/react-native-vision-camera/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
+ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+   companion object {
+     private const val TAG = "CameraDevices"
++    private const val DEVICES_CHANGED_NAME = "CameraDevicesChanged"
+   }
+   private val executor = CameraQueues.cameraExecutor
+   private val coroutineScope = CoroutineScope(executor.asCoroutineDispatcher())
+@@ -68,6 +69,10 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) :
+         Log.i(TAG, "Initializing ExtensionsManager...")
+         extensionsManager = ExtensionsManager.getInstanceAsync(reactContext, cameraProvider!!).await(executor)
+         Log.i(TAG, "Successfully initialized!")
++        // getDevicesJson() returns an empty list until both of the above are set, so any
++        // earlier emission was empty. Without this, JS keeps that empty list for the
++        // entire app session and useCameraDevice() never returns a device.
++        sendAvailableDevicesChangedEvent()
+       } catch (error: Throwable) {
+         Log.e(TAG, "Failed to initialize ProcessCameraProvider/ExtensionsManager! Error: ${error.message}", error)
+       }
+@@ -99,9 +104,10 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) :
+   }
+ 
+   fun sendAvailableDevicesChangedEvent() {
++    if (!reactContext.hasActiveReactInstance()) return
+     val eventEmitter = reactContext.getJSModule(RCTDeviceEventEmitter::class.java)
+     val devices = getDevicesJson()
+-    eventEmitter.emit("CameraDevicesChanged", devices)
++    eventEmitter.emit(DEVICES_CHANGED_NAME, devices)
+   }
+ 
+   override fun getConstants(): MutableMap<String, Any?> {
+@@ -114,10 +120,13 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) :
+     )
+   }
+ 
+-  // Required for NativeEventEmitter, this is just a dummy implementation:
+-  @Suppress("unused", "UNUSED_PARAMETER")
++  // JS subscribes at bundle-eval time, which can be later than the init above emitted.
++  // RCTDeviceEventEmitter drops events that have no listeners, so re-send on subscribe.
++  @Suppress("unused")
+   @ReactMethod
+-  fun addListener(eventName: String) {}
++  fun addListener(eventName: String) {
++    if (eventName == DEVICES_CHANGED_NAME) sendAvailableDevicesChangedEvent()
++  }
+ 
+   @Suppress("unused", "UNUSED_PARAMETER")
+   @ReactMethod

--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -117,14 +117,6 @@ export const CameraView = ({onAddPress}: Props) => {
 
   const disableButton = capturing || !cameraReady || !hasPermission;
 
-  console.log('CAMERA_DEBUG', {
-    hasDevice: !!device,
-    deviceCount: Camera.getAvailableCameraDevices().length,
-    positions: Camera.getAvailableCameraDevices().map(d => d.position),
-    hasPermission,
-    permissionStatus: Camera.getCameraPermissionStatus(),
-  });
-
   let cameraContent;
   if (!hasPermission) {
     cameraContent = (

--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -33,6 +33,11 @@ const m = defineMessages({
     id: '$1screens.CameraScreen.openSettings',
     defaultMessage: 'Open Settings',
   },
+  cameraUnavailable: {
+    id: '$1screens.CameraScreen.cameraUnavailable',
+    defaultMessage:
+      'Camera unavailable. Please close and reopen CoMapeo to try again.',
+  },
 });
 
 type Props = {
@@ -112,31 +117,54 @@ export const CameraView = ({onAddPress}: Props) => {
 
   const disableButton = capturing || !cameraReady || !hasPermission;
 
+  console.log('CAMERA_DEBUG', {
+    hasDevice: !!device,
+    deviceCount: Camera.getAvailableCameraDevices().length,
+    positions: Camera.getAvailableCameraDevices().map(d => d.position),
+    hasPermission,
+    permissionStatus: Camera.getCameraPermissionStatus(),
+  });
+
+  let cameraContent;
+  if (!hasPermission) {
+    cameraContent = (
+      <View style={styles.messageContainer}>
+        <BodyText variant="tinyMeta" style={styles.messageText}>
+          {formatMessage(m.noCameraAccess)}
+        </BodyText>
+        <PrimaryButton
+          fullSize
+          text={formatMessage(m.openSettings)}
+          onPress={() => openSettingsMutation.mutateAsync()}
+        />
+      </View>
+    );
+  } else if (!device) {
+    cameraContent = (
+      <View style={styles.messageContainer}>
+        <BodyText variant="tinyMeta" style={styles.messageText}>
+          {formatMessage(m.cameraUnavailable)}
+        </BodyText>
+      </View>
+    );
+  } else {
+    cameraContent = (
+      <Camera
+        device={device}
+        ref={camera}
+        style={{flex: 1}}
+        isActive={true}
+        photo={true}
+        enableZoomGesture={true}
+        onInitialized={() => setCameraReady(true)}
+      />
+    );
+  }
+
   return (
     <View style={styles.container} testID="MAIN.camera-scrn">
       <StatusBar barStyle="light-content" />
-      {!hasPermission || !device ? (
-        <View style={styles.noPermissionContainer}>
-          <BodyText variant="tinyMeta" style={styles.noPermissionText}>
-            {formatMessage(m.noCameraAccess)}
-          </BodyText>
-          <PrimaryButton
-            fullSize
-            text={formatMessage(m.openSettings)}
-            onPress={() => openSettingsMutation.mutateAsync()}
-          />
-        </View>
-      ) : (
-        <Camera
-          device={device}
-          ref={camera}
-          style={{flex: 1}}
-          isActive={true}
-          photo={true}
-          enableZoomGesture={true}
-          onInitialized={() => setCameraReady(true)}
-        />
-      )}
+      {cameraContent}
 
       <View style={styles.bottomBar}>
         <View style={styles.gpsPillContainer}>
@@ -161,14 +189,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'black',
   },
-  noPermissionContainer: {
+  messageContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     gap: 30,
     paddingHorizontal: 40,
   },
-  noPermissionText: {
+  messageText: {
     color: 'white',
     textAlign: 'center',
   },


### PR DESCRIPTION
closes #2053 

### Summary

The camera screen sometimes says "No access to camera. Please allow access in settings." even though camera permission is granted. It stays broken until the app is restarted.

This was not a permissions bug. It's a startup race in react-native-vision-camera that leaves the app with an empty camera device list. This PR patches the library and splits the error screen so a missing camera is no longer reported as a missing permission.

This PR applies a patch to fix the race condition and some different UI. See below!

### What the problem was and wasn't

**What it wasn't**: permissions. Captured live on a device while the screen referenced above (No access to camera) was showing:

I logged it this way: 
```
CAMERA_DEBUG {deviceCount: 0, hasDevice: false, hasPermission: true, permissionStatus: "granted"}
adb: android.permission.CAMERA: granted=true
```
Permission was granted at every level. That's why "Open Settings" never helped anyone in the field — the settings were already correct.

**What it was**: the app had zero camera devices. vision-camera hands the camera list to JS once at startup, and that list is empty until CameraX finishes initialising in the background. If startup wins that race, JS caches the empty list — nothing ever re-sends it — so useCameraDevice('back') returns undefined for the rest of the app session.

Our screen showed the permission message for both "no permission" and "no camera device," so a device problem looked  like a permission problem. Thanks for this clue, @achou11 !

Why it seems random: the race is decided by about 150ms.

<details> <summary>Evidence from an affected device (Samsung S21)</summary>
Cold start, broken. 
initialize() samples the device list 21ms before CameraX finishes, so JS receives an empty list and never hears again: 

27.342  Initializing ExtensionsManager...   ← binds a Samsung service in a separate OS process
27.470  Camera #0-3 available               ← list sampled here: EMPTY
27.491  Successfully initialized!           ← 21ms too late, nothing is emitted

Reloading JS in the same process (no reinstall, no permission change) fixed it — 0 devices → 4 — because CameraX was warm and the order flipped:

50:12.792  Initializing / Successfully initialized!   ← all in the same millisecond
50:12.964  Camera #0-3 available                      ← list sampled 172ms later: FULL

Six warm cold-starts then won by 118–176ms each. The margin is small enough that slower devices, or devices under load at launch, will lose it routinely.

</details>

### How to reproduce
It's difficult. Here is what I did, but I think it was just luck. I was just starting a Samsung phone that had powered off due to no battery. Once it was charged just enough I powered it on. I deleted the old Comapeo dev app, and ran npm run android which installed a new CoMapeo dev app. I accepted all permissions and onboarded and went to the map. I immediately went to the camera tab and saw the errant screen.

So, in sum, you need CameraX to be slow at startup, which happens on fresh installs, after a reboot or system update, and on slower devices. Force-closing and reopening does not reproduce it; that's what makes it look like it happens "out of the blue".

Deterministically (this is how the fix was verified) — in `node_modules/react-native-vision-camera/android/.../CameraDevicesManager.kt`, add a delay to the top of the init coroutine and rebuild:

`kotlinx.coroutines.delay(45000)`

Without the patch: camera screen is unavailable and stays that way until the app is restarted.
With the patch: camera screen is unavailable, then recovers on its own once initialization finishes, with no user action.

### What the patch does
1. Send the camera list to JS when initialization actually completes (previously it was only ever sent at startup).
2. Re-send the list when JS subscribes, because events sent before JS is listening are dropped.

Both are needed — they cover the two ways the race can be lost. The result is that the device list is no longer a one-shot snapshot: if it arrives late, the UI updates itself.

This problem is fixed in `react-native-vision-camera `v5, which requires the New Architecture. We are on 4.7.3, which is the latest (final?) 4.x release, so there is nothing we can upgrade to. There are [two issues ](https://github.com/mrousavy/react-native-vision-camera/issues/3699) in the repo for this exact problem, and [both are closed ](https://github.com/mrousavy/react-native-vision-camera/issues/3698) with "closed as not planned."

### New screen UI on `CameraView `
Unfortunately (my fault), `CameraView` had one set of UI covering two unrelated failures. 
Now if someone doesn't have camera permissions, they get the cue to open permissions.
If they have no device, they get that message and the clue to reopen CoMapeo instead. 
With the patch, this screen is normally visible for only ~200ms at startup (if at all) before the regular camera preview screen replaces itself. It persists only if CameraX genuinely fails to initialize — in which case restarting the app is what the user needs to do, so the message on the screen (see below) is the most appropriate one.

### Screen shot for new UI
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0ffe7c99-cd43-4075-98c0-c47577799b33" />






