### PR TITLE
fix: no error when cancelling download ios

### DIFF
--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -10,7 +10,11 @@ import {useMutation, useQuery} from '@tanstack/react-query';
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {MEMBER_ROLE_ID} from '../../sharedTypes';
-import {saveDocuments} from '@react-native-documents/picker';
+import {
+  errorCodes,
+  isErrorWithCode,
+  saveDocuments,
+} from '@react-native-documents/picker';
 import {Exports} from '../../sharedTypes/navigation';
 import * as FileSystem from 'expo-file-system/legacy';
 import {useLocaleState} from '../../contexts/LocaleStoreContext';
@@ -18,12 +22,7 @@ import {useIntl} from 'react-intl';
 import noop from '../../lib/noop';
 
 export function isUserCancelled(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'message' in err &&
-    (err as {message?: string}).message === 'user canceled the document picker'
-  );
+  return isErrorWithCode(err) && err.code === errorCodes.OPERATION_CANCELED;
 }
 
 export function useProjectSettings() {

--- a/src/frontend/hooks/server/projects.ts
+++ b/src/frontend/hooks/server/projects.ts
@@ -10,20 +10,12 @@ import {useMutation, useQuery} from '@tanstack/react-query';
 
 import {useActiveProject} from '../../contexts/ActiveProjectContext';
 import {MEMBER_ROLE_ID} from '../../sharedTypes';
-import {
-  errorCodes,
-  isErrorWithCode,
-  saveDocuments,
-} from '@react-native-documents/picker';
+import {saveDocuments} from '@react-native-documents/picker';
 import {Exports} from '../../sharedTypes/navigation';
 import * as FileSystem from 'expo-file-system/legacy';
 import {useLocaleState} from '../../contexts/LocaleStoreContext';
 import {useIntl} from 'react-intl';
 import noop from '../../lib/noop';
-
-export function isUserCancelled(err: unknown): boolean {
-  return isErrorWithCode(err) && err.code === errorCodes.OPERATION_CANCELED;
-}
 
 export function useProjectSettings() {
   const {projectId} = useActiveProject();

--- a/src/frontend/screens/ExportObservations.tsx
+++ b/src/frontend/screens/ExportObservations.tsx
@@ -13,7 +13,8 @@ import {LoadingIndicator} from '../sharedComponents/LoadingIndicator';
 import {useObservations} from '../hooks/server/observations';
 import {useTracks} from '../hooks/server/track';
 import * as Sentry from '@sentry/react-native';
-import {isUserCancelled, useExportObservations} from '../hooks/server/projects';
+import {useExportObservations} from '../hooks/server/projects';
+import {errorCodes, isErrorWithCode} from '@react-native-documents/picker';
 import {toError} from '../utils/errors';
 
 const m = defineMessages({
@@ -78,7 +79,10 @@ export const ExportObservations = ({
           navigation.replace('ExportSuccess', {exportType: typeToExport});
         },
         onError: err => {
-          if (isUserCancelled(err)) {
+          if (
+            isErrorWithCode(err) &&
+            err.code === errorCodes.OPERATION_CANCELED
+          ) {
             return;
           }
           Sentry.captureException(err);


### PR DESCRIPTION
closes #2075 
[React native documents (picker) ships with error codes.](https://react-native-documents.github.io/docs/sponsor-only/errors) The docs say that will be changed in a future PR, but it is very helpful for now as it matches on both iOS and Android. 
So, this PR checks for the error code instead of using a string match as the string is different on iOS and Android.
I tested export on both Android and iOS both with and without photo files and all went smoothly.