### PR TITLE
chore: updates audio buttons

### DIFF
--- a/messages/en-US/primary.json
+++ b/messages/en-US/primary.json
@@ -325,11 +325,11 @@
     "message": "Recording Audio with CoMapeo",
     "description": "Screen title for audio permission screen"
   },
-  "$1screens.AudioPlaybackNew.backToEditing": {
-    "message": "Back to Editing"
-  },
   "$1screens.AudioPlaybackNew.delete": {
     "message": "Delete"
+  },
+  "$1screens.AudioPlaybackNew.done": {
+    "message": "Done"
   },
   "$1screens.AudioPlaybackNew.recordingSaved": {
     "message": "Recording Saved!"

--- a/src/frontend/screens/Audio/AudioDraftPlaybackScreen.tsx
+++ b/src/frontend/screens/Audio/AudioDraftPlaybackScreen.tsx
@@ -13,6 +13,7 @@ import {Bar} from 'react-native-progress';
 import {COMAPEO_BLUE, WHITE, VERY_LIGHT_GREY, BLACK} from '../../lib/styles';
 import {StopIcon} from '../../sharedComponents/icons';
 import PlayArrow from '../../images/PlayArrow.svg';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import {millisecondsToMMSS} from '../../lib/millisecondsToFormattedTime';
 import {DateDistance} from '../../sharedComponents/DateDistance';
 import MaterialIcons from '@react-native-vector-icons/material-icons';
@@ -27,9 +28,9 @@ const m = defineMessages({
     id: '$1screens.AudioPlaybackNew.recordingSaved',
     defaultMessage: 'Recording Saved!',
   },
-  backToEditing: {
-    id: '$1screens.AudioPlaybackNew.backToEditing',
-    defaultMessage: 'Back to Editing',
+  done: {
+    id: '$1screens.AudioPlaybackNew.done',
+    defaultMessage: 'Done',
   },
   delete: {
     id: '$1screens.AudioPlaybackNew.delete',
@@ -77,11 +78,6 @@ export const AudioDraftPlaybackScreen = ({
       dockContainerStyle={{gap: 20, backgroundColor: WHITE}}
       dockContent={
         <>
-          <SecondaryButton
-            fullSize
-            text={formatMessage(m.backToEditing)}
-            onPress={() => navigation.goBack()}
-          />
           <DestructiveButton
             fullSize
             text={formatMessage(m.delete)}
@@ -91,6 +87,18 @@ export const AudioDraftPlaybackScreen = ({
             }}
             renderIcon={({color, size}) => (
               <MaterialIcons name="delete" size={size} color={color} />
+            )}
+          />
+          <SecondaryButton
+            fullSize
+            text={formatMessage(m.done)}
+            onPress={() => navigation.goBack()}
+            renderIcon={({color, size}) => (
+              <Ionicons
+                name="checkmark-circle-outline"
+                color={color}
+                size={size}
+              />
             )}
           />
         </>

--- a/src/frontend/screens/Onboarding/DeviceNaming.tsx
+++ b/src/frontend/screens/Onboarding/DeviceNaming.tsx
@@ -130,7 +130,6 @@ export const DeviceNaming = ({
                 fullSize
                 onPress={handleSavePress}
                 text={t(m.save)}
-                iconPosition="right"
                 renderIcon={({color, size}) => (
                   <Ionicons
                     name="checkmark-circle-outline"

--- a/tests/e2e/specs/audio/audio-add-additional.test.ts
+++ b/tests/e2e/specs/audio/audio-add-additional.test.ts
@@ -14,7 +14,7 @@ describe('Audio - Two Recordings Show in Thumbnails', () => {
 
     await expect($(byTextMatches('Recording Saved!'))).toBeDisplayed();
     await expect($(byTextMatches('0[0-4]:[0-5][0-9]'))).toBeDisplayed();
-    await $(byTextMatches('Back to Editing')).click();
+    await $(byTextMatches('Done')).click();
   });
 
   it('confirms first audio thumbnail is correct', async () => {
@@ -29,7 +29,7 @@ describe('Audio - Two Recordings Show in Thumbnails', () => {
     await $(byResourceId('OBS.add-audio-btn')).click();
     await driver.pause(3000);
     await $('~Stop recording audio.').click();
-    await $(byTextMatches('Back to Editing')).click();
+    await $(byTextMatches('Done')).click();
 
     const thumbnails = await $$('~Play audio recording.');
     expect(thumbnails.length).toBeGreaterThanOrEqual(2);

--- a/tests/e2e/specs/audio/audio-playback-delete.test.ts
+++ b/tests/e2e/specs/audio/audio-playback-delete.test.ts
@@ -12,7 +12,7 @@ describe('Audio - Playback and Delete', () => {
     checkForElementGone(byTextMatches('Recording Saved!'));
     await expect($(byTextMatches('\\d+:\\d{2}'))).toBeDisplayed();
     await expect($(byText('Delete'))).toBeDisplayed();
-    await expect($(byText('Back to Editing'))).toBeDisplayed();
+    await expect($(byText('Done'))).toBeDisplayed();
   });
 
   it('deletes audio and verifies removal from observation', async () => {

--- a/tests/e2e/specs/audio/audio-recording.test.ts
+++ b/tests/e2e/specs/audio/audio-recording.test.ts
@@ -24,12 +24,12 @@ describe('Audio - Recording Flow', () => {
     await stopButton.click();
     await expect($(byText('Recording Saved!'))).toBeDisplayed();
     await expect($(byTextMatches('0[0-4]:[0-5][0-9]'))).toBeDisplayed();
-    await expect($(byTextMatches('Back to Editing'))).toBeDisplayed();
+    await expect($(byTextMatches('Done'))).toBeDisplayed();
     await expect($(byTextMatches('Delete'))).toBeDisplayed();
   });
 
   it('returns to editor and confirms audio attachment is visible', async () => {
-    const editorReturn = await $(byTextMatches('Back to Editing'));
+    const editorReturn = await $(byTextMatches('Done'));
     await editorReturn.click();
 
     await expect($('~Play audio recording.')).toBeDisplayed();


### PR DESCRIPTION
closes #2081 
Updates audio screen buttons. 
Updates device naming button (I noticed it was different in Figma -- moves the icon to the left instead of the right where it was).
Updates E2E tests.
The tests pass locally.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1c371395-bd15-48eb-b388-ad07698bbfc2" />
