### PR TITLE
fix: observation details translation

### DIFF
--- a/src/frontend/hooks/server/fields.ts
+++ b/src/frontend/hooks/server/fields.ts
@@ -1,0 +1,13 @@
+import {useManyDocs} from '@comapeo/core-react';
+import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useLocaleState} from '../../contexts/LocaleStoreContext';
+
+export function useFieldsQuery() {
+  const {projectId} = useActiveProject();
+  const languageTag = useLocaleState(s => s.languageTag);
+  return useManyDocs({
+    projectId,
+    docType: 'field',
+    lang: languageTag,
+  });
+}

--- a/src/frontend/screens/Observation/index.tsx
+++ b/src/frontend/screens/Observation/index.tsx
@@ -10,7 +10,6 @@ import {FieldDetails} from './FieldDetails';
 import {InsetMapView} from './InsetMapView';
 import {NativeNavigationComponent} from '../../sharedTypes/navigation';
 import {ObservationHeaderRight} from './ObservationHeaderRight';
-import {useManyDocs} from '@comapeo/core-react';
 
 import {ButtonFields} from './Buttons.tsx';
 import {AudioAttachment} from '../../sharedTypes/audio.ts';
@@ -24,8 +23,8 @@ import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText.tsx';
 import VerifiedBadge from '../../images/verifiedBadge.svg';
 import {FullScreenCenteredLoader} from '../../sharedComponents/FullScreenCenteredLoader.tsx';
-import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {useObservationWithPreset} from '../../hooks/useObservationWithPreset';
+import {useFieldsQuery} from '../../hooks/server/fields';
 import {Field} from '@comapeo/schema';
 import {HorizontalScrollView} from '../../sharedComponents/HorizontalScrollView.tsx';
 import {
@@ -53,11 +52,10 @@ export const ObservationScreen: NativeNavigationComponent<'Observation'> = ({
   navigation,
 }) => {
   const {observationId} = route.params;
-  const {projectId} = useActiveProject();
   const {observation, preset} = useObservationWithPreset(observationId);
   const {createDraft} = useDraftObservationActions();
 
-  const {data: fieldsData} = useManyDocs({projectId, docType: 'field'});
+  const {data: fieldsData} = useFieldsQuery();
   const {lat, lon, metadata} = observation;
 
   const fields = preset

--- a/src/frontend/screens/ObservationFields/index.tsx
+++ b/src/frontend/screens/ObservationFields/index.tsx
@@ -9,8 +9,7 @@ import {Number as NumberField} from './Number';
 import {TextArea} from './TextArea';
 
 import {NativeRootNavigationProps} from '../../sharedTypes/navigation';
-import {useManyDocs} from '@comapeo/core-react';
-import {useActiveProject} from '../../contexts/ActiveProjectContext';
+import {useFieldsQuery} from '../../hooks/server/fields';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {
   useDraftObservationActions,
@@ -18,7 +17,6 @@ import {
 } from '../../contexts/DraftObservationContext';
 import {COMAPEO_BLUE} from '../../lib/styles';
 import {usePreventRemove} from '@react-navigation/native';
-import {useLocaleState} from '../../contexts/LocaleStoreContext';
 import {DatePicker} from './Date';
 
 const m = defineMessages({
@@ -44,18 +42,12 @@ export const ObservationFields = ({
   navigation,
   route,
 }: NativeRootNavigationProps<'ObservationFields'>) => {
-  const {projectId} = useActiveProject();
   const [current, setCurrent] = React.useState(1);
   const {fieldIds} = route.params;
   const {formatMessage} = useIntl();
   const observationId = useDraftObservationState(store => store.id?.docId);
-  const languageTag = useLocaleState(s => s.languageTag);
 
-  const {data: fields} = useManyDocs({
-    projectId,
-    docType: 'field',
-    lang: languageTag,
-  });
+  const {data: fields} = useFieldsQuery();
 
   const {updateTag} = useDraftObservationActions();
   const tags = useDraftObservationState(state => state.value?.tags);


### PR DESCRIPTION
closes #2052 

This PR makes sure that Observation details when viewing an observation (both questions and answers) are translated.

I made a reusable hook called useFieldsQuery to tie together the two field lookups to make sure they behave the same.
Previously, the ObservationFields screen (used when creating/ editing an observation) had the query done correctly (passing the language tag). 

BUT, the observation fields displayed when viewing an observation did not have the lookup correct (no language passed). 

So I made one hook so that they are both correct and linked together. A single call site so they wouldn't drift apart again.

If you would rather just have the code repeated, I can undo that slight refactor, but just thought it made sense to link them so they are sure to behave the same. However, I don't feel strongly about it.

A bonus! This PR also fixes the share text, which had English labels and option values for the same reason — Buttons.tsx builds its label: value pairs from the same fields array that had been looked up without the language tag.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a4999a35-09ca-473d-87a8-b91955eff6b2" />
