### PR TITLE
fix: showing no wifi screen correctly

### DIFF
--- a/app.json
+++ b/app.json
@@ -121,6 +121,9 @@
     },
     "ios": {
       "bundleIdentifier": "com.comapeo",
+      "entitlements": {
+        "com.apple.developer.networking.wifi-info": true
+      },
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocalNetworkUsageDescription": "CoMapeo uses the local network to discover and sync with nearby devices in your project.",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -98,7 +98,11 @@ const mapServerApi = {
 };
 // iOS only reads the wifi SSID when this is set. Must run before local discovery
 // starts (see below), because configure() drops listeners added before it.
-NetInfo.configure({shouldFetchWiFiSSID: true});
+NetInfo.configure({
+  shouldFetchWiFiSSID: true,
+  // Prevents polling an external URL on iOS since it has no native reachability.
+  reachabilityShouldRun: () => false,
+});
 
 const localDiscoveryController = createLocalDiscoveryController(mapeoApi);
 localDiscoveryController.start();

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -33,6 +33,7 @@ import {
 import {PermissionsAndroid, Platform, AppState} from 'react-native';
 import {requestForegroundPermissionsAsync} from 'expo-location';
 import {AppProviders} from './contexts/AppProviders';
+import NetInfo from '@react-native-community/netinfo';
 import {createLocalDiscoveryController} from './contexts/LocalDiscoveryContext';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Sentry from '@sentry/react-native';
@@ -95,6 +96,10 @@ const mapServerApi = {
     return new URL(await comapeoServicesClient.mapServer.getBaseUrl());
   },
 };
+// iOS only reads the wifi SSID when this is set. Must run before local discovery
+// starts (see below), because configure() drops listeners added before it.
+NetInfo.configure({shouldFetchWiFiSSID: true});
+
 const localDiscoveryController = createLocalDiscoveryController(mapeoApi);
 localDiscoveryController.start();
 

--- a/src/frontend/contexts/LocalDiscoveryContext.tsx
+++ b/src/frontend/contexts/LocalDiscoveryContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {AppState, AppStateStatus} from 'react-native';
+import {AppState, AppStateStatus, Platform} from 'react-native';
 import NetInfo, {
   type NetInfoWifiState,
   type NetInfoState,
@@ -235,8 +235,8 @@ export function createLocalDiscoveryController(mapeoApi: ComapeoCoreClientApi) {
     // Don't do anything if the app is not active (starting and stopping
     // discovery based on appState is handled below in onAppState)
     if (appState !== 'active') return;
-    const nextIpAddress = nextNetInfo.details.ipAddress;
-    const prevIpAddress = netInfo?.details ? netInfo.details.ipAddress : null;
+    const nextIpAddress = getWifiIpAddress(nextNetInfo);
+    const prevIpAddress = getWifiIpAddress(netInfo);
     // netInfo.isConnected is true (I think) only if the wifi network has
     // internet access. We use the presence of an IP address to detect if wifi
     // is connected to a local network.
@@ -274,7 +274,7 @@ export function createLocalDiscoveryController(mapeoApi: ComapeoCoreClientApi) {
     }
     netInfo = nextNetInfo;
     updateState({
-      wifiStatus: nextNetInfo.isWifiEnabled ? 'on' : 'off',
+      wifiStatus: getWifiStatus(nextNetInfo, isLocalWifiConnected),
       wifiConnection: isLocalWifiConnected ? 'connected' : 'disconnected',
       wifiLinkSpeed: nextNetInfo.details.linkSpeed,
       ssid: nextNetInfo.details.ssid,
@@ -432,6 +432,28 @@ function zeroconfServiceToMapeoPeer({
   // remove the suffix when connecting to the peer.
   const name = serviceName.replace(/[^a-fA-F0-9].*/g, '');
   return address ? {address, port, name} : null;
+}
+
+// Both platforms report the wifi interface's IP address as '0.0.0.0' when the
+// device is not associated with a network
+const UNASSIGNED_IP_ADDRESS = '0.0.0.0';
+
+function getWifiIpAddress(
+  netInfoState: NetInfoWifiState | NetInfoDisconnectedStates | null,
+) {
+  const ipAddress = netInfoState?.details?.ipAddress;
+  return !ipAddress || ipAddress === UNASSIGNED_IP_ADDRESS ? null : ipAddress;
+}
+
+// `isWifiEnabled` is Android-only — iOS reports only whether or not we are on a wifi network
+function getWifiStatus(
+  netInfoState: NetInfoWifiState,
+  isLocalWifiConnected: boolean,
+): LocalDiscoveryState['wifiStatus'] {
+  if (Platform.OS === 'android') {
+    return netInfoState.isWifiEnabled ? 'on' : 'off';
+  }
+  return isLocalWifiConnected ? 'on' : 'off';
 }
 
 function shallowPartialEqual<T extends {[k: string]: unknown}>(

--- a/src/frontend/lib/internetStatus.test.ts
+++ b/src/frontend/lib/internetStatus.test.ts
@@ -1,0 +1,48 @@
+import {Platform} from 'react-native';
+import {
+  NetInfoStateType,
+  type NetInfoState,
+} from '@react-native-community/netinfo';
+import {getInternetStatus} from './internetStatus';
+
+function netInfoState(
+  isConnected: boolean | null,
+  isInternetReachable: boolean | null,
+): NetInfoState {
+  return {
+    type: NetInfoStateType.wifi,
+    isConnected,
+    isInternetReachable,
+    details: {isConnectionExpensive: false},
+  } as NetInfoState;
+}
+
+describe('on Android', () => {
+  beforeEach(() => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+  });
+
+  it('uses the natively reported reachability', () => {
+    expect(getInternetStatus(netInfoState(true, true))).toBe('online');
+    expect(getInternetStatus(netInfoState(true, false))).toBe('offline');
+  });
+
+  it('is unknown until reachability is reported', () => {
+    expect(getInternetStatus(netInfoState(true, null))).toBe('unknown');
+  });
+});
+
+describe('on iOS', () => {
+  beforeEach(() => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+  });
+
+  it('uses the connection state, not reachability', () => {
+    expect(getInternetStatus(netInfoState(true, false))).toBe('online');
+    expect(getInternetStatus(netInfoState(false, false))).toBe('offline');
+  });
+
+  it('is unknown until a connection state is reported', () => {
+    expect(getInternetStatus(netInfoState(null, false))).toBe('unknown');
+  });
+});

--- a/src/frontend/lib/internetStatus.ts
+++ b/src/frontend/lib/internetStatus.ts
@@ -1,0 +1,16 @@
+import {Platform} from 'react-native';
+import {type NetInfoState} from '@react-native-community/netinfo';
+
+export type InternetStatus = 'online' | 'offline' | 'unknown';
+
+/**
+ * Android reports internet reachability natively. iOS does not, so
+ * NetInfo can only get it by polling an external URL.
+ * On iOS whether a network route exists is the most we can know.
+ */
+export function getInternetStatus(state: NetInfoState): InternetStatus {
+  const isOnline =
+    Platform.OS === 'android' ? state.isInternetReachable : state.isConnected;
+  if (typeof isOnline !== 'boolean') return 'unknown';
+  return isOnline ? 'online' : 'offline';
+}

--- a/src/frontend/metrics/AppUsageData.ts
+++ b/src/frontend/metrics/AppUsageData.ts
@@ -1,4 +1,5 @@
 import * as NetInfo from '@react-native-community/netinfo';
+import {getInternetStatus} from '../lib/internetStatus';
 import * as Sentry from '@sentry/react-native';
 import * as Application from 'expo-application';
 import {getLastKnownPositionAsync} from 'expo-location';
@@ -124,7 +125,7 @@ export class AppUsageData {
 
     subscriptionCleanupFns.push(
       NetInfo.addEventListener(state => {
-        this.#isOnline = Boolean(state.isInternetReachable);
+        this.#isOnline = getInternetStatus(state) === 'online';
         this.#update();
       }),
     );

--- a/src/frontend/metrics/DeviceDiagnosticMetrics.ts
+++ b/src/frontend/metrics/DeviceDiagnosticMetrics.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-native';
 import {AppState, Dimensions, PixelRatio, Platform} from 'react-native';
 import * as NetInfo from '@react-native-community/netinfo';
+import {getInternetStatus} from '../lib/internetStatus';
 import * as Application from 'expo-application';
 import * as Device from 'expo-device';
 import {getMonthlyHash} from './getMonthlyHash';
@@ -116,7 +117,7 @@ export class DeviceDiagnostics {
 
     subscriptionCleanupFns.push(
       NetInfo.addEventListener(state => {
-        this.#isOnline = Boolean(state.isInternetReachable);
+        this.#isOnline = getInternetStatus(state) === 'online';
         this.#update();
       }),
     );

--- a/src/frontend/screens/Exchange/index.tsx
+++ b/src/frontend/screens/Exchange/index.tsx
@@ -12,6 +12,7 @@ import {NoWifiDisplay} from './NoWifiDisplay';
 import {ExchangeScreenContent} from './ExchangeScreenContent';
 import {FullScreenCenteredLoader} from '../../sharedComponents/FullScreenCenteredLoader';
 import {useNetInfo} from '@react-native-community/netinfo';
+import {getInternetStatus} from '../../lib/internetStatus';
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {defineMessages} from 'react-intl';
 
@@ -25,7 +26,7 @@ const m = defineMessages({
 export const SyncScreen = ({navigation}: NativeRootNavigationProps<'Sync'>) => {
   const wifiStatus = useLocalDiscoveryState(state => state.wifiStatus);
 
-  const hasInternetAccess = useNetInfo().isConnected;
+  const internetStatus = getInternetStatus(useNetInfo());
 
   const {projectId} = useActiveProject();
   const syncState = useSyncState({projectId});
@@ -48,7 +49,7 @@ export const SyncScreen = ({navigation}: NativeRootNavigationProps<'Sync'>) => {
     }
     // Case 2: Remote archive exists, but no general internet connection.
     // If a user has a remote archive they can sync on NON-wifi internet connections
-    if (hasRemoteArchive && !hasInternetAccess) {
+    if (hasRemoteArchive && internetStatus === 'offline') {
       return true;
     }
     return false;


### PR DESCRIPTION
closes #2076 
This PR addresses several issues related to wifi and connection that are different in iOS than in Android and fixes some little glitches in Android too.

#### Changes
1. Adds functions at the end of `src/frontend/contexts/LocalDiscoveryContext.tsx` to deal with the differences between Android and iOS related to wifi connection and network availability. `isWifiEnabled` is Android only. Also adds a check of the correct wifi IP so discovery only starts when wifi is joined to a network (not just when it is "on"). 
2. In order to show the wifi network (SSID) on iOS we need to add an entitlement and a configuration in App.tsx. More on that at the end.
3. Relating to the remote archive and the metrics sharing, iOS does not have a native internet reachability check, so we were polling every 2 seconds (a value set in [`LocalDiscoverContext`](https://github.com/digidem/comapeo-mobile/blob/bded730502111f27f91be00dc021f359292ae849/src/frontend/contexts/LocalDiscoveryContext.tsx#L37). This PR fixes that in the configuration in App.tsx and also uses a utility function to correctly get the internet status with precise types, instead of a boolean, to prevent flickering for the user.
4. Adds a test for the new utility function

<img width="300" alt="IMG_2521" src="https://github.com/user-attachments/assets/27ae7489-6c7f-4fdc-9770-eb3dba3899a6" />

### About Entitlement
Apple also only allows the app to see the SSID if the user granted precise location. We already ask for location but it should be noted that anyone who picks "Approximate" will still see -- at the top of the screen (not the name of the wifi).

The [next eas build should enable Access Wi-Fi Information and regenerate the profile](https://docs.expo.dev/build-reference/ios-capabilities/). It'll ask for an Apple login when we do any kind of `eas build ...`. Each variant is its own App ID (com.comapeo.dev, .rc, .pre, com.comapeo), so each picks it up on its first build. It needs to happen before the next signed device build. If the profile doesn't carry the entitlement, signing will fail.


