### PR TITLE
chore: adds disabled button to exchange screen

### DIFF
--- a/src/frontend/screens/Exchange/ExchangeScreenContent.tsx
+++ b/src/frontend/screens/Exchange/ExchangeScreenContent.tsx
@@ -212,31 +212,28 @@ export const ExchangeScreenContent = ({syncState}: {syncState: SyncState}) => {
   } else {
     switch (syncStage.name) {
       case 'idle': {
-        dockContent =
-          syncStage.connectedPeersCount > 0 ? (
-            <PrimaryButton
-              fullSize
-              text={t(m.start)}
-              renderIcon={({size}) => <SyncIcon size={size} />}
-              onPress={() => {
-                // TODO: Catch/surface error
-                startSync.mutate(undefined);
-              }}
-            />
-          ) : (
-            <SecondaryButton
-              fullSize={true}
-              text={t(m.close)}
-              onPress={() => navigation.goBack()}
-            />
-          );
+        const hasConnectedPeers = syncStage.connectedPeersCount > 0;
+
+        dockContent = (
+          <PrimaryButton
+            fullSize
+            text={t(m.start)}
+            disabled={!hasConnectedPeers}
+            testID="EXCHANGE.start-btn"
+            renderIcon={({color, size}) => (
+              <SyncIcon color={color} size={size} />
+            )}
+            onPress={() => {
+              // TODO: Catch/surface error
+              startSync.mutate(undefined);
+            }}
+          />
+        );
 
         syncInfoContent = (
           <>
             <HeaderText variant="header2" style={styles.exchangeInfoText}>
-              {syncStage.connectedPeersCount > 0
-                ? t(m.devicesFound)
-                : t(m.noDevicesFound)}
+              {hasConnectedPeers ? t(m.devicesFound) : t(m.noDevicesFound)}
             </HeaderText>
           </>
         );

--- a/src/frontend/sharedComponents/Buttons.tsx
+++ b/src/frontend/sharedComponents/Buttons.tsx
@@ -10,6 +10,7 @@ type ButtonProps = {
   fullSize: boolean;
   text: string;
   onPress: () => void;
+  disabled?: boolean;
   testID?: string;
   style?: ViewStyleProp;
 };
@@ -31,11 +32,7 @@ const BaseButton = ({
   testID,
   style,
   colors,
-}: Omit<ButtonProps, 'onPress'> & {
-  onPress?: () => void;
-  disabled?: boolean;
-  colors: ButtonColors;
-}) => {
+}: ButtonProps & {colors: ButtonColors}) => {
   return (
     <TouchableOpacity
       testID={testID}
@@ -71,7 +68,25 @@ const BaseButton = ({
   );
 };
 
+const DisabledButton = (props: ButtonProps) => {
+  return (
+    <BaseButton
+      {...props}
+      colors={{
+        background: BLUE_GREY,
+        text: WHITE,
+        icon: WHITE,
+        border: BLUE_GREY,
+      }}
+    />
+  );
+};
+
 export const PrimaryButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}
@@ -86,6 +101,10 @@ export const PrimaryButton = (props: ButtonProps) => {
 };
 
 export const SecondaryButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}
@@ -100,6 +119,10 @@ export const SecondaryButton = (props: ButtonProps) => {
 };
 
 export const DestructiveButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}
@@ -113,22 +136,11 @@ export const DestructiveButton = (props: ButtonProps) => {
   );
 };
 
-export const DisabledButton = (props: Omit<ButtonProps, 'onPress'>) => {
-  return (
-    <BaseButton
-      {...props}
-      disabled
-      colors={{
-        background: BLUE_GREY,
-        text: WHITE,
-        icon: WHITE,
-        border: BLUE_GREY,
-      }}
-    />
-  );
-};
-
 export const SecondaryDestructiveButton = (props: ButtonProps) => {
+  if (props.disabled) {
+    return <DisabledButton {...props} />;
+  }
+
   return (
     <BaseButton
       {...props}

--- a/src/frontend/sharedComponents/Buttons.tsx
+++ b/src/frontend/sharedComponents/Buttons.tsx
@@ -27,13 +27,20 @@ const BaseButton = ({
   iconPosition = 'left',
   text,
   fullSize,
+  disabled = false,
   testID,
   style,
   colors,
-}: ButtonProps & {colors: ButtonColors}) => {
+}: Omit<ButtonProps, 'onPress'> & {
+  onPress?: () => void;
+  disabled?: boolean;
+  colors: ButtonColors;
+}) => {
   return (
     <TouchableOpacity
       testID={testID}
+      disabled={disabled}
+      accessibilityState={{disabled}}
       style={[
         style,
         buttonStyles.base,
@@ -101,6 +108,21 @@ export const DestructiveButton = (props: ButtonProps) => {
         text: WHITE,
         icon: WHITE,
         border: WARNING_RED,
+      }}
+    />
+  );
+};
+
+export const DisabledButton = (props: Omit<ButtonProps, 'onPress'>) => {
+  return (
+    <BaseButton
+      {...props}
+      disabled
+      colors={{
+        background: BLUE_GREY,
+        text: WHITE,
+        icon: WHITE,
+        border: BLUE_GREY,
       }}
     />
   );

--- a/tests/e2e/specs/exchange/no-devices.test.ts
+++ b/tests/e2e/specs/exchange/no-devices.test.ts
@@ -13,6 +13,8 @@ describe('Exchange - Exchange Screen No Devices', () => {
     await expect($(byResourceId('wifi-icon'))).toBeDisplayed();
 
     await expect($(byTextMatches('No devices found.'))).toBeDisplayed();
-    await expect($(byTextMatches('Close'))).toBeDisplayed();
+    const startBtn = await $(byResourceId('EXCHANGE.start-btn'));
+    await expect(startBtn).toBeDisplayed();
+    await expect(startBtn).not.toBeEnabled();
   });
 });


### PR DESCRIPTION
closes #2079 
Uses the new disabled param in the exchange screen for the button when there are no devices
Adds a variable for that situation (no connected peers) and uses it
Adds a test id to the button
Passes a color to the icon (just in case)
Uses the new test id in the E2e test.
Checks for the disabled button in the E2E test.
I ran the test locally and it passes.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bace9727-8527-4ad3-b060-db542c2a2abb" />

