### PR TITLE
fix: stops tracks from crashing due to too many re-renders

### DIFF
--- a/src/frontend/screens/MapScreen/CurrentTrack/UserTooltipMarker.tsx
+++ b/src/frontend/screens/MapScreen/CurrentTrack/UserTooltipMarker.tsx
@@ -22,7 +22,6 @@ export const UserTooltipMarker = () => {
     // We dont want to put this check in the parent because it will cause the parent (the map) to render too often
     location?.coords && (
       <MarkerView
-        key={`locationView-${timer}`}
         id="locationView"
         coordinate={[location.coords.longitude, location.coords.latitude]}
         anchor={{x: 0.5, y: 1.2}}>


### PR DESCRIPTION
closes #2107 

On my physical iPhone and simulator turning on tracks was causing the entire app to crash. The `<MarkerView / >` had a key that was reset every second. The constant re-rendering seems to have caused the app to crash.

Removes the key entirely