### PR TITLE
chore: uses disabled button on exchange screen

### DIFF
--- a/src/frontend/screens/Exchange/ExchangeScreenContent.tsx
+++ b/src/frontend/screens/Exchange/ExchangeScreenContent.tsx
@@ -36,7 +36,11 @@ import {Circle} from '../../sharedComponents/icons/Circle';
 import {ScreenContentWithDock} from '../../sharedComponents/ScreenContentWithDock';
 import {HeaderText} from '../../sharedComponents/Text/HeaderText';
 import {BodyText} from '../../sharedComponents/Text/BodyText';
-import {PrimaryButton, SecondaryButton} from '../../sharedComponents/Buttons';
+import {
+  DisabledButton,
+  PrimaryButton,
+  SecondaryButton,
+} from '../../sharedComponents/Buttons';
 import {ROOT_QUERY_KEY} from '../../constants';
 import {useActiveArchiveServer} from '../../hooks/server/projects';
 import {Button} from '../../sharedComponents/Button';
@@ -224,10 +228,13 @@ export const ExchangeScreenContent = ({syncState}: {syncState: SyncState}) => {
               }}
             />
           ) : (
-            <SecondaryButton
-              fullSize={true}
-              text={t(m.close)}
-              onPress={() => navigation.goBack()}
+            <DisabledButton
+              fullSize
+              testID="EXCHANGE.start-btn-disabled"
+              text={t(m.start)}
+              renderIcon={({color, size}) => (
+                <SyncIcon color={color} size={size} />
+              )}
             />
           );
 

--- a/src/frontend/sharedComponents/Buttons.tsx
+++ b/src/frontend/sharedComponents/Buttons.tsx
@@ -27,13 +27,20 @@ const BaseButton = ({
   iconPosition = 'left',
   text,
   fullSize,
+  disabled = false,
   testID,
   style,
   colors,
-}: ButtonProps & {colors: ButtonColors}) => {
+}: Omit<ButtonProps, 'onPress'> & {
+  onPress?: () => void;
+  disabled?: boolean;
+  colors: ButtonColors;
+}) => {
   return (
     <TouchableOpacity
       testID={testID}
+      disabled={disabled}
+      accessibilityState={{disabled}}
       style={[
         style,
         buttonStyles.base,
@@ -101,6 +108,21 @@ export const DestructiveButton = (props: ButtonProps) => {
         text: WHITE,
         icon: WHITE,
         border: WARNING_RED,
+      }}
+    />
+  );
+};
+
+export const DisabledButton = (props: Omit<ButtonProps, 'onPress'>) => {
+  return (
+    <BaseButton
+      {...props}
+      disabled
+      colors={{
+        background: BLUE_GREY,
+        text: WHITE,
+        icon: WHITE,
+        border: BLUE_GREY,
       }}
     />
   );

--- a/tests/e2e/specs/exchange/no-devices.test.ts
+++ b/tests/e2e/specs/exchange/no-devices.test.ts
@@ -13,6 +13,8 @@ describe('Exchange - Exchange Screen No Devices', () => {
     await expect($(byResourceId('wifi-icon'))).toBeDisplayed();
 
     await expect($(byTextMatches('No devices found.'))).toBeDisplayed();
-    await expect($(byTextMatches('Close'))).toBeDisplayed();
+    await expect(
+      $(byResourceId('EXCHANGE.start-btn-disabled')),
+    ).toBeDisplayed();
   });
 });


### PR DESCRIPTION
closes #2079 
stacked on #2087 

Adds the new disabled button to be used in the exchange screen (instead of close)
Adds a test id to that button
Uses that new test id as an assertion in the End to End test (instead of Close, as it used to be)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/dc748499-89eb-4885-8886-a45a450f312d" />
