### PR TITLE
fix: status bar error

### DIFF
--- a/app.json
+++ b/app.json
@@ -125,7 +125,7 @@
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocalNetworkUsageDescription": "CoMapeo uses the local network to discover and sync with nearby devices in your project.",
         "NSBonjourServices": ["_comapeo._tcp"],
-        "UIViewControllerBasedStatusBarAppearance": true
+        "UIViewControllerBasedStatusBarAppearance": false
       }
     },
     "extra": {

--- a/app.json
+++ b/app.json
@@ -125,7 +125,7 @@
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocalNetworkUsageDescription": "CoMapeo uses the local network to discover and sync with nearby devices in your project.",
         "NSBonjourServices": ["_comapeo._tcp"],
-        "UIViewControllerBasedStatusBarAppearance": false
+        "UIViewControllerBasedStatusBarAppearance": true
       }
     },
     "extra": {

--- a/src/frontend/sharedComponents/CameraView.tsx
+++ b/src/frontend/sharedComponents/CameraView.tsx
@@ -1,5 +1,11 @@
 import React, {useRef} from 'react';
-import {StyleSheet, TouchableOpacity, View, StatusBar} from 'react-native';
+import {
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  StatusBar,
+  Platform,
+} from 'react-native';
 import {Accelerometer, AccelerometerMeasurement} from 'expo-sensors';
 import {
   Camera,
@@ -155,7 +161,12 @@ export const CameraView = ({onAddPress}: Props) => {
 
   return (
     <View style={styles.container} testID="MAIN.camera-scrn">
-      <StatusBar barStyle="light-content" />
+      {/* iOS gets its status bar style from react-navigation's `statusBarStyle`, 
+      which needs UIViewControllerBasedStatusBarAppearance YES in app.json. 
+      And in iOS RN's <StatusBar /> errors unless that same key is NO. */}
+      {Platform.OS === 'android' ? (
+        <StatusBar barStyle="light-content" />
+      ) : null}
       {cameraContent}
 
       <View style={styles.bottomBar}>


### PR DESCRIPTION
closes #2073 

We cannot use the <StatusBar /> component in the camera on iOS with this key in the app.json `UIViewControllerBasedStatusBarAppearance": true` set to false. However, if we set it to false, we can't use the status bar styling we have set up in the whole rest of the app. So this PR only uses the <StatusBar /> component in Android. See below for an image of the dark status bar on iOS. It is only an issue when the phone camera is not pointed at anything (like the phone is sitting on a desk, for example). It is pretty tricky to change that styling to light content on iOS.