### PR TITLE
fix: share observation crashing when no `original` photo

### DIFF
--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -111,9 +111,8 @@ export const ButtonFields = ({
   }
 
   async function fetchAttachmentBase64(attachment: SavedPhoto) {
-    const originalUrl = await getAttachmentUrl(attachment, 'original');
-
     try {
+      const originalUrl = await getAttachmentUrl(attachment, 'original');
       return await convertUrlToBase64(originalUrl);
     } catch {
       // The original may fail to load depending on media sync settings.

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -15,6 +15,7 @@ import {getFieldAnswerText} from '../../sharedComponents/FormattedData.tsx';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {BodyText} from '../../sharedComponents/Text/BodyText.tsx';
 import {isSavedPhoto} from '../../lib/attachmentTypeChecks.ts';
+import {type PhotoVariant, type SavedPhoto} from '../../sharedTypes';
 import {useOpenShareDialog} from '../../hooks/share.ts';
 import {useCoordinateFormat} from '../../contexts/CoordinateFormatStoreContext.ts';
 import {useUnitSystem} from '../../contexts/UnitSystemStoreContext';
@@ -97,7 +98,32 @@ export const ButtonFields = ({
     navigation.navigate('ConfirmDeleteObservationBottomSheet', {observationId});
   }
 
-  async function fetchFreshUrls() {
+  async function getAttachmentUrl(
+    attachment: SavedPhoto,
+    variant: PhotoVariant,
+  ) {
+    return projectApi.$blobs.getUrl({
+      driveId: attachment.driveDiscoveryId,
+      name: attachment.name,
+      type: 'photo',
+      variant,
+    });
+  }
+
+  async function fetchAttachmentBase64(attachment: SavedPhoto) {
+    const originalUrl = await getAttachmentUrl(attachment, 'original');
+
+    try {
+      return await convertUrlToBase64(originalUrl);
+    } catch {
+      // The original may fail to load depending on media sync settings.
+      // Fall back to the preview variant if using the original does not work.
+      const previewUrl = await getAttachmentUrl(attachment, 'preview');
+      return await convertUrlToBase64(previewUrl);
+    }
+  }
+
+  async function fetchFreshBase64Urls() {
     const {attachments} = observation;
 
     if (!attachments || attachments.length === 0) {
@@ -108,27 +134,20 @@ export const ButtonFields = ({
       return [];
     }
 
-    return await Promise.all(
-      photoAttachments.map(async attachment => {
-        return projectApi.$blobs.getUrl({
-          driveId: attachment.driveDiscoveryId,
-          name: attachment.name,
-          type: 'photo',
-          variant: 'original',
-        });
-      }),
-    );
+    return await Promise.all(photoAttachments.map(fetchAttachmentBase64));
   }
 
   async function handlePressShare() {
     setIsShareButtonLoading(true);
 
     try {
-      const urls = await fetchFreshUrls();
-      const base64Urls =
-        urls.length > 0
-          ? await Promise.all(urls.map(url => convertUrlToBase64(url)))
-          : [];
+      const base64Urls = await fetchFreshBase64Urls().catch(err => {
+        // Report the failure, but swallow it so sharing can proceed without photos
+        // instead of blocking the whole share on a single failed conversion.
+        Sentry.captureException(err);
+        // Empty array matches fetchFreshBase64Urls' return type (string[]).
+        return [];
+      });
 
       const completedFields: Array<{label: string; value: string}> = [];
       for (const field of fields) {

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -134,11 +134,18 @@ export const ButtonFields = ({
       return [];
     }
 
+    // Report the failure, but swallow it so sharing can proceed without photos
+    // instead of blocking the whole share on a single failed conversion.
     const settledPromises = await Promise.allSettled(
       photoAttachments.map(fetchAttachmentBase64),
     );
 
-    //If there are any photos that have thrown an error we still want allow the rest of the sharing to happen
+    settledPromises.forEach(prom => {
+      if (prom.status === 'rejected') {
+        Sentry.captureException(prom.reason);
+      }
+    });
+
     return settledPromises
       .filter(promise => promise.status === 'fulfilled')
       .map(resolvedPromise => resolvedPromise.value);
@@ -148,13 +155,7 @@ export const ButtonFields = ({
     setIsShareButtonLoading(true);
 
     try {
-      const base64Urls = await fetchFreshBase64Urls().catch(err => {
-        // Report the failure, but swallow it so sharing can proceed without photos
-        // instead of blocking the whole share on a single failed conversion.
-        Sentry.captureException(err);
-        // Empty array matches fetchFreshBase64Urls' return type (string[]).
-        return [];
-      });
+      const base64Urls = await fetchFreshBase64Urls();
 
       const completedFields: Array<{label: string; value: string}> = [];
       for (const field of fields) {

--- a/src/frontend/screens/Observation/Buttons.tsx
+++ b/src/frontend/screens/Observation/Buttons.tsx
@@ -134,7 +134,14 @@ export const ButtonFields = ({
       return [];
     }
 
-    return await Promise.all(photoAttachments.map(fetchAttachmentBase64));
+    const settledPromises = await Promise.allSettled(
+      photoAttachments.map(fetchAttachmentBase64),
+    );
+
+    //If there are any photos that have thrown an error we still want allow the rest of the sharing to happen
+    return settledPromises
+      .filter(promise => promise.status === 'fulfilled')
+      .map(resolvedPromise => resolvedPromise.value);
   }
 
   async function handlePressShare() {

--- a/src/frontend/utils/base64.ts
+++ b/src/frontend/utils/base64.ts
@@ -2,6 +2,9 @@ import {Buffer} from 'buffer';
 
 export const convertUrlToBase64 = async (url: string) => {
   const imageResponse = await fetch(url);
+  if (!imageResponse.ok) {
+    throw new Error(`Failed to fetch image from ${url}`);
+  }
   const imageType = imageResponse.headers.get('content-type');
   const arrayBuffer = await imageResponse.arrayBuffer();
   const base64 = Buffer.from(arrayBuffer).toString('base64');


### PR DESCRIPTION
closes #2043 

When an original photo was not available while sharing an observation, the sharing module throws an error and returns a json with the error message. 

This fix catches the error, and then attempts to find the `preview` photo. 

I also made it that if there are any errors at all (eg In both attempts to fetch `original` and `preview`) it doesn't throw an error at all. I am still sending the error to sentry, but I figure it is better to still share the other information then throwing an error completely.