### PR TITLE
fix: adjust setting so we can record audio

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -86,6 +86,7 @@ jest.mock('expo-audio', () => {
       HIGH_QUALITY: {ios: {}, android: {}, web: {}},
       LOW_QUALITY: {ios: {}, android: {}, web: {}},
     },
+    setAudioModeAsync: jest.fn(() => Promise.resolve()),
   };
 });
 

--- a/src/frontend/screens/Audio/AudioRecording/index.tsx
+++ b/src/frontend/screens/Audio/AudioRecording/index.tsx
@@ -49,17 +49,17 @@ export function AudioRecording({
 
   React.useEffect(() => {
     const start = async () => {
-      await startRecording();
-      setIsLoading(false);
+      try {
+        await startRecording();
+        setIsLoading(false);
+      } catch (error) {
+        Sentry.captureException(error);
+        navigation.replace('ErrorBottomSheet', {
+          error: toError(error, 'Error starting recording'),
+        });
+      }
     };
-    try {
-      start();
-    } catch (error) {
-      Sentry.captureException(error);
-      navigation.replace('ErrorBottomSheet', {
-        error: toError(error, 'Error starting recording'),
-      });
-    }
+    start();
   }, [startRecording, navigation]);
 
   const finishRecording = React.useCallback(async () => {

--- a/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
+++ b/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
@@ -28,8 +28,7 @@ export function useAudioRecording() {
   const startRecording = useCallback(async () => {
     // iOS gates recording on allowsRecording, which defaults to false; without
     // this the native recorder throws as soon as record() is called.
-    // This is not documented in expo, but can be seen in the error that is thrown
-    await setAudioModeAsync({allowsRecording: true, playsInSilentMode: true});
+    await setAudioModeAsync({allowsRecording: true});
     await recorder.prepareToRecordAsync();
     // expo-audio releases the recorder's native object when this hook unmounts.
     // If the screen unmounts while prepareToRecordAsync is still awaiting,

--- a/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
+++ b/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
@@ -2,10 +2,16 @@ import {useCallback, useEffect, useRef} from 'react';
 import {
   useAudioRecorder,
   useAudioRecorderState,
+  setAudioModeAsync,
   RecordingPresets,
 } from 'expo-audio';
 
-const RECORDING_OPTIONS = RecordingPresets.HIGH_QUALITY!;
+// `directory: 'document'` keeps recordings out of the cache dir, which iOS can
+// purge under storage pressure before the draft observation gets saved.
+const RECORDING_OPTIONS = {
+  ...RecordingPresets.HIGH_QUALITY!,
+  directory: 'document' as const,
+};
 
 export function useAudioRecording() {
   const recorder = useAudioRecorder(RECORDING_OPTIONS);
@@ -20,6 +26,10 @@ export function useAudioRecording() {
   }, []);
 
   const startRecording = useCallback(async () => {
+    // iOS gates recording on allowsRecording, which defaults to false; without
+    // this the native recorder throws as soon as record() is called.
+    // This is not documented in expo, but can be seen in the error that is thrown
+    await setAudioModeAsync({allowsRecording: true, playsInSilentMode: true});
     await recorder.prepareToRecordAsync();
     // expo-audio releases the recorder's native object when this hook unmounts.
     // If the screen unmounts while prepareToRecordAsync is still awaiting,

--- a/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
+++ b/src/frontend/screens/Audio/AudioRecording/useAudioRecording.ts
@@ -28,7 +28,7 @@ export function useAudioRecording() {
   const startRecording = useCallback(async () => {
     // iOS gates recording on allowsRecording, which defaults to false; without
     // this the native recorder throws as soon as record() is called.
-    await setAudioModeAsync({allowsRecording: true});
+    await setAudioModeAsync({allowsRecording: true, playsInSilentMode: true});
     await recorder.prepareToRecordAsync();
     // expo-audio releases the recorder's native object when this hook unmounts.
     // If the screen unmounts while prepareToRecordAsync is still awaiting,


### PR DESCRIPTION
closes #2105 

In iOS, `allowAudioRecording` is set to `false` [by default](https://docs.expo.dev/versions/latest/sdk/audio/#audiomode). In order to record we need to explicitly set it to true.

I also explicity set the [RecordingDirectory](https://docs.expo.dev/versions/latest/sdk/audio/#recordingdirectory) to `Document`. The cache was being purged when the app was closed. So if the user had not saved an observation with an audio file, and then closed the app, we would lose that audio file before it was saved to the db.