### PR TITLE
chore: add a disabled button

### DIFF
--- a/src/frontend/sharedComponents/Buttons.tsx
+++ b/src/frontend/sharedComponents/Buttons.tsx
@@ -10,6 +10,7 @@ type ButtonProps = {
   fullSize: boolean;
   text: string;
   onPress: () => void;
+  disabled?: boolean;
   testID?: string;
   style?: ViewStyleProp;
 };
@@ -31,11 +32,7 @@ const BaseButton = ({
   testID,
   style,
   colors,
-}: Omit<ButtonProps, 'onPress'> & {
-  onPress?: () => void;
-  disabled?: boolean;
-  colors: ButtonColors;
-}) => {
+}: ButtonProps & {colors: ButtonColors}) => {
   return (
     <TouchableOpacity
       testID={testID}
@@ -71,7 +68,25 @@ const BaseButton = ({
   );
 };
 
+const DisabledButton = (props: ButtonProps) => {
+  return (
+    <BaseButton
+      {...props}
+      colors={{
+        background: BLUE_GREY,
+        text: WHITE,
+        icon: WHITE,
+        border: BLUE_GREY,
+      }}
+    />
+  );
+};
+
 export const PrimaryButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}
@@ -86,6 +101,10 @@ export const PrimaryButton = (props: ButtonProps) => {
 };
 
 export const SecondaryButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}
@@ -100,6 +119,10 @@ export const SecondaryButton = (props: ButtonProps) => {
 };
 
 export const DestructiveButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}
@@ -113,22 +136,11 @@ export const DestructiveButton = (props: ButtonProps) => {
   );
 };
 
-export const DisabledButton = (props: Omit<ButtonProps, 'onPress'>) => {
-  return (
-    <BaseButton
-      {...props}
-      disabled
-      colors={{
-        background: BLUE_GREY,
-        text: WHITE,
-        icon: WHITE,
-        border: BLUE_GREY,
-      }}
-    />
-  );
-};
-
 export const SecondaryDestructiveButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}

--- a/src/frontend/sharedComponents/Buttons.tsx
+++ b/src/frontend/sharedComponents/Buttons.tsx
@@ -27,13 +27,20 @@ const BaseButton = ({
   iconPosition = 'left',
   text,
   fullSize,
+  disabled = false,
   testID,
   style,
   colors,
-}: ButtonProps & {colors: ButtonColors}) => {
+}: Omit<ButtonProps, 'onPress'> & {
+  onPress?: () => void;
+  disabled?: boolean;
+  colors: ButtonColors;
+}) => {
   return (
     <TouchableOpacity
       testID={testID}
+      disabled={disabled}
+      accessibilityState={{disabled}}
       style={[
         style,
         buttonStyles.base,
@@ -101,6 +108,21 @@ export const DestructiveButton = (props: ButtonProps) => {
         text: WHITE,
         icon: WHITE,
         border: WARNING_RED,
+      }}
+    />
+  );
+};
+
+export const DisabledButton = (props: Omit<ButtonProps, 'onPress'>) => {
+  return (
+    <BaseButton
+      {...props}
+      disabled
+      colors={{
+        background: BLUE_GREY,
+        text: WHITE,
+        icon: WHITE,
+        border: BLUE_GREY,
       }}
     />
   );


### PR DESCRIPTION
closes #2078 
Adds disabled as a param and a type for buttons.

The param goes to the base button. Then, within each button type, the disabled button can be exported if the param is received.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/67b06005-320e-4496-b68a-1db29310634f" />

I checked through all of the SVG icons used with buttons and they all took a color or were already white. Is that ok? It just seemed like overkill to change them to take currentColor and pass white when they were already white.
