### PR TITLE
fix: back button screen name on iOS

### DIFF
--- a/src/frontend/sharedComponents/CustomHeaderLeft.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeft.tsx
@@ -5,7 +5,7 @@ import {HeaderBackButtonProps} from '@react-navigation/elements';
 import {BackIcon} from './icons';
 import {BLACK} from '../lib/styles';
 import {useNavigationFromRoot} from '../hooks/useNavigationWithTypes';
-import {StyleSheet} from 'react-native';
+import {Platform, StyleSheet} from 'react-native';
 
 // We use a slightly larger back icon, to improve accessibility
 // TODO iOS: This should probably be a chevron not an arrow
@@ -39,5 +39,11 @@ export const CustomHeaderLeft = ({
 };
 
 export const CustomHeaderLeftStyles = StyleSheet.create({
-  headerStyles: {marginLeft: 0, marginRight: 15},
+  headerStyles: {
+    marginLeft: 0,
+    // iOS 26 draws a glass capsule around the button's frame, ("liquid glass") and a trailing
+    // margin sits inside it, pushing the arrow off center. Android has no
+    // capsule and needs the gap before the title.
+    marginRight: Platform.OS === 'android' ? 15 : 0,
+  },
 }).headerStyles;

--- a/src/frontend/sharedComponents/CustomHeaderLeft.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeft.tsx
@@ -28,6 +28,8 @@ export const CustomHeaderLeft = ({
   return (
     <HeaderBackButton
       {...headerBackButtonProps}
+      // next line is needed for iOS so it doesn't include the previous screen's title in the back button
+      displayMode="minimal"
       testID="MAIN.header-back-btn"
       onPress={onPress || (() => navigation.goBack())}
       style={CustomHeaderLeftStyles}

--- a/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
@@ -150,6 +150,7 @@ const SharedBackButton = ({
   return (
     <HeaderBackButton
       {...headerBackButtonProps}
+      displayMode="minimal"
       style={{marginLeft: 0, marginRight: 15}}
       onPress={onPress ? onPress : () => navigation.goBack()}
       testID="OBS.close-icon"

--- a/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/CustomHeaderLeftClose.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {HeaderBackButton} from '@react-navigation/elements';
 import {HeaderBackButtonProps} from '@react-navigation/elements';
+import {CustomHeaderLeftStyles} from './CustomHeaderLeft';
 import {BackHandler} from 'react-native';
 import isEqual from 'lodash.isequal';
 
@@ -151,7 +152,7 @@ const SharedBackButton = ({
     <HeaderBackButton
       {...headerBackButtonProps}
       displayMode="minimal"
-      style={{marginLeft: 0, marginRight: 15}}
+      style={CustomHeaderLeftStyles}
       onPress={onPress ? onPress : () => navigation.goBack()}
       testID="OBS.close-icon"
       backImage={() => <HeaderCloseIcon tintColor={tintColor || BLACK} />}

--- a/src/frontend/sharedComponents/HeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/HeaderLeftClose.tsx
@@ -18,6 +18,7 @@ export const HeaderLeftClose = ({
   return (
     <HeaderBackButton
       {...headerBackButtonProps}
+      displayMode="minimal"
       testID="OBS.header-left-close"
       style={{marginLeft: 0, marginRight: 15}}
       onPress={onPress}

--- a/src/frontend/sharedComponents/HeaderLeftClose.tsx
+++ b/src/frontend/sharedComponents/HeaderLeftClose.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {BLACK} from '../lib/styles';
 import {HeaderCloseIcon} from './CustomHeaderLeftClose';
+import {CustomHeaderLeftStyles} from './CustomHeaderLeft';
 import {HeaderBackButtonProps} from '@react-navigation/elements';
 import {HeaderBackButton} from '@react-navigation/elements';
 
@@ -20,7 +21,7 @@ export const HeaderLeftClose = ({
       {...headerBackButtonProps}
       displayMode="minimal"
       testID="OBS.header-left-close"
-      style={{marginLeft: 0, marginRight: 15}}
+      style={CustomHeaderLeftStyles}
       onPress={onPress}
       backImage={() => <HeaderCloseIcon tintColor={tintColor || BLACK} />}
     />


### PR DESCRIPTION
closes #2074 
Changes the display mode for the back buttons to minimal for iOS so that the screen name won't show. 

Not sure why but `HeaderBackButton` from @react-navigation/elements defaults `displayMode` to 'default' on iOS and 'minimal' on Android. 

'default' renders the previous screen's title next to the icon and 'minimal' does not render the screen title. 

So this PR keeps the exact same behavior for Android and makes the iOS match it.

<img width="300" alt="IMG_2519" src="https://github.com/user-attachments/assets/2e16a1d3-4dc9-43f1-912f-41d25f4775d5" />
