### PR TITLE
chore: fix early access labels for e2e test

### DIFF
--- a/src/frontend/screens/ComapeoSettings/index.tsx
+++ b/src/frontend/screens/ComapeoSettings/index.tsx
@@ -279,6 +279,7 @@ export const AppSettings: NativeNavigationComponent<'AppSettings'> = ({
       </BodyText>
       <SettingsRow
         testID="earlyAccessFlag"
+        labelTestID="earlyAccessFlagLabel"
         onPress={() => navigation.navigate('EarlyAccess')}
         label={
           isEarlyAccess
@@ -336,19 +337,24 @@ function SettingsRow({
   label,
   onPress,
   testID,
+  labelTestID,
   Icon,
   EndContent,
 }: {
   label: string;
   onPress: () => void;
   testID?: string;
+  labelTestID?: string;
   Icon: React.ReactNode;
   EndContent: React.ReactNode;
 }) {
   return (
     <TouchableOpacity testID={testID} onPress={onPress} style={styles.row}>
       {Icon}
-      <HeaderText variant="header6" style={styles.rowLabel}>
+      <HeaderText
+        variant="header6"
+        style={styles.rowLabel}
+        testID={labelTestID}>
         {label}
       </HeaderText>
       {EndContent}

--- a/tests/e2e/specs/settings/early-access.test.ts
+++ b/tests/e2e/specs/settings/early-access.test.ts
@@ -9,10 +9,9 @@ describe('Settings - Early Access Mode', () => {
     await drawerIcon.click();
     const appSettingsOption = await $('~Go to app settings screen.');
     await appSettingsOption.click();
-    const earlyAccessItem = await $(byResourceId('earlyAccessFlag'));
-    await earlyAccessItem.scrollIntoView();
+    await $(byResourceId('earlyAccessFlagLabel')).scrollIntoView();
     await expect($(byTextMatches('Early Access OFF'))).toBeDisplayed();
-    await earlyAccessItem.click();
+    await $(byResourceId('earlyAccessFlag')).click();
     await expect($(byTextMatches('Early Access Mode'))).toBeDisplayed();
     await expect($(byText('See CoMapeo Updates'))).toBeDisplayed();
   });
@@ -35,10 +34,9 @@ describe('Settings - Early Access Mode', () => {
   it('should show ON in the App Settings list item text', async () => {
     const backBtn = await $(byResourceId('MAIN.header-back-btn'));
     await backBtn.click();
-    const earlyAccessItem = await $(byResourceId('earlyAccessFlag'));
-    await earlyAccessItem.scrollIntoView();
+    await $(byResourceId('earlyAccessFlagLabel')).scrollIntoView();
     await expect($(byTextMatches('Early Access ON'))).toBeDisplayed();
-    await earlyAccessItem.click();
+    await $(byResourceId('earlyAccessFlag')).click();
     await expect($(byResourceId('EA.checkbox-on'))).toBeDisplayed();
   });
 
@@ -59,10 +57,9 @@ describe('Settings - Early Access Mode', () => {
     const seeUpdates = await $(byTextMatches('See CoMapeo Updates'));
     await seeUpdates.scrollIntoView();
     await expect(seeUpdates).toBeDisplayed();
-    await backBtn.click();
-    const earlyAccessFlag = await $(byResourceId('earlyAccessFlag'));
-    await earlyAccessFlag.scrollIntoView();
-    await earlyAccessFlag.click();
+    await $(byResourceId('MAIN.header-back-btn')).click();
+    await $(byResourceId('earlyAccessFlagLabel')).scrollIntoView();
+    await $(byResourceId('earlyAccessFlag')).click();
   });
 
   it('should toggle OFF, show bottom sheet, close it, and show OFF in App Settings', async () => {
@@ -76,6 +73,7 @@ describe('Settings - Early Access Mode', () => {
     await expect($(byResourceId('EA.checkbox-off'))).toBeDisplayed();
     const backBtn = await $(byResourceId('MAIN.header-back-btn'));
     await backBtn.click();
+    await $(byResourceId('earlyAccessFlagLabel')).scrollIntoView();
     await expect($(byTextMatches('Early Access OFF'))).toBeDisplayed();
     await backBtn.click();
     await $(byResourceId('MAIN.map-screen')).click();


### PR DESCRIPTION
closes #2071 

Taking this fix from #2050 

From the Description in 2050:

> Early access in the settings test is a little tricky. On Browserstack, the very top edge of the Early Access "box" is visible (see screenshot from the test). But that doesn't mean the contents of it are visible on the page. In fact they are not! However, scrolling to the element using the existing test ID just doesn't work, because the element IS in fact "visible" on the screen. The very top edge is there. So the test thinks it has been scrolled to.

> To fix that in the settings test, which needs the whole early access element to be visible, I had to add a test id for the text within the box. That way, the whole accessible element is in the frame and accessible to the test rather than just the first appearance of the box which goes around that particular setting. I tried so many other ways to scroll, scroll to end, etc. and none of them worked consistently. So I know it is another parameter, but it definitely fixes the test flakiness and the test consistently not working.
