### PR TITLE
fix: awkward grey bottom bar ios

### DIFF
--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {Platform} from 'react-native';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {WHITE, MEDIUM_GREY} from '../../lib/styles';
@@ -28,6 +29,11 @@ export type NavigatorLayout = NonNullable<
 export type NavigatorScreenLayout = NonNullable<
   React.ComponentProps<typeof RootStack.Navigator>['screenLayout']
 >;
+
+// Android's bottom inset sits behind the system navigation bar, where grey is a
+// deliberate visual choice (#1671). iOS's is the home activity indicator, where anything but
+// color of the tabs doesn't fit visually (#2077).
+const BOTTOM_INSET_COLOR = Platform.OS === 'android' ? MEDIUM_GREY : WHITE;
 
 const NavigatorScreenOptions: NativeStackNavigationOptions = {
   presentation: 'card',
@@ -69,7 +75,7 @@ export const RootStackNavigator = () => {
   const layout: NavigatorLayout = ({children, state, navigation}) => (
     <SafeAreaView
       edges={['bottom']}
-      style={{flex: 1, backgroundColor: MEDIUM_GREY}}>
+      style={{flex: 1, backgroundColor: BOTTOM_INSET_COLOR}}>
       <React.Suspense fallback={<FullScreenCenteredLoader />}>
         <PendingInvitesListener
           currentRouteName={state.routes[state.index]?.name}

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {Platform} from 'react-native';
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import {SafeAreaView, type Edge} from 'react-native-safe-area-context';
 import {WHITE, MEDIUM_GREY} from '../../lib/styles';
 import {CustomHeaderLeft} from '../../sharedComponents/CustomHeaderLeft';
 import {AppStackParamsList} from '../../sharedTypes/navigation';
@@ -30,10 +30,7 @@ export type NavigatorScreenLayout = NonNullable<
   React.ComponentProps<typeof RootStack.Navigator>['screenLayout']
 >;
 
-// Android's bottom inset sits behind the system navigation bar, where grey is a
-// deliberate visual choice. iOS's is the home activity indicator, where anything but
-// color of the tabs doesn't fit visually.
-const BOTTOM_INSET_COLOR = Platform.OS === 'android' ? MEDIUM_GREY : WHITE;
+const SAFE_AREA_EDGES: Edge[] = Platform.OS === 'android' ? ['bottom'] : [];
 
 const NavigatorScreenOptions: NativeStackNavigationOptions = {
   presentation: 'card',
@@ -74,8 +71,8 @@ export const RootStackNavigator = () => {
 
   const layout: NavigatorLayout = ({children, state, navigation}) => (
     <SafeAreaView
-      edges={['bottom']}
-      style={{flex: 1, backgroundColor: BOTTOM_INSET_COLOR}}>
+      edges={SAFE_AREA_EDGES}
+      style={{flex: 1, backgroundColor: MEDIUM_GREY}}>
       <React.Suspense fallback={<FullScreenCenteredLoader />}>
         <PendingInvitesListener
           currentRouteName={state.routes[state.index]?.name}

--- a/src/frontend/Navigation/Stack/index.tsx
+++ b/src/frontend/Navigation/Stack/index.tsx
@@ -31,8 +31,8 @@ export type NavigatorScreenLayout = NonNullable<
 >;
 
 // Android's bottom inset sits behind the system navigation bar, where grey is a
-// deliberate visual choice (#1671). iOS's is the home activity indicator, where anything but
-// color of the tabs doesn't fit visually (#2077).
+// deliberate visual choice. iOS's is the home activity indicator, where anything but
+// color of the tabs doesn't fit visually.
 const BOTTOM_INSET_COLOR = Platform.OS === 'android' ? MEDIUM_GREY : WHITE;
 
 const NavigatorScreenOptions: NativeStackNavigationOptions = {


### PR DESCRIPTION
closes #2077 
The safe area on iOS is technically the home activity indicator area. Since there is no home button, this is the part of the screen a user presses for that function. On Android (on my Samsung for example) it is the bottom navigation bar. So we had set the color to be grey to set that Android navigation bar apart from our app. On iOS the different color looks weird. So this PR separates the behavior between iOS and Android. It is probably the first of many visual changes we will need to make...

So on iOS we make the color white. On Android, we keep it medium grey, which is what it was before.

<img width="300" alt="IMG_2517" src="https://github.com/user-attachments/assets/c6cd3231-9143-4697-a5e3-24974807d701" />

