### PR TITLE
fix: naming casting unmounting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
       "version": "1.14.0-pre",
       "hasInstallScript": true,
       "dependencies": {
-        "@comapeo/core-react": "12.0.2",
+        "@comapeo/core-react": "12.0.3",
         "@comapeo/core-react-native": "1.0.0-pre.10",
         "@comapeo/default-categories": "1.1.2",
-        "@comapeo/ipc": "9.0.1",
         "@expo-google-fonts/rubik": "0.4.2",
         "@formatjs/intl-datetimeformat": "7.5.0",
         "@formatjs/intl-getcanonicallocales": "3.2.9",
@@ -110,6 +109,7 @@
         "@babel/runtime": "7.29.7",
         "@comapeo/cloud": "0.4.0",
         "@comapeo/core": "7.4.0",
+        "@comapeo/ipc": "9.0.1",
         "@comapeo/schema": "2.3.0",
         "@digidem/types": "2.4.1",
         "@eslint-react/eslint-plugin": "5.11.2",
@@ -2558,9 +2558,9 @@
       }
     },
     "node_modules/@comapeo/core-react": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-12.0.2.tgz",
-      "integrity": "sha512-QIMW2IAefXjKLN0C+FsIFeOWSky6lVjp/Ufz2ZQ5apsLm769nw7UM5gIPvVcAA8m+aqGGDGs7wiLr0cSNfmTGA==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@comapeo/core-react/-/core-react-12.0.3.tgz",
+      "integrity": "sha512-nDzjtl9rRGmvGP3DAvCy5/M1B6Hrn08lAXq/xdfcSwC2ocm002ReahK9FcYo+pR3QMzlPzNtN+Px0m+smPzlBg==",
       "license": "MIT",
       "dependencies": {
         "@comapeo/map-server": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,9 @@
     "test:e2e:build": "npm run build:android:e2e && npm run test:e2e:nobuild"
   },
   "dependencies": {
-    "@comapeo/core-react": "12.0.2",
+    "@comapeo/core-react": "12.0.3",
     "@comapeo/core-react-native": "1.0.0-pre.10",
     "@comapeo/default-categories": "1.1.2",
-    "@comapeo/ipc": "9.0.1",
     "@expo-google-fonts/rubik": "0.4.2",
     "@formatjs/intl-datetimeformat": "7.5.0",
     "@formatjs/intl-getcanonicallocales": "3.2.9",
@@ -131,6 +130,7 @@
     "@babel/runtime": "7.29.7",
     "@comapeo/cloud": "0.4.0",
     "@comapeo/core": "7.4.0",
+    "@comapeo/ipc": "9.0.1",
     "@comapeo/schema": "2.3.0",
     "@digidem/types": "2.4.1",
     "@eslint-react/eslint-plugin": "5.11.2",

--- a/src/frontend/contexts/ActiveProjectContext.tsx
+++ b/src/frontend/contexts/ActiveProjectContext.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import {useSingleProject} from '@comapeo/core-react';
-import {type MapeoProjectApi} from '@comapeo/ipc';
+import {type ComapeoProjectClientApi} from '@comapeo/ipc';
 
 const ActiveProjectContext = React.createContext<
-  {projectId: string; projectApi: MapeoProjectApi} | undefined
+  {projectId: string; projectApi: ComapeoProjectClientApi} | undefined
 >(undefined);
 
 type Props = {

--- a/src/frontend/contexts/ActiveProjectIdStoreContext.test.tsx
+++ b/src/frontend/contexts/ActiveProjectIdStoreContext.test.tsx
@@ -1,7 +1,7 @@
 import {act, renderHook, waitFor} from '@testing-library/react-native';
 import React, {type ReactNode} from 'react';
 import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
+import type {ComapeoCoreClientApi} from '@comapeo/ipc';
 
 import {
   ActiveProjectIdStoreProvider,
@@ -13,7 +13,10 @@ import {
 import {createManager, setUpIPC} from '../../../tests/integration/helpers/core';
 import {MapeoApiWrapper} from '../../../tests/integration/helpers/MapeoApiWrapper';
 
-function createWrapper(store: ActiveProjectIdStore, client: MapeoClientApi) {
+function createWrapper(
+  store: ActiveProjectIdStore,
+  client: ComapeoCoreClientApi,
+) {
   return ({children}: {children: ReactNode}) => {
     return (
       <MapeoApiWrapper mapeoApi={client}>
@@ -27,7 +30,7 @@ function createWrapper(store: ActiveProjectIdStore, client: MapeoClientApi) {
 
 describe('ActiveProjectIdStore', () => {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
 
   beforeEach(async () => {
@@ -65,6 +68,8 @@ describe('ActiveProjectIdStore', () => {
     await waitFor(() => {
       expect(stateHook.result.current).toBeUndefined();
     });
+
+    stateHook.unmount();
   });
 
   test('if project is available, store will populate with project', async () => {
@@ -82,6 +87,8 @@ describe('ActiveProjectIdStore', () => {
     await waitFor(() => {
       expect(stateHook.result.current).toStrictEqual(projectId);
     });
+
+    stateHook.unmount();
   });
 
   test('setActiveProjectId action sets the active project ID', async () => {
@@ -107,5 +114,8 @@ describe('ActiveProjectIdStore', () => {
     );
 
     expect(stateHook.result.current).toBe('12345');
+
+    actionsHook.unmount();
+    stateHook.unmount();
   });
 });

--- a/src/frontend/contexts/AppProviders.tsx
+++ b/src/frontend/contexts/AppProviders.tsx
@@ -10,7 +10,7 @@ import {
   LocalDiscoveryProvider,
   createLocalDiscoveryController,
 } from './LocalDiscoveryContext';
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import {DraftObservationProvider} from './DraftObservationContext';
 import {DraftObservationStore} from './PersistedStores/DraftObservationStore';
 import {type TrackStore, TrackStoreProvider} from './TrackStoreContext';
@@ -60,7 +60,7 @@ import {
 type AppProvidersProps = {
   children: React.ReactNode;
   localDiscoveryController: ReturnType<typeof createLocalDiscoveryController>;
-  mapeoApi: MapeoClientApi;
+  mapeoApi: ComapeoCoreClientApi;
   mapServerApi: {getBaseUrl: () => Promise<URL>};
   persistedDrafObservationStore: DraftObservationStore;
   trackStore: TrackStore;

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -10,7 +10,7 @@ import Zeroconf, {
   type Service,
   type Service as ZeroconfService,
 } from 'react-native-zeroconf';
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import * as Sentry from '@sentry/react-native';
 import noop from '../lib/noop';
 import pTimeout from 'p-timeout';
@@ -82,7 +82,7 @@ export function useLocalDiscoveryController() {
  *
  * Subscribe to changes in the state with subscribe(listener).
  */
-export function createLocalDiscoveryController(mapeoApi: MapeoClientApi) {
+export function createLocalDiscoveryController(mapeoApi: ComapeoCoreClientApi) {
   let appState = AppState.currentState;
   let netInfo: NetInfoWifiState | NetInfoDisconnectedStates | null = null;
   let unsubscribeInternal: undefined | (() => void);

--- a/src/frontend/hooks/useLocalPeers.ts
+++ b/src/frontend/hooks/useLocalPeers.ts
@@ -1,8 +1,10 @@
 import {useSyncExternalStore} from 'react';
 import {useClientApi} from '@comapeo/core-react';
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 
-type LocalPeer = Awaited<ReturnType<MapeoClientApi['listLocalPeers']>>[number];
+type LocalPeer = Awaited<
+  ReturnType<ComapeoCoreClientApi['listLocalPeers']>
+>[number];
 
 let localPeerState: ReturnType<typeof createLocalPeerState> | undefined;
 
@@ -19,7 +21,7 @@ export function useLocalPeers(): LocalPeer[] {
   return useSyncExternalStore(subscribe, getSnapshot);
 }
 
-function createLocalPeerState(api: MapeoClientApi) {
+function createLocalPeerState(api: ComapeoCoreClientApi) {
   let state: LocalPeer[] = [];
   let isSubscribedInternal = false;
   let error: Error | undefined;

--- a/src/frontend/screens/BackgroundMaps/SelectMapShareDevice.test.ts
+++ b/src/frontend/screens/BackgroundMaps/SelectMapShareDevice.test.ts
@@ -1,10 +1,10 @@
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import type {MemberApi} from '@comapeo/core';
 import {getSelectableDevicesForMapShare} from './SelectMapShareDevice';
 import {COORDINATOR_ROLE_ID, MEMBER_ROLE_ID} from '../../sharedTypes';
 
 type PublicPeerInfo = Awaited<
-  ReturnType<MapeoClientApi['listLocalPeers']>
+  ReturnType<ComapeoCoreClientApi['listLocalPeers']>
 >[number];
 
 function mockPeer(

--- a/src/frontend/screens/BackgroundMaps/SelectMapShareDevice.tsx
+++ b/src/frontend/screens/BackgroundMaps/SelectMapShareDevice.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react-native';
 
 import {useSendMapShare, useManyMembers} from '@comapeo/core-react';
 import type {MemberApi} from '@comapeo/core';
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import {toError} from '../../utils/errors';
 import {useLocalDiscoveryState} from '../../hooks/useLocalDiscoveryState';
 import WifiIcon from '../../images/WifiIcon.svg';
@@ -19,7 +19,7 @@ import {type NativeRootNavigationProps} from '../../sharedTypes/navigation';
 import {useInitiallyConnectedPeers} from '../YourTeam/useInitiallyConnectedPeers';
 
 type PublicPeerInfo = Awaited<
-  ReturnType<MapeoClientApi['listLocalPeers']>
+  ReturnType<ComapeoCoreClientApi['listLocalPeers']>
 >[number];
 
 export function getSelectableDevicesForMapShare({

--- a/src/frontend/screens/Exchange/index.test.tsx
+++ b/src/frontend/screens/Exchange/index.test.tsx
@@ -1,7 +1,7 @@
 import {act, render, screen, userEvent} from '@testing-library/react-native';
 
 import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
+import type {ComapeoCoreClientApi} from '@comapeo/ipc';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {
@@ -22,7 +22,7 @@ jest.mock('../../hooks/useCurrentTime');
 
 describe('Exchange screen', () => {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
   let projectId: string;
 

--- a/src/frontend/screens/MapScreen/MapScreen.lowStorage.test.tsx
+++ b/src/frontend/screens/MapScreen/MapScreen.lowStorage.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react-native';
 
 import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
+import type {ComapeoCoreClientApi} from '@comapeo/ipc';
 
 import {
   createManager,
@@ -104,7 +104,7 @@ const Stack = createNativeStackNavigator<{Map: undefined}>();
 
 describe('MapScreen low-storage banner', () => {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
 
   beforeEach(async () => {

--- a/src/frontend/screens/SetQADeviceName.test.tsx
+++ b/src/frontend/screens/SetQADeviceName.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@testing-library/react-native';
 
 import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
+import type {ComapeoCoreClientApi} from '@comapeo/ipc';
 
 import {createManager, setUpIPC} from '../../../tests/integration/helpers/core';
 import {createAppProvidersWrapper} from '../../../tests/integration/helpers/react';
@@ -31,7 +31,7 @@ jest.mock('@comapeo/core-react', () => {
 
 describe('On QA Device require existence of a QA Device name', () => {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
 
   beforeEach(async () => {
@@ -59,7 +59,7 @@ describe('On QA Device require existence of a QA Device name', () => {
     const app = createAppProvidersWrapper({mapeoApi: client});
     onTeardown.push(app.teardown);
 
-    await render(
+    const {unmount} = await render(
       <React.Suspense fallback={null}>
         <AppNavigator
           permissionAsked={false}
@@ -68,6 +68,7 @@ describe('On QA Device require existence of a QA Device name', () => {
       </React.Suspense>,
       {wrapper: app.wrapper},
     );
+    onTeardown.unshift(unmount);
 
     await waitFor(() => {
       expect(screen.getByText('Set QA Device Name')).toBeOnTheScreen();
@@ -84,7 +85,7 @@ describe('On QA Device require existence of a QA Device name', () => {
     });
     onTeardown.push(app.teardown);
 
-    await render(
+    const {unmount} = await render(
       <React.Suspense fallback={null}>
         <AppNavigator
           permissionAsked={false}
@@ -93,6 +94,7 @@ describe('On QA Device require existence of a QA Device name', () => {
       </React.Suspense>,
       {wrapper: app.wrapper},
     );
+    onTeardown.unshift(unmount);
 
     await waitFor(() => {
       expect(screen.queryByText('Set QA Device Name')).not.toBeOnTheScreen();
@@ -103,7 +105,7 @@ describe('On QA Device require existence of a QA Device name', () => {
     const app = createAppProvidersWrapper({mapeoApi: client});
     onTeardown.push(app.teardown);
 
-    await render(
+    const {unmount} = await render(
       <React.Suspense fallback={null}>
         <AppNavigator
           permissionAsked={false}
@@ -112,6 +114,7 @@ describe('On QA Device require existence of a QA Device name', () => {
       </React.Suspense>,
       {wrapper: app.wrapper},
     );
+    onTeardown.unshift(unmount);
 
     await waitFor(() => {
       expect(

--- a/src/frontend/screens/YourTeam/SelectInviteDevice.test.ts
+++ b/src/frontend/screens/YourTeam/SelectInviteDevice.test.ts
@@ -1,5 +1,5 @@
 import type {MemberApi} from '@comapeo/core';
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import {getSelectableDevicesForInvite} from './SelectInviteDevice';
 import {
   BLOCKED_ROLE_ID,
@@ -9,7 +9,7 @@ import {
 } from '../../sharedTypes';
 
 type PublicPeerInfo = Awaited<
-  ReturnType<MapeoClientApi['listLocalPeers']>
+  ReturnType<ComapeoCoreClientApi['listLocalPeers']>
 >[number];
 
 function mockPeer(

--- a/src/frontend/screens/YourTeam/SelectInviteDevice.tsx
+++ b/src/frontend/screens/YourTeam/SelectInviteDevice.tsx
@@ -4,7 +4,7 @@ import {ScrollView, StyleSheet, View, TouchableOpacity} from 'react-native';
 
 import {useManyMembers} from '@comapeo/core-react';
 import type {MemberApi} from '@comapeo/core';
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import {useLocalDiscoveryState} from '../../hooks/useLocalDiscoveryState';
 import WifiIcon from '../../images/WifiIcon.svg';
 import {DeviceNameWithIcon} from '../../sharedComponents/DeviceNameWithIcon';
@@ -22,7 +22,7 @@ import {
 import {useInitiallyConnectedPeers} from './useInitiallyConnectedPeers';
 
 type PublicPeerInfo = Awaited<
-  ReturnType<MapeoClientApi['listLocalPeers']>
+  ReturnType<ComapeoCoreClientApi['listLocalPeers']>
 >[number];
 
 export function getSelectableDevicesForInvite({

--- a/src/frontend/sharedComponents/HomeHeader.lowStorage.test.tsx
+++ b/src/frontend/sharedComponents/HomeHeader.lowStorage.test.tsx
@@ -8,7 +8,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {render, screen} from '@testing-library/react-native';
 import type {BottomTabHeaderProps} from '@react-navigation/bottom-tabs';
 import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
+import type {ComapeoCoreClientApi} from '@comapeo/ipc';
 
 import {createManager, setUpIPC} from '../../../tests/integration/helpers/core';
 import {createAppProvidersWrapper} from '../../../tests/integration/helpers/react';
@@ -63,7 +63,7 @@ function HomeHeaderScreen() {
 
 describe('HomeHeader low storage badge (navigator + AppProviders)', () => {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
   let projectId: string;
 

--- a/tests/integration/helpers/MapeoApiWrapper.tsx
+++ b/tests/integration/helpers/MapeoApiWrapper.tsx
@@ -1,4 +1,4 @@
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
 import {ComapeoCoreProvider} from '@comapeo/core-react';
@@ -8,7 +8,7 @@ export const MapeoApiWrapper = ({
   mapeoApi,
   children,
 }: {
-  mapeoApi: MapeoClientApi;
+  mapeoApi: ComapeoCoreClientApi;
   children: ReactNode;
 }) => {
   const queryClient = new QueryClient({

--- a/tests/integration/helpers/core.ts
+++ b/tests/integration/helpers/core.ts
@@ -2,11 +2,11 @@ import {spawn} from 'node:child_process';
 import path from 'node:path';
 import {MessageChannel} from 'node:worker_threads';
 import {FastifyController, MapeoManager} from '@comapeo/core';
-import type {MapeoProjectApi} from '@comapeo/ipc';
+import type {ComapeoProjectClientApi} from '@comapeo/ipc';
 import {
-  closeMapeoClient,
-  createMapeoClient,
-  createMapeoServer,
+  closeComapeoCoreClient,
+  createComapeoCoreClient,
+  createComapeoCoreServer,
 } from '@comapeo/ipc';
 import {KeyManager} from '@mapeo/crypto';
 import Fastify from 'fastify';
@@ -57,8 +57,16 @@ export async function createManager(
 export function setUpIPC({manager}: {manager: MapeoManager}) {
   const {port1, port2} = new MessageChannel();
 
-  const server = createMapeoServer(manager, port1);
-  const client = createMapeoClient(port2, {timeout: 30_000});
+  // Cast needed: Node's MessagePort type doesn't match rpc-reflector's
+  // MessagePortLike, though it satisfies it at runtime.
+  const server = createComapeoCoreServer(
+    manager,
+    port1 as unknown as Parameters<typeof createComapeoCoreServer>[1],
+  );
+  const client = createComapeoCoreClient(
+    port2 as unknown as Parameters<typeof createComapeoCoreClient>[0],
+    {timeout: 30_000},
+  );
 
   return {
     client,
@@ -71,7 +79,7 @@ export function setUpIPC({manager}: {manager: MapeoManager}) {
     },
     stop: async () => {
       server.close();
-      await closeMapeoClient(client);
+      await closeComapeoCoreClient(client);
       port1.close();
       port2.close();
     },
@@ -143,7 +151,7 @@ async function stopPeerDiscovery(
 }
 
 export async function inviteToProject(
-  project: MapeoProjectApi,
+  project: ComapeoProjectClientApi,
   invitee: MapeoManager,
 ): Promise<void> {
   const inviteId = randomBytes(32);

--- a/tests/integration/helpers/react.tsx
+++ b/tests/integration/helpers/react.tsx
@@ -1,4 +1,4 @@
-import {type MapeoClientApi} from '@comapeo/ipc';
+import {type ComapeoCoreClientApi} from '@comapeo/ipc';
 import {getLocales} from 'expo-localization';
 import {Component, type ComponentPropsWithoutRef, type ReactNode} from 'react';
 
@@ -76,7 +76,7 @@ export function createAppProvidersWrapper({
   activeProjectId,
   qaDeviceName,
 }: {
-  mapeoApi: MapeoClientApi;
+  mapeoApi: ComapeoCoreClientApi;
   isOnline?: boolean;
   activeProjectId?: string;
   qaDeviceName?: string;

--- a/tests/integration/helpers/setupIntegrationTest.tsx
+++ b/tests/integration/helpers/setupIntegrationTest.tsx
@@ -1,6 +1,6 @@
 import {render} from '@testing-library/react-native';
 import type {MapeoManager} from '@comapeo/core';
-import type {MapeoClientApi} from '@comapeo/ipc';
+import type {ComapeoCoreClientApi} from '@comapeo/ipc';
 import {createManager, setUpIPC} from './core';
 import {createAppProvidersWrapper} from './react';
 import {MockedAppNavigator} from './navigation';
@@ -9,7 +9,7 @@ import React from 'react';
 
 export function setupIntegrationTest() {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
   let projectId: string;
 
@@ -81,7 +81,7 @@ export function setupIntegrationTest() {
 
 export function setupIntegrationTestWithoutProject() {
   let manager: MapeoManager;
-  let client: MapeoClientApi;
+  let client: ComapeoCoreClientApi;
   let onTeardown: Array<() => unknown> = [];
 
   beforeEach(async () => {


### PR DESCRIPTION
1. This PR updates to the latest version of comapeo/core-react
It also moves comapeo/ipc to a dev dependency per instruction

Also, when IPC changed previously, all(?) the exported symbol names were changed.
2. This PR reflects those name changes.

3. Also `rpc-reflector` (a dependency of `@comapeo/ipc`) bumped from 3.0.1 to 4.3.1, changing `MessagePortLike`'s expected interface, which no longer structurally matches Node's MessagePort typing. That was fixed with a type assertion derived from the functions' own parameter types (no new import needed).

4. SetQADeviceName.test.tsx and ActiveProjectIdStoreContext.test.tsx were failing because the new @comapeo/ipc throws ClientClosed/RpcChannelClosed when a React component's useEffect cleanup (removeListener) runs after the RPC client is closed. 

IN this PR, this failure was fixed in those tests by explicitly unmounting rendered trees/hooks before the test's afterEach closes the client, rather than relying on unclear ordering between React Testing Library's automatic cleanup and the file's own teardown.