### PR TITLE
fix: reinstates audio blue screen animation

### DIFF
--- a/src/frontend/screens/Audio/AudioRecording/AnimatedBackground.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/AnimatedBackground.tsx
@@ -1,4 +1,4 @@
-import {Dimensions, StyleSheet} from 'react-native';
+import {StyleSheet, useWindowDimensions} from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -10,7 +10,7 @@ import {COMAPEO_BLUE} from '../../../lib/styles';
 
 export function AnimatedBackground({timeElapsed}: {timeElapsed: number}) {
   const {bottom} = useSafeAreaInsets();
-  const {height} = Dimensions.get('window');
+  const {height} = useWindowDimensions();
   const targetHeight = height - bottom;
 
   const elapsedTimeValue = useDerivedValue(() => {
@@ -29,7 +29,6 @@ export function AnimatedBackground({timeElapsed}: {timeElapsed: number}) {
 const styles = StyleSheet.create({
   fill: {
     position: 'absolute',
-    zIndex: -1,
     bottom: 0,
     width: '100%',
   },

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -105,6 +105,8 @@ export function AudioRecording({
 
   return (
     <View style={styles.background}>
+      {/* Remove animated background in E2E mode to avoid performance issues in Appium/BrowserStack */}
+      {!isE2E && <AnimatedBackground timeElapsed={timeElapsed} />}
       <ScreenContentWithDock
         contentContainerStyle={styles.contentContainer}
         dockContainerStyle={styles.dockContainer}
@@ -140,8 +142,6 @@ export function AudioRecording({
           </View>
         </View>
       </ScreenContentWithDock>
-      {/* Remove animated background in E2E mode to avoid performance issues in Appium/BrowserStack */}
-      {!isE2E && <AnimatedBackground timeElapsed={timeElapsed} />}
     </View>
   );
 }


### PR DESCRIPTION
closes #2046 
Changes needed to get the animated blue background on audio to show.
There are two changes in this PR.

One is the change to `useWindowDimensions() `which was made while investigating the bug. It turned out not to be the cause but I think it is worth keeping because the old way, `Dimensions.get()`, reads the screen size once, when it is mounted, and never updates.
`useWindowDimensions()` is React's recommended reactive equivalent. It re-renders the component if the dimensions change (rotation, split-screen, or a late-arriving correct value).
This app already fixed the same `Dimensions.get() `pattern for the same reason in `TrackBottomSheet`, so this keeps `AnimatedBackground` consistent.
However, if you can think of a reason to revert to Dimensions.get() I would be happy to change it back.

One is the needed fix. 
It was a stacking order issue. Fabric doesn't reliably honor negative z index. In the new architecture, a later rendered sibling renders on top of the earlier sibling. So I just changed the order so the background renders first (and got rid of the unneeded negative zIndex). Now you can see the background again!

Screen shot:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8feb8d38-0f4d-4d8a-bbac-c919dfefcecc" />

Screen recording:

https://github.com/user-attachments/assets/2fee065d-5d7a-47d8-9c97-0ecbffdd4f41