### PR TITLE
fix: blank drawer

### DIFF
--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -23,15 +23,16 @@ import {useAuthContext} from '../../contexts/AuthContext';
 
 const Tab = createBottomTabNavigator<HomeTabsParamsList>();
 
-const APPROX_APP_BAR_HEIGHT = 56;
+// These mirror react-native-drawer-layout's own defaults, so the drawer keeps
+// exactly the size it had before. The gap leaves a strip of screen uncovered
+// beside the open drawer so it can be tapped to dismiss — the library calls it
+// APPROX_APP_BAR_HEIGHT. 360 is the Material Design 3 standard drawer width:
+// https://m3.material.io/components/navigation-drawer/specs
+const DRAWER_EDGE_GAP = 56;
 const MAX_DRAWER_WIDTH = 360;
 
-// Mirrors react-native-drawer-layout's default so the drawer keeps its usual size.
 function getDrawerWidth(windowWidth: number) {
-  return Math.max(
-    Math.min(windowWidth - APPROX_APP_BAR_HEIGHT, MAX_DRAWER_WIDTH),
-    0,
-  );
+  return Math.max(Math.min(windowWidth - DRAWER_EDGE_GAP, MAX_DRAWER_WIDTH), 0);
 }
 
 export const HomeTabs = ({navigation}: NativeRootNavigationProps<'Home'>) => {

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {TouchableOpacity} from 'react-native';
+import {TouchableOpacity, useWindowDimensions} from 'react-native';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {CameraScreen} from '../../screens/CameraScreen';
 import {MapScreen} from '../../screens/MapScreen';
@@ -23,8 +23,20 @@ import {useAuthContext} from '../../contexts/AuthContext';
 
 const Tab = createBottomTabNavigator<HomeTabsParamsList>();
 
+const APPROX_APP_BAR_HEIGHT = 56;
+const MAX_DRAWER_WIDTH = 360;
+
+// Mirrors react-native-drawer-layout's default so the drawer keeps its usual size.
+function getDrawerWidth(windowWidth: number) {
+  return Math.max(
+    Math.min(windowWidth - APPROX_APP_BAR_HEIGHT, MAX_DRAWER_WIDTH),
+    0,
+  );
+}
+
 export const HomeTabs = ({navigation}: NativeRootNavigationProps<'Home'>) => {
   const [drawerOpen, setDrawerOpen] = useOpenDrawer();
+  const drawerWidth = getDrawerWidth(useWindowDimensions().width);
 
   return (
     <>
@@ -39,6 +51,11 @@ export const HomeTabs = ({navigation}: NativeRootNavigationProps<'Home'>) => {
         }}
         drawerType="slide"
         swipeEnabled={false}
+        // The library's `maxWidth: '100%'` resolves to 0 if the panel lays out
+        // while an ancestor is momentarily zero-width — which a suspense
+        // hide/reveal on project switch does, blanking the drawer until restart
+        // (#1613). `width` matches so the library's drawerWidth stays in sync.
+        drawerStyle={{width: drawerWidth, maxWidth: drawerWidth}}
         renderDrawerContent={() => (
           <DrawerMenu
             closeMenu={() => {

--- a/src/frontend/Navigation/Tab/index.tsx
+++ b/src/frontend/Navigation/Tab/index.tsx
@@ -26,9 +26,10 @@ const Tab = createBottomTabNavigator<HomeTabsParamsList>();
 // These mirror react-native-drawer-layout's own defaults, so the drawer keeps
 // exactly the size it had before. The gap leaves a strip of screen uncovered
 // beside the open drawer so it can be tapped to dismiss — the library calls it
-// APPROX_APP_BAR_HEIGHT. 360 is the Material Design 3 standard drawer width:
-// https://m3.material.io/components/navigation-drawer/specs
+// APPROX_APP_BAR_HEIGHT.
 const DRAWER_EDGE_GAP = 56;
+// 360 is the Material Design 3 standard drawer width:
+// https://m3.material.io/components/navigation-drawer/specs
 const MAX_DRAWER_WIDTH = 360;
 
 function getDrawerWidth(windowWidth: number) {


### PR DESCRIPTION
closes #1613 
## Summary

Fixes when the drawer menu sometimes opens blank.

It happens after switching projects or accepting an invite. Once it happens, the drawer stays blank until the app is restarted.

**Cause:** the sliding container that holds the drawer menu gets laid out as **0 wide**. The menu is still there, it just has no designated space to show itself.

Why it goes to zero: `react-native-drawer-layout` caps the panel with `maxWidth: '100%'`. That is a percentage, measured against the parent. During a project switch, a Suspense boundary above the drawer briefly hides and re-shows the whole screen. If the panel is measured in that moment, the parent is zero wide — so 100% of it is zero.

It never recovers because nothing tells React to re-measure. 

## The Fix

One prop on `<Drawer>`:

```tsx
drawerStyle={{width: drawerWidth, maxWidth: drawerWidth}}
```

A fixed number cannot be a percentage of zero.

`width` is passed too because the library uses that same number to decide how far the map slides when the drawer opens. Passing it keeps the two the same.


### How I know this is the right fix

Through the magic of AI and luck (I was able to reproduce the blank drawer a few times) I captured the native view tree on a real device while the drawer was blank. 

It showed the panel was present but had a **width of 0 with zero children**. No crash, no error.

I then forced a re-measure with `adb shell wm size` (no restart). The drawer's width jumped from **0 back to its normal 304** and the whole menu reappeared instantly 

I modified `node_modules` and forced the failure by setting the library's max width to 0%. Then it was a blank drawer every time, with the same numbers as the real bug (the drawer container's measured size - specifically 0 wide × 752 tall (in dp)).

Then I re-ran that last bit (max width set to 0%) with this fix in this PR applied — and the drawer rendered normally. Same setup as was causing the blank drawer; only the fix changed.

This modification of the `node_modules` makes the bug (blank drawer) happen on demand, so the fix is proven rather than guessed.

### Suggestions for testing / verifying
The drawer should look exactly the same as before. Any visible difference is a bug.
I checked on a Pixel fold because I was worried about differences on a large screen but in this branch and develop the drawer looked exactly the same.
